### PR TITLE
Refactor ArbeidsgiverNotifikasjonService to avoid duplicate code

### DIFF
--- a/src/main/kotlin/no/nav/syfo/BootstrapApplication.kt
+++ b/src/main/kotlin/no/nav/syfo/BootstrapApplication.kt
@@ -71,8 +71,9 @@ fun main() {
                 val oppfolgingstilfelleConsumer = getSyfosyketilfelleConsumer(env.urlEnv, stsConsumer)
                 val sykmeldingerConsumer = SykmeldingerConsumer(env.urlEnv, azureAdTokenConsumer)
                 val narmesteLederConsumer = NarmesteLederConsumer(env.urlEnv, azureAdTokenConsumer)
+                val narmesteLederService = NarmesteLederService(narmesteLederConsumer)
                 val arbeidsgiverNotifikasjonProdusent = ArbeidsgiverNotifikasjonProdusent(env.urlEnv, azureAdTokenConsumer)
-                val arbeidsgiverNotifikasjonService = ArbeidsgiverNotifikasjonService(arbeidsgiverNotifikasjonProdusent)
+                val arbeidsgiverNotifikasjonService = ArbeidsgiverNotifikasjonService(arbeidsgiverNotifikasjonProdusent, narmesteLederService, env.urlEnv.baseUrlDineSykmeldte)
 
                 val beskjedKafkaProducer = BeskjedKafkaProducer(env)
                 val dineSykmeldteHendelseKafkaProducer = DineSykmeldteHendelseKafkaProducer(env)
@@ -88,15 +89,12 @@ fun main() {
                 val svarMotebehovVarselPlanner = SvarMotebehovVarselPlanner(database, oppfolgingstilfelleConsumer, varselSendtService)
                 val svarMotebehovVarselPlannerSyketilfellebit = SvarMotebehovVarselPlannerSyketilfellebit(database, syketilfellebitService, varselSendtService)
                 val replanleggingService = ReplanleggingService(database, merVeiledningVarselPlanner, aktivitetskravVarselPlanner)
-                val narmesteLederService = NarmesteLederService(narmesteLederConsumer)
                 val brukernotifikasjonerService = BrukernotifikasjonerService(beskjedKafkaProducer, accessControl)
                 val motebehovVarselService = MotebehovVarselService(
                     dineSykmeldteHendelseKafkaProducer,
                     brukernotifikasjonerService,
                     arbeidsgiverNotifikasjonService,
-                    narmesteLederService,
                     env.urlEnv.dialogmoterUrl,
-                    env.urlEnv.baseUrlDineSykmeldte
                 )
 
                 val syfoMotebehovConsumer = SyfoMotebehovConsumer(env.urlEnv, stsConsumer)

--- a/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverNotifikasjonService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverNotifikasjonService.kt
@@ -22,29 +22,31 @@ class ArbeidsgiverNotifikasjonService(
     ) {
         runBlocking {
             val narmesteLederRelasjon = narmesteLederService.getNarmesteLederRelasjon(arbeidsgiverNotifikasjon.ansattFnr, arbeidsgiverNotifikasjon.virksomhetsnummer)
-            if (narmesteLederRelasjon !== null && narmesteLederService.hasNarmesteLederInfo(narmesteLederRelasjon)) {
-                if (arbeidsgiverNotifikasjon.narmesteLederFnr == null || arbeidsgiverNotifikasjon.narmesteLederFnr.equals(narmesteLederRelasjon.narmesteLederFnr)) {
-                    val url = dineSykmeldteUrl + "/${narmesteLederRelasjon.narmesteLederId}"
-                    val arbeidsgiverNotifikasjonen = ArbeidsgiverNotifikasjon(
-                        arbeidsgiverNotifikasjon.uuid.toString(),
-                        arbeidsgiverNotifikasjon.virksomhetsnummer,
-                        url,
-                        narmesteLederRelasjon.narmesteLederFnr!!,
-                        arbeidsgiverNotifikasjon.ansattFnr,
-                        arbeidsgiverNotifikasjon.messageText,
-                        narmesteLederRelasjon.narmesteLederEpost!!,
-                        arbeidsgiverNotifikasjon.emailTitle,
-                        arbeidsgiverNotifikasjon.emailBody(url),
-                        arbeidsgiverNotifikasjon.hardDeleteDate,
-                    )
 
-                    arbeidsgiverNotifikasjonProdusent.createNewNotificationForArbeidsgiver(arbeidsgiverNotifikasjonen)
-                } else {
-                    log.warn("Sender ikke varsel til ag-notifikasjon: den ansatte har nærmeste leder med annet fnr enn mottaker i varselHendelse")
-                }
-            } else {
+            if (narmesteLederRelasjon == null || !narmesteLederService.hasNarmesteLederInfo(narmesteLederRelasjon)) {
                 log.warn("Sender ikke varsel til ag-notifikasjon: narmesteLederRelasjon er null eller har ikke kontaktinfo")
+                return@runBlocking
             }
+
+            if (arbeidsgiverNotifikasjon.narmesteLederFnr !== null && !arbeidsgiverNotifikasjon.narmesteLederFnr.equals(narmesteLederRelasjon.narmesteLederFnr)) {
+                log.warn("Sender ikke varsel til ag-notifikasjon: den ansatte har nærmeste leder med annet fnr enn mottaker i varselHendelse")
+                return@runBlocking
+            }
+
+            val url = dineSykmeldteUrl + "/${narmesteLederRelasjon.narmesteLederId}"
+            val arbeidsgiverNotifikasjonen = ArbeidsgiverNotifikasjon(
+                arbeidsgiverNotifikasjon.uuid.toString(),
+                arbeidsgiverNotifikasjon.virksomhetsnummer,
+                url,
+                narmesteLederRelasjon.narmesteLederFnr!!,
+                arbeidsgiverNotifikasjon.ansattFnr,
+                arbeidsgiverNotifikasjon.messageText,
+                narmesteLederRelasjon.narmesteLederEpost!!,
+                arbeidsgiverNotifikasjon.emailTitle,
+                arbeidsgiverNotifikasjon.emailBody(url),
+                arbeidsgiverNotifikasjon.hardDeleteDate,
+            )
+            arbeidsgiverNotifikasjonProdusent.createNewNotificationForArbeidsgiver(arbeidsgiverNotifikasjonen)
         }
     }
 }

--- a/src/main/kotlin/no/nav/syfo/service/SendVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/SendVarselService.kt
@@ -1,21 +1,21 @@
 package no.nav.syfo.service
 
-import no.nav.syfo.DINE_SYKMELDTE_AKTIVITETSKRAV_TEKST
-import no.nav.syfo.UrlEnv
+import no.nav.syfo.*
 import no.nav.syfo.consumer.narmesteLeder.NarmesteLederService
 import no.nav.syfo.consumer.syfomotebehov.SyfoMotebehovConsumer
 import no.nav.syfo.db.domain.PPlanlagtVarsel
 import no.nav.syfo.db.domain.UTSENDING_FEILET
-import no.nav.syfo.db.domain.VarselType
+import no.nav.syfo.db.domain.VarselType.*
+import no.nav.syfo.kafka.consumers.varselbus.domain.DineSykmeldteHendelseType
 import no.nav.syfo.kafka.producers.brukernotifikasjoner.BeskjedKafkaProducer
 import no.nav.syfo.kafka.producers.dinesykmeldte.DineSykmeldteHendelseKafkaProducer
 import no.nav.syfo.kafka.producers.dinesykmeldte.domain.DineSykmeldteVarsel
-import no.nav.syfo.kafka.consumers.varselbus.domain.DineSykmeldteHendelseType
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.net.URL
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
+import java.util.*
 
 class SendVarselService(
     val beskjedKafkaProducer: BeskjedKafkaProducer,
@@ -41,35 +41,24 @@ class SendVarselService(
 
                 if (varselUrl !== null && varselContent !== null) {
                     when {
-                        VarselType.AKTIVITETSKRAV.toString().equals(pPlanlagtVarsel.type) -> {
-                            if (uuid != "66705dc4-e3b6-4afd-ab1a-ccd08bbcbc78" &&
-                                uuid != "b2dec22e-4c5d-49f0-8e53-8ed06dea68e5"
-                            ) {
-                                sendVarselTilSykmeldt(fnr, varselContent, uuid, varselUrl)
-                            }
+                        AKTIVITETSKRAV.toString().equals(pPlanlagtVarsel.type) -> {
+                            sendVarselTilSykmeldt(fnr, varselContent, uuid, varselUrl)
                             if (orgnummer !== null) {
-                                log.info("Henter NL-relasjon for UUID: $uuid")
-                                val narmesteLederRelasjon = narmesteLederService.getNarmesteLederRelasjon(fnr, orgnummer)
-                                log.info("NL-relasjon hentet for UUID: $uuid")
-                                if (narmesteLederService.hasNarmesteLederInfo(narmesteLederRelasjon)) {
-                                    sendAktivitetskravVarselTilArbeidsgiver(
-                                        fnr,
-                                        orgnummer,
-                                        uuid,
-                                        narmesteLederRelasjon!!.narmesteLederFnr!!,
-                                        narmesteLederRelasjon.narmesteLederEpost!!
-                                    )
-                                }
+                                sendAktivitetskravVarselTilArbeidsgiver(
+                                    uuid,
+                                    fnr,
+                                    orgnummer
+                                )
                             }
                             pPlanlagtVarsel.type
                         }
 
-                        VarselType.MER_VEILEDNING.toString().equals(pPlanlagtVarsel.type) -> {
+                        MER_VEILEDNING.toString().equals(pPlanlagtVarsel.type) -> {
                             sendVarselTilSykmeldt(fnr, varselContent, uuid, varselUrl)
                             pPlanlagtVarsel.type
                         }
 
-                        VarselType.SVAR_MOTEBEHOV.toString().equals(pPlanlagtVarsel.type) -> {
+                        SVAR_MOTEBEHOV.toString().equals(pPlanlagtVarsel.type) -> {
                             syfoMotebehovConsumer.sendVarselTilArbeidstaker(pPlanlagtVarsel.aktorId, pPlanlagtVarsel.fnr)
                             if (orgnummer !== null) {
                                 val narmesteLederRelasjon = narmesteLederService.getNarmesteLederRelasjon(fnr, orgnummer)
@@ -101,9 +90,9 @@ class SendVarselService(
         }
     }
 
-    private suspend fun sendAktivitetskravVarselTilArbeidsgiver(fnr: String, orgnummer: String, uuid: String, narmesteLederFnr: String, narmesteLederEpostadresse: String) {
+    private fun sendAktivitetskravVarselTilArbeidsgiver(uuid: String, arbeidstakerFnr: String, orgnummer: String) {
         val dineSykmeldteVarsel = DineSykmeldteVarsel(
-            fnr,
+            arbeidstakerFnr,
             orgnummer,
             DineSykmeldteHendelseType.AKTIVITETSKRAV.toString(),
             null,
@@ -111,28 +100,21 @@ class SendVarselService(
             OffsetDateTime.now().plusWeeks(WEEKS_BEFORE_DELETE_AKTIVITETSKRAV)
         )
 
-        val nlRelasjon = narmesteLederService.getNarmesteLederRelasjon(fnr, orgnummer)
-        val dineSykmeldteUrlSuffix = when {
-            nlRelasjon !== null && narmesteLederService.hasNarmesteLederInfo(nlRelasjon) -> "/${nlRelasjon.narmesteLederId}"
-            else -> {
-                log.warn("Lenker til Dine sykmeldte landingsside: narmesteLederRelasjon er null eller har ikke kontaktinfo")
-                ""
-            }
-        }
-
         log.info("Sender AKTIVITETSKRAV varsel til Dine sykmeldte for uuid $uuid")
         dineSykmeldteHendelseKafkaProducer.sendVarsel(dineSykmeldteVarsel)
 
         log.info("Sender AKTIVITETSKRAV varsel til Arbeidsgivernotifikasjoner for uuid $uuid")
         arbeidsgiverNotifikasjonService.sendNotifikasjon(
-            VarselType.AKTIVITETSKRAV,
-            uuid,
-            orgnummer,
-            "${urlEnv.baseUrlDineSykmeldte}$dineSykmeldteUrlSuffix",
-            narmesteLederFnr,
-            fnr,
-            narmesteLederEpostadresse,
-            LocalDateTime.now().plusWeeks(WEEKS_BEFORE_DELETE_AKTIVITETSKRAV),
+            ArbeidsgiverNotifikasjonInput(
+                UUID.fromString(uuid),
+                orgnummer,
+                null,
+                arbeidstakerFnr,
+                ARBEIDSGIVERNOTIFIKASJON_AKTIVITETSKRAV_MESSAGE_TEXT,
+                ARBEIDSGIVERNOTIFIKASJON_AKTIVITETSKRAV_EMAIL_TITLE,
+                {url: String -> ARBEIDSGIVERNOTIFIKASJON_AKTIVITETSKRAV_EMAIL_BODY_START + url + ARBEIDSGIVERNOTIFIKASJON_AKTIVITETSKRAV_EMAIL_BODY_END},
+                LocalDateTime.now().plusWeeks(WEEKS_BEFORE_DELETE_AKTIVITETSKRAV)
+            )
         )
     }
 
@@ -144,9 +126,9 @@ class SendVarselService(
 
     private fun varselContentFromType(type: String): String? {
         return when (type) {
-            VarselType.AKTIVITETSKRAV.toString() -> "NAV skal vurdere aktivitetsplikten din"
-            VarselType.MER_VEILEDNING.toString() -> "Det nærmer seg datoen da du ikke lenger kan få sykepenger."
-            VarselType.SVAR_MOTEBEHOV.toString() -> "Ikke i bruk"
+            AKTIVITETSKRAV.toString() -> "NAV skal vurdere aktivitetsplikten din"
+            MER_VEILEDNING.toString() -> "Det nærmer seg datoen da du ikke lenger kan få sykepenger."
+            SVAR_MOTEBEHOV.toString() -> "Ikke i bruk"
             else -> null
         }
     }
@@ -158,9 +140,9 @@ class SendVarselService(
         val svarMotebehovUrl = URL(baseUrlSykInfo + "/ikke-i-bruk")
 
         return when (type) {
-            VarselType.AKTIVITETSKRAV.toString() -> aktivitetskravUrl
-            VarselType.MER_VEILEDNING.toString() -> merVeiledningUrl
-            VarselType.SVAR_MOTEBEHOV.toString() -> svarMotebehovUrl
+            AKTIVITETSKRAV.toString() -> aktivitetskravUrl
+            MER_VEILEDNING.toString() -> merVeiledningUrl
+            SVAR_MOTEBEHOV.toString() -> svarMotebehovUrl
             else -> null
         }
     }


### PR DESCRIPTION
- Moved call to NarmesteLederService inside ArbeidsgiverNotifikasjonService, as it was duplicated in SendVarselService and MotebehovVarselService (and future services)
- Pulled out references to type specific constants in ArbeidsgiverNotifikasjonService (`ARBEIDSGIVERNOTIFIKASJON_AKTIVITETSKRAV_MESSAGE_TEXT`, `ARBEIDSGIVERNOTIFIKASJON_SVAR_MOTEBEHOV_MESSAGE_TEXT` etc)