### PR TITLE
Skru av sammenligning inntil videre pga. performance issues

### DIFF
--- a/src/main/kotlin/no/nav/syfo/varsel/MerVeiledningVarselPlanner.kt
+++ b/src/main/kotlin/no/nav/syfo/varsel/MerVeiledningVarselPlanner.kt
@@ -25,12 +25,6 @@ class MerVeiledningVarselPlanner(
 
     override suspend fun processOppfolgingstilfelle(aktorId: String, fnr: String) = coroutineScope {
         val oppfolgingstilfelle = syfosyketilfelleConsumer.getOppfolgingstilfelle39Uker(aktorId)
-        try {
-            val oppfolgingstilfelleIntern = syketilfelleService.beregnKOppfolgingstilfelle39UkersVarsel(fnr)
-            log.info("SST: ${oppfolgingstilfelle?.fom} <--> ${oppfolgingstilfelle?.tom} (${oppfolgingstilfelle?.antallSykefravaersDagerTotalt})| INT: ${oppfolgingstilfelleIntern?.fom} <--> ${oppfolgingstilfelleIntern?.tom} (${oppfolgingstilfelleIntern?.antallSykefravaersDagerTotalt})")
-        } catch (e: IllegalArgumentException) {
-            log.warn("Spør på fnr som ikke har noen syketilfellebiter i databasen")
-        }
         
         if(oppfolgingstilfelle == null) {
             log.info("[$name]: Fant ikke oppfolgingstilfelle for denne brukeren. Planlegger ikke nytt varsel")


### PR DESCRIPTION
Sammenligning av oppfølgingstilfelle fra syfosyketilfelle og intern esyfovarsel-database skaper latency for kall gjennom API-GW (syfoapi). Vi trenger ikke sammenligne før alle syketilfellebitene er på plass fra flex.syketilfelletopic og kan inntil videre skru av denne for å gjøre kallene fra ditt-sykefravaer kortere.