### PR TITLE
Lagt til "UGRADERT" som gradering for å unngå parsing-feil

### DIFF
--- a/src/main/kotlin/no/nav/syfo/consumer/pdl/PdlResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/consumer/pdl/PdlResponse.kt
@@ -39,7 +39,8 @@ data class Adressebeskyttelse(
 enum class Gradering : Serializable {
     STRENGT_FORTROLIG_UTLAND,
     STRENGT_FORTROLIG,
-    FORTROLIG
+    FORTROLIG,
+    UGRADERT
 }
 
 data class PdlError(


### PR DESCRIPTION
Fiks for å unngå feil av denne typen:
```
Error in [aapen-syfo-oppfolgingstilfelle-v1] listener: Could not parse message | Cannot deserialize value of type `no.nav.syfo.consumer.pdl.Gradering` from String "UGRADERT": not one of the values accepted for Enum class: [FORTROLIG, STRENGT_FORTROLIG_UTLAND, STRENGT_FORTROLIG]
 at [Source: (String)"{"data":{"hentPerson":{"adressebeskyttelse":[{"gradering":"UGRADERT"}]}}}"; line: 1, column: 59] (through reference chain: no.nav.syfo.consumer.pdl.PdlPersonResponse["data"]->no.nav.syfo.consumer.pdl.PdlHentPerson["hentPerson"]->no.nav.syfo.consumer.pdl.PdlPerson["adressebeskyttelse"]->java.util.ArrayList[0]->no.nav.syfo.consumer.pdl.Adressebeskyttelse["gradering"])
```