### PR TITLE
Add storing of max date when processing kafka events

### DIFF
--- a/src/main/kotlin/no/nav/syfo/service/SykepengerMaxDateService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/SykepengerMaxDateService.kt
@@ -32,6 +32,7 @@ class SykepengerMaxDateService(private val databaseInterface: DatabaseInterface)
     }
 
     fun processUtbetalingSpleisEvent(utbetaling: UtbetalingUtbetalt) {
+        processNewMaxDate(utbetaling.fødselsnummer, utbetaling.foreløpigBeregnetSluttPåSykepenger, SykepengerMaxDateSource.SPLEIS)
         databaseInterface.storeSpleisUtbetaling(utbetaling)
     }
 
@@ -40,6 +41,7 @@ class SykepengerMaxDateService(private val databaseInterface: DatabaseInterface)
     }
 
     fun processInfotrygdEvent(fnr: String, sykepengerMaxDate: LocalDate, utbetaltTilDate: LocalDate, gjenstaendeSykepengedager: Int) {
+        processNewMaxDate(fnr,sykepengerMaxDate, SykepengerMaxDateSource.SPLEIS)
         databaseInterface.storeInfotrygdUtbetaling(fnr, sykepengerMaxDate, utbetaltTilDate, gjenstaendeSykepengedager)
     }
 

--- a/src/main/kotlin/no/nav/syfo/service/SykepengerMaxDateService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/SykepengerMaxDateService.kt
@@ -41,7 +41,7 @@ class SykepengerMaxDateService(private val databaseInterface: DatabaseInterface)
     }
 
     fun processInfotrygdEvent(fnr: String, sykepengerMaxDate: LocalDate, utbetaltTilDate: LocalDate, gjenstaendeSykepengedager: Int) {
-        processNewMaxDate(fnr,sykepengerMaxDate, SykepengerMaxDateSource.SPLEIS)
+        processNewMaxDate(fnr,sykepengerMaxDate, SykepengerMaxDateSource.INFOTRYGD)
         databaseInterface.storeInfotrygdUtbetaling(fnr, sykepengerMaxDate, utbetaltTilDate, gjenstaendeSykepengedager)
     }
 


### PR DESCRIPTION
Users might be provided with incorrect max date.  
Add processing of max date to update `SYKEPENGER_MAX_DATE `table