### PR TITLE
Do not plan 'MER_VEILEDNING'-varsel if planned notification date is in

### DIFF
--- a/src/main/kotlin/no/nav/syfo/varsel/MerVeiledningVarselPlanner.kt
+++ b/src/main/kotlin/no/nav/syfo/varsel/MerVeiledningVarselPlanner.kt
@@ -7,6 +7,7 @@ import no.nav.syfo.db.domain.PlanlagtVarsel
 import no.nav.syfo.db.domain.VarselType
 import no.nav.syfo.util.VarselUtil
 import no.nav.syfo.utils.isEqualOrAfter
+import no.nav.syfo.utils.isEqualOrBefore
 import no.nav.syfo.utils.todayIsBetweenFomAndTom
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -59,7 +60,8 @@ class MerVeiledningVarselPlanner(val databaseAccess: DatabaseInterface, val syfo
 
     private fun varselDate39Uker(fom: LocalDate, tom: LocalDate): LocalDate? {
         val fomPlus39Weeks = fom.plusWeeks(nrOfWeeksThreshold)
-        return if (tom.isEqualOrAfter(fomPlus39Weeks))
+        val today = LocalDate.now()
+        return if (tom.isEqualOrAfter(fomPlus39Weeks) && today.isEqualOrBefore(fomPlus39Weeks))
             fomPlus39Weeks
         else
             null

--- a/src/test/kotlin/no/nav/syfo/varsel/MerVeiledningVarselPlannerSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/varsel/MerVeiledningVarselPlannerSpek.kt
@@ -84,11 +84,10 @@ object MerVeiledningVarselPlannerSpek : Spek({
             }
         }
 
-        it("Varsel blir planlagt selv om arbeidstaker har vært sykmeldt over 39 uker allerede") {
+        it("Varsel skal ikke planlegges dersom utsendingsdatoen er eldre enn dagens dato") {
 
             val fom = LocalDate.now().minusWeeks(40)
             val tom = LocalDate.now().plusWeeks(1)
-            val utsendingsdato = fom.plusWeeks(39)
 
             val oppfolgingstilfelle39Uker = Oppfolgingstilfelle39Uker(
                 arbeidstakerAktorId1,
@@ -104,8 +103,7 @@ object MerVeiledningVarselPlannerSpek : Spek({
                 merVeiledningVarselPlanner.processOppfolgingstilfelle(arbeidstakerAktorId1, arbeidstakerFnr1)
                 val lagreteVarsler = embeddedDatabase.fetchPlanlagtVarselByFnr(arbeidstakerFnr1)
 
-                lagreteVarsler.skalHaEt39UkersVarsel()
-                lagreteVarsler.skalHaUtsendingPaDato(utsendingsdato)
+                lagreteVarsler.skalIkkeHa39UkersVarsel()
             }
         }
 


### PR DESCRIPTION
the past. This might be a problem when enabling esyfovarsel in
production for the first time because it may lead to duplicate
notifications from two different systems (syfoservice and esyfovarsel)