### PR TITLE
Handle failed requests the same way as before upgrading ktor

### DIFF
--- a/src/main/kotlin/no/nav/syfo/auth/AzureAdTokenConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/auth/AzureAdTokenConsumer.kt
@@ -31,6 +31,7 @@ class AzureAdTokenConsumer(env: AppEnvironment) {
 
     val config: HttpClientConfig<ApacheEngineConfig>.() -> Unit = {
         install(JsonFeature) {
+            expectSuccess = false
             serializer = JacksonSerializer {
                 registerKotlinModule()
                 registerModule(JavaTimeModule())

--- a/src/main/kotlin/no/nav/syfo/auth/StsConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/auth/StsConsumer.kt
@@ -18,6 +18,7 @@ open class StsConsumer(env: CommonEnvironment) {
     private var token: Token? = null
 
     private val client = HttpClient(CIO) {
+        expectSuccess = false
         install(JsonFeature) {
             serializer = JacksonSerializer {
                 registerKotlinModule()

--- a/src/main/kotlin/no/nav/syfo/consumer/DkifConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/consumer/DkifConsumer.kt
@@ -27,6 +27,7 @@ class DkifConsumer(env: CommonEnvironment, stsConsumer: StsConsumer) {
 
     init {
         client = HttpClient(CIO) {
+            expectSuccess = false
             install(JsonFeature) {
                 serializer = JacksonSerializer {
                     registerKotlinModule()
@@ -54,7 +55,7 @@ class DkifConsumer(env: CommonEnvironment, stsConsumer: StsConsumer) {
                     }
                 }
             } catch (e: Exception) {
-                log.error("Error while calling DKIF: ${e.message}")
+                log.error("Error while calling DKIF: ${e.message}", e)
                 null
             }
 

--- a/src/main/kotlin/no/nav/syfo/consumer/PdlConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/consumer/PdlConsumer.kt
@@ -26,6 +26,7 @@ open class PdlConsumer(env: CommonEnvironment, stsConsumer: StsConsumer) {
 
     init {
         client = HttpClient(CIO) {
+            expectSuccess = false
             install(JsonFeature) {
                 serializer = JacksonSerializer {
                     registerKotlinModule()
@@ -100,7 +101,7 @@ open class PdlConsumer(env: CommonEnvironment, stsConsumer: StsConsumer) {
                     body = requestBody
                 }
             } catch (e: Exception) {
-                log.error("Error while calling PDL ($service): ${e.message}")
+                log.error("Error while calling PDL ($service): ${e.message}", e)
                 null
             }
         }

--- a/src/main/kotlin/no/nav/syfo/consumer/SyfosyketilfelleConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/consumer/SyfosyketilfelleConsumer.kt
@@ -27,6 +27,7 @@ open class SyfosyketilfelleConsumer(env: AppEnvironment, stsConsumer: StsConsume
 
     init {
         client = HttpClient(CIO) {
+            expectSuccess = false
             install(JsonFeature) {
                 serializer = JacksonSerializer {
                     registerKotlinModule()

--- a/src/main/kotlin/no/nav/syfo/consumer/SykmeldingerConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/consumer/SykmeldingerConsumer.kt
@@ -29,6 +29,7 @@ class SykmeldingerConsumer(env: AppEnvironment, azureAdTokenConsumer: AzureAdTok
 
     init {
         client = HttpClient(CIO) {
+            expectSuccess = false
             install(JsonFeature) {
                 serializer = JacksonSerializer {
                     registerKotlinModule()

--- a/src/main/kotlin/no/nav/syfo/kafka/oppfolgingstilfelle/OppfolgingstilfelleKafkaConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/oppfolgingstilfelle/OppfolgingstilfelleKafkaConsumer.kt
@@ -58,16 +58,16 @@ class OppfolgingstilfelleKafkaConsumer(
                             try {
                                 runBlocking { planner.processOppfolgingstilfelle(aktorId, fnr) }
                             } catch (e: Exception) {
-                                log.error("Error in [${planner.name}] planner: | ${e.message}")
+                                log.error("Error in [${planner.name}] planner: | ${e.message}", e)
                                 tellFeilIPlanner()
                             }
                         }
                     }
                 } catch (e: IOException) {
-                    log.error("Error in [$topicOppfolgingsTilfelle] listener: Could not parse message | ${e.message}")
+                    log.error("Error in [$topicOppfolgingsTilfelle] listener: Could not parse message | ${e.message}", e)
                     tellFeilIParsing()
                 } catch (e: Exception) {
-                    log.error("Error in [$topicOppfolgingsTilfelle] listener: Could not process message | ${e.message}")
+                    log.error("Error in [$topicOppfolgingsTilfelle] listener: Could not process message | ${e.message}", e)
                     tellFeilIProsessering()
                 }
             }

--- a/src/main/kotlin/no/nav/syfo/service/SendVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/SendVarselService.kt
@@ -25,7 +25,7 @@ class SendVarselService(
                 } ?: throw RuntimeException("Klarte ikke mappe typestreng til innholdstekst")
             }
         } catch (e: RuntimeException) {
-            log.error("Feil i utsending av varsel med UUID: ${pPlanlagtVarsel.uuid} | ${e.message}")
+            log.error("Feil i utsending av varsel med UUID: ${pPlanlagtVarsel.uuid} | ${e.message}", e)
             return UTSENDING_FEILET
         }
         return pPlanlagtVarsel.type


### PR DESCRIPTION
Når vi oppgraderte ktor så førte det til at måten vi behandler feil fra backend (300-, 400- og 500-feil) forandret seg. Den nye måten er at det kastes exception. For å få det til å oppføre seg som før kan man legge til `expectSuccess = false`. Se https://youtrack.jetbrains.com/issue/KTOR-1412 for mer informasjon

I tillegg har jeg lagt inn throwable i kall til log.error(), der hvor vi har en exception. Dette letter feilsøking fordi vi kan se stacktrace i kibana.