### PR TITLE
Lagt til logging hvis kafkaconsumer stopper

### DIFF
--- a/src/main/kotlin/no/nav/syfo/kafka/oppfolgingstilfelle/OppfolgingstilfelleKafkaConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/oppfolgingstilfelle/OppfolgingstilfelleKafkaConsumer.kt
@@ -74,6 +74,7 @@ class OppfolgingstilfelleKafkaConsumer(
             kafkaListener.commitSync()
             delay(10)
         }
+        log.info("Stopping listening to $topicOppfolgingsTilfelle")
     }
 
     fun addPlanner(varselPlanner: VarselPlanner): OppfolgingstilfelleKafkaConsumer {


### PR DESCRIPTION
Vi har opplevd noen ganger at consumeren stopper å polle etter meldinger. Har lagt til logging for å få bekrefte om det er vår kode som stopper consumeren, eller om det er en annen grunn til dette.