### PR TITLE
Skyver syketilfelle-konsument ned til VarselPlanner implementasjon

### DIFF
--- a/src/main/kotlin/no/nav/syfo/BootstrapApplication.kt
+++ b/src/main/kotlin/no/nav/syfo/BootstrapApplication.kt
@@ -110,8 +110,8 @@ fun Application.kafkaModule() {
         val sykmeldingerConsumer = SykmeldingerConsumer(env, azureAdTokenConsumer)
         val sykmeldingService = SykmeldingService(sykmeldingerConsumer)
 
-        val oppfolgingstilfelleKafkaConsumer = OppfolgingstilfelleKafkaConsumer(env, oppfolgingstilfelleConsumer, accessControl)
-            .addPlanner(AktivitetskravVarselPlanner(database, sykmeldingService))
+        val oppfolgingstilfelleKafkaConsumer = OppfolgingstilfelleKafkaConsumer(env, accessControl)
+            .addPlanner(AktivitetskravVarselPlanner(database, oppfolgingstilfelleConsumer, sykmeldingService))
 
         launch(backgroundTasksContext) {
             launchKafkaListener(

--- a/src/main/kotlin/no/nav/syfo/kafka/oppfolgingstilfelle/OppfolgingstilfelleKafkaConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/oppfolgingstilfelle/OppfolgingstilfelleKafkaConsumer.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import no.nav.syfo.ApplicationState
 import no.nav.syfo.Environment
-import no.nav.syfo.consumer.SyfosyketilfelleConsumer
 import no.nav.syfo.kafka.KafkaListener
 import no.nav.syfo.kafka.consumerProperties
 import no.nav.syfo.kafka.oppfolgingstilfelle.domain.KOppfolgingstilfellePeker
@@ -25,7 +24,6 @@ import java.time.Duration
 @KtorExperimentalAPI
 class OppfolgingstilfelleKafkaConsumer(
     val env: Environment,
-    val syfosyketilfelleConsumer: SyfosyketilfelleConsumer,
     val accessControl: AccessControl
 ) : KafkaListener {
 
@@ -53,10 +51,7 @@ class OppfolgingstilfelleKafkaConsumer(
                     val aktorId = peker.aktorId
                     val fnr = accessControl.getFnrIfUserCanBeNotified(aktorId)
                     fnr?.let {
-                        val oppfolgingstilfelle = syfosyketilfelleConsumer.getOppfolgingstilfelle(aktorId)
-                        oppfolgingstilfelle?.let {
-                            varselPlanners.forEach { planner -> runBlocking { planner.processOppfolgingstilfelle(oppfolgingstilfelle, fnr) } }
-                        }
+                        varselPlanners.forEach { planner -> runBlocking { planner.processOppfolgingstilfelle(aktorId, fnr) } }
                     }
                 } catch (e: IOException) {
                     log.error("Error in [$topicOppfolgingsTilfelle] listener: Could not parse message | ${e.message}")

--- a/src/main/kotlin/no/nav/syfo/util/VarselUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/util/VarselUtil.kt
@@ -34,12 +34,4 @@ class VarselUtil(private val databaseAccess: DatabaseInterface) {
         val gjeldendeSykmeldingerSet = gjeldendeSykmeldinger.flatten().toSet()
         return (ressursIds intersect gjeldendeSykmeldingerSet).isNotEmpty()
     }
-
-    fun isVarselSendUt(fnr: String, varselType: VarselType, varselDato: LocalDate): Boolean {
-        return databaseAccess.fetchPlanlagtVarselByFnr(fnr)
-            .filter { varselType.name == it.type }
-            .filter { it.utsendingsdato == varselDato }
-            .filter { it.utsendingsdato.isBefore(LocalDate.now()) || it.utsendingsdato == LocalDate.now() }
-            .any()
-    }
 }

--- a/src/main/kotlin/no/nav/syfo/varsel/AktivitetskravVarselPlanner.kt
+++ b/src/main/kotlin/no/nav/syfo/varsel/AktivitetskravVarselPlanner.kt
@@ -49,6 +49,7 @@ class AktivitetskravVarselPlanner(
 
                 if (varselUtil.isVarselDatoForIDag(aktivitetskravVarselDato)) {
                     log.info("[AKTIVITETSKRAV_VARSEL]: Beregnet dato for varsel er før i dag, sletter tidligere planlagt varsel om det finnes i DB")
+                    databaseAccess.deletePlanlagtVarselBySykmeldingerId(sykeforlop.ressursIds)
                 } else if (varselUtil.isVarselDatoEtterTilfelleSlutt(aktivitetskravVarselDato, forlopSluttDato)) {
                     log.info("[AKTIVITETSKRAV_VARSEL]: Tilfelle er kortere enn 6 uker, sletter tidligere planlagt varsel om det finnes i DB")
                     databaseAccess.deletePlanlagtVarselBySykmeldingerId(sykeforlop.ressursIds)

--- a/src/main/kotlin/no/nav/syfo/varsel/VarselPlanner.kt
+++ b/src/main/kotlin/no/nav/syfo/varsel/VarselPlanner.kt
@@ -1,7 +1,5 @@
 package no.nav.syfo.varsel
 
-import no.nav.syfo.consumer.domain.OppfolgingstilfellePerson
-
 interface VarselPlanner {
-    suspend fun processOppfolgingstilfelle(oppfolgingstilfellePerson: OppfolgingstilfellePerson, fnr: String)
+    suspend fun processOppfolgingstilfelle(aktorId: String, fnr: String)
 }

--- a/src/test/kotlin/no/nav/syfo/kafka/KafkaConsumerSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/kafka/KafkaConsumerSpek.kt
@@ -7,7 +7,6 @@ import no.nav.syfo.ApplicationState
 import no.nav.syfo.auth.StsConsumer
 import no.nav.syfo.consumer.DkifConsumer
 import no.nav.syfo.consumer.PdlConsumer
-import no.nav.syfo.consumer.SyfosyketilfelleConsumer
 import no.nav.syfo.kafka.oppfolgingstilfelle.OppfolgingstilfelleKafkaConsumer
 import no.nav.syfo.kafka.oppfolgingstilfelle.domain.KOppfolgingstilfellePeker
 import no.nav.syfo.service.AccessControl
@@ -50,11 +49,10 @@ object KafkaConsumerSpek : Spek({
     val syfosyketilfelleServer = mockServers.mockSyfosyketilfelleServer()
 
     val stsConsumer = StsConsumer(testEnv)
-    val syfosyketilfelleConsumer = SyfosyketilfelleConsumer(testEnv, stsConsumer)
     val pdlConsumer = PdlConsumer(testEnv, stsConsumer)
     val dkifConsumer = DkifConsumer(testEnv, stsConsumer)
     val accessControl = AccessControl(pdlConsumer, dkifConsumer)
-    val oppfolgingstilfelleKafkaConsumer = OppfolgingstilfelleKafkaConsumer(testEnv, syfosyketilfelleConsumer, accessControl)
+    val oppfolgingstilfelleKafkaConsumer = OppfolgingstilfelleKafkaConsumer(testEnv, accessControl)
         .addPlanner(MockVarselPlaner(fakeApplicationState))
 
 

--- a/src/test/kotlin/no/nav/syfo/testutil/mocks/MockVarselPlaner.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/mocks/MockVarselPlaner.kt
@@ -2,11 +2,10 @@ package no.nav.syfo.testutil.mocks
 
 import kotlinx.coroutines.coroutineScope
 import no.nav.syfo.ApplicationState
-import no.nav.syfo.consumer.domain.OppfolgingstilfellePerson
 import no.nav.syfo.varsel.VarselPlanner
 
 class MockVarselPlaner(val applicationState: ApplicationState) : VarselPlanner {
-    override suspend fun processOppfolgingstilfelle(oppfolgingstilfellePerson: OppfolgingstilfellePerson, fnr: String) = coroutineScope {
+    override suspend fun processOppfolgingstilfelle(aktorId: String, fnr: String) = coroutineScope {
         applicationState.running = false
     }
 }

--- a/src/test/kotlin/no/nav/syfo/varsel/AktivitetskravVarselPlannerSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/varsel/AktivitetskravVarselPlannerSpek.kt
@@ -4,6 +4,7 @@ import io.ktor.util.*
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
+import no.nav.syfo.consumer.SyfosyketilfelleConsumer
 import no.nav.syfo.consumer.SykmeldingerConsumer
 import no.nav.syfo.consumer.domain.OppfolgingstilfellePerson
 import no.nav.syfo.consumer.domain.Syketilfellebit
@@ -18,11 +19,11 @@ import no.nav.syfo.service.SykmeldingService
 import no.nav.syfo.testutil.EmbeddedDatabase
 import no.nav.syfo.testutil.dropData
 import org.amshove.kluent.shouldEqual
-import org.amshove.kluent.shouldNotEqual
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 import java.time.LocalDate
 import java.time.LocalDateTime
+import kotlin.test.assertFailsWith
 
 const val SYKEFORLOP_MIN_DIFF_DAGER: Long = 16L
 const val AKTIVITETSKRAV_DAGER: Long = 42L
@@ -38,8 +39,9 @@ object AktivitetskravVarselPlannerSpek : Spek({
 
     val embeddedDatabase by lazy { EmbeddedDatabase() }
     val sykmeldingerConsumer = mockk<SykmeldingerConsumer>()
+    val syfosyketilfelleConsumer = mockk<SyfosyketilfelleConsumer>()
 
-    val aktivitetskravVarselPlanner = AktivitetskravVarselPlanner(embeddedDatabase, SykmeldingService(sykmeldingerConsumer))
+    val aktivitetskravVarselPlanner = AktivitetskravVarselPlanner(embeddedDatabase, syfosyketilfelleConsumer, SykmeldingService(sykmeldingerConsumer))
 
     describe("AktivitetskravVarselPlannerSpek") {
         val planlagtVarselToStore2 = PlanlagtVarsel(arbeidstakerFnr1, arbeidstakerAktorId1, setOf("1"), VarselType.MER_VEILEDNING)
@@ -61,24 +63,25 @@ object AktivitetskravVarselPlannerSpek : Spek({
             embeddedDatabase.storePlanlagtVarsel(planlagtVarselToStore3)
 
             val syketilfellebit1 =
-                Syketilfellebit("1", arbeidstakerAktorId1, "2", LocalDateTime.now(), LocalDateTime.now(), listOf("ANNET_FRAVAR", "SENDT"), "3", LocalDateTime.now(), LocalDateTime.now())
+                Syketilfellebit("1", arbeidstakerAktorId1, "2", LocalDateTime.now(), LocalDateTime.now(), listOf("ANNET_FRAVAR", "SENDT"), "3", LocalDateTime.now(), LocalDateTime.now().plusDays(7))
             val syketilfellebit2 =
-                Syketilfellebit("1", arbeidstakerAktorId1, "2", LocalDateTime.now(), LocalDateTime.now(), listOf("ANNET_FRAVAR", "UTDANNING"), "3", LocalDateTime.now(), LocalDateTime.now())
+                Syketilfellebit("2", arbeidstakerAktorId1, "2", LocalDateTime.now(), LocalDateTime.now(), listOf("ANNET_FRAVAR", "SENDT"), "3", LocalDateTime.now().plusDays(8), LocalDateTime.now().plusDays(16))
             val syketilfellebit3 =
-                Syketilfellebit("1", arbeidstakerAktorId1, "2", LocalDateTime.now(), LocalDateTime.now(), listOf("ANNET_FRAVAR", "BEKREFTET"), "3", LocalDateTime.now(), LocalDateTime.now())
+                Syketilfellebit("3", arbeidstakerAktorId1, "2", LocalDateTime.now(), LocalDateTime.now(), listOf("ANNET_FRAVAR", "SENDT"), "3", LocalDateTime.now().plusDays(17), LocalDateTime.now().plusDays(50))
 
-            val syketilfelledag1 = Syketilfelledag(LocalDate.now().minusDays(4), syketilfellebit1)
-            val syketilfelledag2 = Syketilfelledag(LocalDate.now().minusDays(2), syketilfellebit2)
-            val syketilfelledag3 = Syketilfelledag(LocalDate.now().plusDays(100), syketilfellebit3)
+            val syketilfelledag1 = Syketilfelledag(LocalDate.now(), syketilfellebit1)
+            val syketilfelledag2 = Syketilfelledag(LocalDate.now().plusDays(16), syketilfellebit2)
+            val syketilfelledag3 = Syketilfelledag(LocalDate.now().plusDays(50), syketilfellebit3)
 
-            val sykmeldtStatusResponse = SykmeldtStatusResponse(erSykmeldt = true, gradert = false, fom = LocalDate.now(), tom = LocalDate.now())
+            val sykmeldtStatusResponse = SykmeldtStatusResponse(erSykmeldt = true, gradert = false, fom = LocalDate.now(), tom = LocalDate.now().plusDays(50))
+            val oppfolgingstilfellePerson =
+                OppfolgingstilfellePerson(arbeidstakerFnr1, listOf(syketilfelledag1, syketilfelledag2, syketilfelledag3), syketilfelledag1, 0, false, LocalDateTime.now())
 
             coEvery { sykmeldingerConsumer.getSykmeldtStatusPaDato(any(), any()) } returns sykmeldtStatusResponse
+            coEvery { syfosyketilfelleConsumer.getOppfolgingstilfelle(any()) } returns oppfolgingstilfellePerson
 
             runBlocking {
-                val oppfolgingstilfellePerson =
-                    OppfolgingstilfellePerson(arbeidstakerFnr1, listOf(syketilfelledag1, syketilfelledag2, syketilfelledag3), syketilfelledag1, 0, false, LocalDateTime.now())
-                aktivitetskravVarselPlanner.processOppfolgingstilfelle(oppfolgingstilfellePerson, arbeidstakerFnr1)
+                aktivitetskravVarselPlanner.processOppfolgingstilfelle(arbeidstakerAktorId1, arbeidstakerFnr1)
 
                 val lagreteVarsler = embeddedDatabase.fetchPlanlagtVarselByFnr(arbeidstakerFnr1)
                 val nrOfRowsFetchedTotal = lagreteVarsler.size
@@ -103,15 +106,16 @@ object AktivitetskravVarselPlannerSpek : Spek({
                     LocalDateTime.now().minusDays(100))
 
             val syketilfelledag1 = Syketilfelledag(LocalDate.now().minusDays(60), syketilfellebit1)
+            val oppfolgingstilfellePerson =
+                OppfolgingstilfellePerson(arbeidstakerFnr1, listOf(syketilfelledag1), syketilfelledag1, 0, false, LocalDateTime.now())
 
             val sykmeldtStatusResponse = SykmeldtStatusResponse(erSykmeldt = true, gradert = false, fom = LocalDate.now(), tom = LocalDate.now())
 
             coEvery { sykmeldingerConsumer.getSykmeldtStatusPaDato(any(), any()) } returns sykmeldtStatusResponse
+            coEvery { syfosyketilfelleConsumer.getOppfolgingstilfelle(any()) } returns oppfolgingstilfellePerson
 
             runBlocking {
-                val oppfolgingstilfellePerson =
-                    OppfolgingstilfellePerson(arbeidstakerFnr1, listOf(syketilfelledag1), syketilfelledag1, 0, false, LocalDateTime.now())
-                aktivitetskravVarselPlanner.processOppfolgingstilfelle(oppfolgingstilfellePerson, arbeidstakerFnr1)
+                aktivitetskravVarselPlanner.processOppfolgingstilfelle(arbeidstakerAktorId1, arbeidstakerFnr1)
 
                 val lagreteVarsler = embeddedDatabase.fetchPlanlagtVarselByFnr(arbeidstakerFnr1)
                 val nrOfRowsFetchedTotal = lagreteVarsler.size
@@ -129,22 +133,24 @@ object AktivitetskravVarselPlannerSpek : Spek({
             val syketilfellebit1 =
                 Syketilfellebit("1", arbeidstakerAktorId1, "2", LocalDateTime.now(), LocalDateTime.now(), listOf("SYKMELDING", "SENDT"), "3", LocalDateTime.now(), LocalDateTime.now())
             val syketilfellebit2 =
-                Syketilfellebit("1", arbeidstakerAktorId1, "2", LocalDateTime.now(), LocalDateTime.now(), listOf("SYKMELDING", "UTDANNING"), "3", LocalDateTime.now(), LocalDateTime.now())
+                Syketilfellebit("2", arbeidstakerAktorId1, "2", LocalDateTime.now(), LocalDateTime.now(), listOf("SYKMELDING", "SENDT"), "3", LocalDateTime.now(), LocalDateTime.now())
             val syketilfellebit3 =
-                Syketilfellebit("1", arbeidstakerAktorId1, "2", LocalDateTime.now(), LocalDateTime.now(), listOf("PAPIRSYKMELDING", "BEKREFTET"), "3", LocalDateTime.now(), LocalDateTime.now())
+                Syketilfellebit("3", arbeidstakerAktorId1, "2", LocalDateTime.now(), LocalDateTime.now(), listOf("PAPIRSYKMELDING", "SENDT"), "3", LocalDateTime.now(), LocalDateTime.now())
 
             val syketilfelledag1 = Syketilfelledag(LocalDate.now().minusDays(4), syketilfellebit1)
             val syketilfelledag2 = Syketilfelledag(LocalDate.now().minusDays(2), syketilfellebit2)
             val syketilfelledag3 = Syketilfelledag(LocalDate.now().plusDays(6), syketilfellebit3)
 
             val sykmeldtStatusResponse = SykmeldtStatusResponse(erSykmeldt = true, gradert = false, fom = LocalDate.now(), tom = LocalDate.now())
+            val oppfolgingstilfellePerson =
+                OppfolgingstilfellePerson(arbeidstakerFnr1, listOf(syketilfelledag1, syketilfelledag2, syketilfelledag3), syketilfelledag1, 0, false, LocalDateTime.now())
 
             coEvery { sykmeldingerConsumer.getSykmeldtStatusPaDato(any(), any()) } returns sykmeldtStatusResponse
+            coEvery { syfosyketilfelleConsumer.getOppfolgingstilfelle(any()) } returns oppfolgingstilfellePerson
 
             runBlocking {
-                val oppfolgingstilfellePerson =
-                    OppfolgingstilfellePerson(arbeidstakerFnr1, listOf(syketilfelledag1, syketilfelledag2, syketilfelledag3), syketilfelledag1, 0, false, LocalDateTime.now())
-                aktivitetskravVarselPlanner.processOppfolgingstilfelle(oppfolgingstilfellePerson, arbeidstakerFnr1)
+
+                aktivitetskravVarselPlanner.processOppfolgingstilfelle(arbeidstakerAktorId1, arbeidstakerFnr1)
 
                 val lagreteVarsler = embeddedDatabase.fetchPlanlagtVarselByFnr(arbeidstakerFnr1)
                 val nrOfRowsFetchedTotal = lagreteVarsler.size
@@ -160,24 +166,25 @@ object AktivitetskravVarselPlannerSpek : Spek({
             embeddedDatabase.storePlanlagtVarsel(planlagtVarselToStore3)
 
             val syketilfellebit1 =
-                Syketilfellebit("1", arbeidstakerAktorId1, "2", LocalDateTime.now(), LocalDateTime.now(), listOf("SYKMELDING", "SENDT"), "3", LocalDateTime.now(), LocalDateTime.now())
+                Syketilfellebit("1", arbeidstakerAktorId1, "2", LocalDateTime.now(), LocalDateTime.now(), listOf("SYKMELDING", "SENDT"), "3", LocalDateTime.now(), LocalDateTime.now().plusDays(7))
             val syketilfellebit2 =
-                Syketilfellebit("1", arbeidstakerAktorId1, "2", LocalDateTime.now(), LocalDateTime.now(), listOf("SYKMELDING", "UTDANNING"), "3", LocalDateTime.now(), LocalDateTime.now())
+                Syketilfellebit("2", arbeidstakerAktorId1, "2", LocalDateTime.now(), LocalDateTime.now(), listOf("SYKMELDING", "SENDT"), "3", LocalDateTime.now().plusDays(8), LocalDateTime.now().plusDays(16))
             val syketilfellebit3 =
-                Syketilfellebit("1", arbeidstakerAktorId1, "2", LocalDateTime.now(), LocalDateTime.now(), listOf("PAPIRSYKMELDING", "BEKREFTET"), "3", LocalDateTime.now(), LocalDateTime.now())
+                Syketilfellebit("3", arbeidstakerAktorId1, "2", LocalDateTime.now(), LocalDateTime.now(), listOf("SYKMELDING", "SENDT"), "3", LocalDateTime.now().plusDays(17), LocalDateTime.now().plusDays(50))
 
-            val syketilfelledag1 = Syketilfelledag(LocalDate.now().minusDays(4), syketilfellebit1)
-            val syketilfelledag2 = Syketilfelledag(LocalDate.now().minusDays(2), syketilfellebit2)
-            val syketilfelledag3 = Syketilfelledag(LocalDate.now().plusDays(100), syketilfellebit3)
+            val syketilfelledag1 = Syketilfelledag(LocalDate.now(), syketilfellebit1)
+            val syketilfelledag2 = Syketilfelledag(LocalDate.now().plusDays(16), syketilfellebit2)
+            val syketilfelledag3 = Syketilfelledag(LocalDate.now().plusDays(50), syketilfellebit3)
 
-            val sykmeldtStatusResponse = SykmeldtStatusResponse(erSykmeldt = true, gradert = true, fom = LocalDate.now(), tom = LocalDate.now())
+            val sykmeldtStatusResponse = SykmeldtStatusResponse(erSykmeldt = true, gradert = true, fom = LocalDate.now(), tom = LocalDate.now().plusDays(50))
+            val oppfolgingstilfellePerson =
+                OppfolgingstilfellePerson(arbeidstakerFnr1, listOf(syketilfelledag1, syketilfelledag2, syketilfelledag3), syketilfelledag1, 0, false, LocalDateTime.now())
 
             coEvery { sykmeldingerConsumer.getSykmeldtStatusPaDato(any(), any()) } returns sykmeldtStatusResponse
+            coEvery { syfosyketilfelleConsumer.getOppfolgingstilfelle(any()) } returns oppfolgingstilfellePerson
 
             runBlocking {
-                val oppfolgingstilfellePerson =
-                    OppfolgingstilfellePerson(arbeidstakerFnr1, listOf(syketilfelledag1, syketilfelledag2, syketilfelledag3), syketilfelledag1, 0, false, LocalDateTime.now())
-                aktivitetskravVarselPlanner.processOppfolgingstilfelle(oppfolgingstilfellePerson, arbeidstakerFnr1)
+                aktivitetskravVarselPlanner.processOppfolgingstilfelle(arbeidstakerAktorId1, arbeidstakerFnr1)
 
                 val lagreteVarsler = embeddedDatabase.fetchPlanlagtVarselByFnr(arbeidstakerFnr1)
                 val nrOfRowsFetchedTotal = lagreteVarsler.size
@@ -210,18 +217,18 @@ object AktivitetskravVarselPlannerSpek : Spek({
             val syketilfelledag1 = Syketilfelledag(LocalDate.now(), syketilfellebit1)
 
             val sykmeldtStatusResponse = SykmeldtStatusResponse(erSykmeldt = true, gradert = false, fom = LocalDate.now(), tom = LocalDate.now())
+            val oppfolgingstilfellePerson = OppfolgingstilfellePerson(arbeidstakerFnr1, listOf(syketilfelledag1), syketilfelledag1, 0, false, LocalDateTime.now())
 
             coEvery { sykmeldingerConsumer.getSykmeldtStatusPaDato(any(), any()) } returns sykmeldtStatusResponse
+            coEvery { syfosyketilfelleConsumer.getOppfolgingstilfelle(any()) } returns oppfolgingstilfellePerson
 
             val lagreteVarsler1 = embeddedDatabase.fetchPlanlagtVarselByFnr(arbeidstakerFnr1)
             val nrOfRowsFetchedTotal1 = lagreteVarsler1.size
 
             nrOfRowsFetchedTotal1 shouldEqual 1
 
-            val oppfolgingstilfellePerson = OppfolgingstilfellePerson(arbeidstakerFnr1, listOf(syketilfelledag1), syketilfelledag1, 0, false, LocalDateTime.now())
-
             // Skal lagre varsel
-            runBlocking { aktivitetskravVarselPlanner.processOppfolgingstilfelle(oppfolgingstilfellePerson, arbeidstakerFnr1) }
+            runBlocking { aktivitetskravVarselPlanner.processOppfolgingstilfelle(arbeidstakerAktorId1, arbeidstakerFnr1) }
 
             val lagreteVarsler = embeddedDatabase.fetchPlanlagtVarselByFnr(arbeidstakerFnr1)
             val nrOfRowsFetchedTotal = lagreteVarsler.size
@@ -229,47 +236,12 @@ object AktivitetskravVarselPlannerSpek : Spek({
             nrOfRowsFetchedTotal shouldEqual 1
         }
 
-        it("Aktivitetskrav varsel er allerede sendt ut, varsel skal ikke opprettes") {
-            val planlagtVarselToStore1 = PlanlagtVarsel(arbeidstakerFnr1, arbeidstakerAktorId1, setOf("1"), VarselType.AKTIVITETSKRAV, LocalDate.now().minusDays(7))
-
-            embeddedDatabase.storePlanlagtVarsel(planlagtVarselToStore1)
-            embeddedDatabase.storePlanlagtVarsel(planlagtVarselToStore2)
-            embeddedDatabase.storePlanlagtVarsel(planlagtVarselToStore3)
-
-            val syketilfellebit1 =
-                Syketilfellebit("1", arbeidstakerAktorId1, "2", LocalDateTime.now(), LocalDateTime.now(), listOf("SYKMELDING", "SENDT"), "3", LocalDateTime.now(), LocalDateTime.now())
-            val syketilfellebit2 =
-                Syketilfellebit("1", arbeidstakerAktorId1, "2", LocalDateTime.now(), LocalDateTime.now(), listOf("ANNET_FRAVAR", "UTDANNING"), "3", LocalDateTime.now(), LocalDateTime.now())
-            val syketilfellebit3 =
-                Syketilfellebit("1", arbeidstakerAktorId1, "2", LocalDateTime.now(), LocalDateTime.now(), listOf("PAPIRSYKMELDING", "BEKREFTET"), "3", LocalDateTime.now(), LocalDateTime.now())
-
-            val syketilfelledag1 = Syketilfelledag(LocalDate.now().minusDays(4), syketilfellebit1)
-            val syketilfelledag2 = Syketilfelledag(LocalDate.now().minusDays(2), syketilfellebit2)
-            val syketilfelledag3 = Syketilfelledag(LocalDate.now().plusDays(100), syketilfellebit3)
-
-            val sykmeldtStatusResponse = SykmeldtStatusResponse(erSykmeldt = true, gradert = false, fom = LocalDate.now(), tom = LocalDate.now())
-
-            coEvery { sykmeldingerConsumer.getSykmeldtStatusPaDato(any(), any()) } returns sykmeldtStatusResponse
-
-            val oppfolgingstilfellePerson = OppfolgingstilfellePerson(arbeidstakerFnr1, listOf(syketilfelledag1, syketilfelledag2, syketilfelledag3), syketilfelledag1, 0, false, LocalDateTime.now())
-            runBlocking { aktivitetskravVarselPlanner.processOppfolgingstilfelle(oppfolgingstilfellePerson, arbeidstakerFnr1) }
-
-            val lagreteVarsler = embeddedDatabase.fetchPlanlagtVarselByFnr(arbeidstakerFnr1)
-            val nrOfRowsFetchedTotal = lagreteVarsler.size
-
-            nrOfRowsFetchedTotal shouldEqual 2
-            nrOfRowsFetchedTotal shouldNotEqual 3
-
-            lagreteVarsler.filter { it.type == VarselType.AKTIVITETSKRAV.name }.size shouldEqual 1
-        }
-
         it("Aktivitetskrav varsel blir lagret i database, ett sykeforløp") {
             val utsendingsdato1 = LocalDate.now().plusDays(2)
             //Gammel varsel
             val planlagtVarselToStore1 = PlanlagtVarsel(arbeidstakerFnr1, arbeidstakerAktorId1, setOf("1"), VarselType.AKTIVITETSKRAV, utsendingsdato1)
 
-            embeddedDatabase.storePlanlagtVarsel(planlagtVarselToStore1)//Gammel usendt AKTIVITETSKRAV
-
+            embeddedDatabase.storePlanlagtVarsel(planlagtVarselToStore1)        //Gammel usendt AKTIVITETSKRAV
             val fom1 = utsendingsdato1.minusDays(AKTIVITETSKRAV_DAGER)
             val tom1 = utsendingsdato1.plusDays(20)
 
@@ -287,8 +259,8 @@ object AktivitetskravVarselPlannerSpek : Spek({
                 )
 
             //Ny sykmelding, nytt forlop
-            val fom2 = tom1.plusDays(SYKEFORLOP_MIN_DIFF_DAGER).plusDays(2)
-            val tom2 = fom2.plusDays(AKTIVITETSKRAV_DAGER).plusDays(2)
+            val fom2 = tom1.plusDays(SYKEFORLOP_MIN_DIFF_DAGER + 2L)
+            val tom2 = fom2.plusDays(AKTIVITETSKRAV_DAGER + 2L)
             val syketilfellebit2 =
                 Syketilfellebit(
                     "1",
@@ -329,11 +301,15 @@ object AktivitetskravVarselPlannerSpek : Spek({
 
             val oppfolgingstilfellePerson2 =
                 OppfolgingstilfellePerson(arbeidstakerFnr1, listOf(syketilfelledag1, syketilfelledag2), syketilfelledag1, 0, false, LocalDateTime.now())
+
+            coEvery { syfosyketilfelleConsumer.getOppfolgingstilfelle(any()) } returns oppfolgingstilfellePerson2
+            runBlocking { aktivitetskravVarselPlanner.processOppfolgingstilfelle(arbeidstakerAktorId1, arbeidstakerFnr1) }
+
             val oppfolgingstilfellePerson3 =
                 OppfolgingstilfellePerson(arbeidstakerFnr1, listOf(syketilfelledag1, syketilfelledag2, syketilfelledag3), syketilfelledag1, 0, false, LocalDateTime.now())
 
-            runBlocking { aktivitetskravVarselPlanner.processOppfolgingstilfelle(oppfolgingstilfellePerson2, arbeidstakerFnr1) }
-            runBlocking { aktivitetskravVarselPlanner.processOppfolgingstilfelle(oppfolgingstilfellePerson3, arbeidstakerFnr1) }
+            coEvery { syfosyketilfelleConsumer.getOppfolgingstilfelle(any()) } returns oppfolgingstilfellePerson3
+            runBlocking { aktivitetskravVarselPlanner.processOppfolgingstilfelle(arbeidstakerAktorId1, arbeidstakerFnr1) }
 
             val lagreteVarsler = embeddedDatabase.fetchPlanlagtVarselByFnr(arbeidstakerFnr1)
             val nrOfRowsFetchedTotal = lagreteVarsler.size
@@ -375,8 +351,8 @@ object AktivitetskravVarselPlannerSpek : Spek({
                 )
 
             //Ny sykmelding, nytt forlop
-            val fom2 = tom1.plusDays(18)
-            val tom2 = fom2.plusDays(AKTIVITETSKRAV_DAGER).plusDays(2)
+            val fom2 = tom1.plusDays(SYKEFORLOP_MIN_DIFF_DAGER + 2L)
+            val tom2 = fom2.plusDays(AKTIVITETSKRAV_DAGER + 2L)
             val syketilfellebit2 =
                 Syketilfellebit(
                     "1",
@@ -391,8 +367,8 @@ object AktivitetskravVarselPlannerSpek : Spek({
                 )
 
             //Ny sykmelding, nytt forlop
-            val fom3 = tom2.plusDays(18)
-            val tom3 = fom3.plusDays(AKTIVITETSKRAV_DAGER).plusDays(2)
+            val fom3 = tom2.plusDays(SYKEFORLOP_MIN_DIFF_DAGER + 2L)
+            val tom3 = fom3.plusDays(AKTIVITETSKRAV_DAGER + 2L)
 
             val syketilfellebit3 =
                 Syketilfellebit(
@@ -417,11 +393,13 @@ object AktivitetskravVarselPlannerSpek : Spek({
 
             val oppfolgingstilfellePerson2 =
                 OppfolgingstilfellePerson(arbeidstakerFnr1, listOf(syketilfelledag1, syketilfelledag2), syketilfelledag1, 0, false, LocalDateTime.now())
+            coEvery { syfosyketilfelleConsumer.getOppfolgingstilfelle(any()) } returns oppfolgingstilfellePerson2
+            runBlocking { aktivitetskravVarselPlanner.processOppfolgingstilfelle(arbeidstakerAktorId1, arbeidstakerFnr1) }
+
             val oppfolgingstilfellePerson3 =
                 OppfolgingstilfellePerson(arbeidstakerFnr1, listOf(syketilfelledag1, syketilfelledag2, syketilfelledag3), syketilfelledag1, 0, false, LocalDateTime.now())
-
-            runBlocking { aktivitetskravVarselPlanner.processOppfolgingstilfelle(oppfolgingstilfellePerson2, arbeidstakerFnr1) }
-            runBlocking { aktivitetskravVarselPlanner.processOppfolgingstilfelle(oppfolgingstilfellePerson3, arbeidstakerFnr1) }
+            coEvery { syfosyketilfelleConsumer.getOppfolgingstilfelle(any()) } returns oppfolgingstilfellePerson3
+            runBlocking { aktivitetskravVarselPlanner.processOppfolgingstilfelle(arbeidstakerAktorId1, arbeidstakerFnr1) }
 
             val lagreteVarsler = embeddedDatabase.fetchPlanlagtVarselByFnr(arbeidstakerFnr1)
             val nrOfRowsFetchedTotal = lagreteVarsler.size
@@ -429,14 +407,14 @@ object AktivitetskravVarselPlannerSpek : Spek({
 
             val aktivitetskravVarsler = lagreteVarsler.filter { it.type == VarselType.AKTIVITETSKRAV.name }
 
-            val varsel1 = planlagtVarselToStore1.utsendingsdato
-            val varsel2 = fom2.plusDays(AKTIVITETSKRAV_DAGER)
-            val varsel3 = fom3.plusDays(AKTIVITETSKRAV_DAGER)
+            val varsel1dato = planlagtVarselToStore1.utsendingsdato
+            val varsel2dato = fom2.plusDays(AKTIVITETSKRAV_DAGER)
+            val varsel3dato = fom3.plusDays(AKTIVITETSKRAV_DAGER)
 
             aktivitetskravVarsler.size shouldEqual 3
-            aktivitetskravVarsler.filter { it.utsendingsdato == varsel1 }.toList().size shouldEqual 1
-            aktivitetskravVarsler.filter { it.utsendingsdato == varsel2 }.toList().size shouldEqual 1
-            aktivitetskravVarsler.filter { it.utsendingsdato == varsel3 }.toList().size shouldEqual 1
+            aktivitetskravVarsler.filter { it.utsendingsdato == varsel1dato }.toList().size shouldEqual 1
+            aktivitetskravVarsler.filter { it.utsendingsdato == varsel2dato }.toList().size shouldEqual 1
+            aktivitetskravVarsler.filter { it.utsendingsdato == varsel3dato }.toList().size shouldEqual 1
         }
 
         it("Aktivitetskrav varsel blir slettet fra database ved nytt sykeforløp hvis sluttdato i ny sykmelding er før sykeforløpets startdato") {
@@ -484,13 +462,14 @@ object AktivitetskravVarselPlannerSpek : Spek({
             val syketilfelledag1 = Syketilfelledag(LocalDate.now().minusDays(1), syketilfellebit1)
             val syketilfelledag2 = Syketilfelledag(LocalDate.now(), syketilfellebit2)
 
+            val sykmeldtStatusResponse = SykmeldtStatusResponse(erSykmeldt = true, gradert = false, fom = LocalDate.now(), tom = LocalDate.now())
             val oppfolgingstilfellePerson2 =
                 OppfolgingstilfellePerson(arbeidstakerFnr1, listOf(syketilfelledag1, syketilfelledag2), syketilfelledag2, 0, false, LocalDateTime.now())
 
-            val sykmeldtStatusResponse = SykmeldtStatusResponse(erSykmeldt = true, gradert = false, fom = LocalDate.now(), tom = LocalDate.now())
+            coEvery { syfosyketilfelleConsumer.getOppfolgingstilfelle(any()) } returns oppfolgingstilfellePerson2
             coEvery { sykmeldingerConsumer.getSykmeldtStatusPaDato(any(), any()) } returns sykmeldtStatusResponse
 
-            runBlocking { aktivitetskravVarselPlanner.processOppfolgingstilfelle(oppfolgingstilfellePerson2, arbeidstakerFnr1) }
+            runBlocking { aktivitetskravVarselPlanner.processOppfolgingstilfelle(arbeidstakerAktorId1, arbeidstakerFnr1) }
 
             val lagreteVarsler2 = embeddedDatabase.fetchPlanlagtVarselByFnr(arbeidstakerFnr1)
             val nrOfRowsFetchedTotal2 = lagreteVarsler2.size
@@ -524,7 +503,7 @@ object AktivitetskravVarselPlannerSpek : Spek({
 
             //Ny sykmelding. Skal være samme forlop, men med senere fom
             val fom2 = fom1.plusDays(2)
-            val tom2 = fom2.plusDays(AKTIVITETSKRAV_DAGER).plusDays(2)
+            val tom2 = fom2.plusDays(AKTIVITETSKRAV_DAGER + 2L)
             val utsendingsdato2 = fom2.plusDays(AKTIVITETSKRAV_DAGER)
 
             val syketilfellebit2 =
@@ -543,18 +522,26 @@ object AktivitetskravVarselPlannerSpek : Spek({
             val syketilfelledag1 = Syketilfelledag(LocalDate.now().minusDays(1), syketilfellebit1)
             val syketilfelledag2 = Syketilfelledag(LocalDate.now(), syketilfellebit2)
 
+            val sykmeldtStatusResponse = SykmeldtStatusResponse(erSykmeldt = true, gradert = false, fom = LocalDate.now(), tom = LocalDate.now())
             val oppfolgingstilfellePerson2 =
                 OppfolgingstilfellePerson(arbeidstakerFnr1, listOf(syketilfelledag1, syketilfelledag2), syketilfelledag2, 0, false, LocalDateTime.now())
 
-            val sykmeldtStatusResponse = SykmeldtStatusResponse(erSykmeldt = true, gradert = false, fom = LocalDate.now(), tom = LocalDate.now())
             coEvery { sykmeldingerConsumer.getSykmeldtStatusPaDato(any(), any()) } returns sykmeldtStatusResponse
+            coEvery { syfosyketilfelleConsumer.getOppfolgingstilfelle(any()) } returns oppfolgingstilfellePerson2
 
-            runBlocking { aktivitetskravVarselPlanner.processOppfolgingstilfelle(oppfolgingstilfellePerson2, arbeidstakerFnr1) }
+            runBlocking { aktivitetskravVarselPlanner.processOppfolgingstilfelle(arbeidstakerAktorId1, arbeidstakerFnr1) }
 
             val lagreteVarsler2 = embeddedDatabase.fetchPlanlagtVarselByFnr(arbeidstakerFnr1)
 
             lagreteVarsler2.size shouldEqual 1
             lagreteVarsler2[0].utsendingsdato shouldEqual utsendingsdato2
+        }
+
+        it("AkvitietskravVarselPlanner kaster RuntimeException dersom syfosyketilfelleConsumer returnerer 'null'") {
+            assertFailsWith(RuntimeException::class) {
+                coEvery { syfosyketilfelleConsumer.getOppfolgingstilfelle(any()) } returns null
+                runBlocking { aktivitetskravVarselPlanner.processOppfolgingstilfelle(arbeidstakerAktorId1, arbeidstakerFnr1) }
+            }
         }
     }
 })


### PR DESCRIPTION
Fjerner unødvendig branch i if-statement (og assosiert util-funksjon)
som blir implisitt sjekket av tidligere branch

Fjerner unødvendig test

39-ukers varsel, aktivitetskrav (og muligens møtebehov) bruker forskjellige endepunkt i syfosyketilfelle.
Kallet til syfosyketilfelle bør derfor gjøres i hvert enkelt VarselPlanner