### PR TITLE
Add veileder-tilgangskontroll-consumer and use in max-date-api

### DIFF
--- a/.nais/dev.json
+++ b/.nais/dev.json
@@ -27,7 +27,9 @@
     "DOKDIST_FORDELING_SCOPE": "api://dev-fss.teamdokumenthandtering.saf/.default",
     "DOKARKIV_URL": "https://dokarkiv.dev-fss-pub.nais.io",
     "DOKARKIV_SCOPE": "api://dev-fss.teamdokumenthandtering.dokarkiv/.default",
-    "SYFOOPPDFGEN_URL": "https://syfooppdfgen.dev.intern.nav.no"
+    "SYFOOPPDFGEN_URL": "https://syfooppdfgen.dev.intern.nav.no",
+    "SYFOTILGANGSKONTROLL_URL": "https://syfo-tilgangskontroll.dev-fss-pub.nais.io",
+    "SYFOTILGANGSKONTROLL_SCOPE": "api://dev-fss.teamsykefravr.syfo-tilgangskontroll/.default"
   },
   "job": {
     "KTOR_ENV": "remote",

--- a/.nais/prod.json
+++ b/.nais/prod.json
@@ -27,7 +27,9 @@
     "DOKDIST_FORDELING_SCOPE": "api://prod-fss.teamdokumenthandtering.saf/.default",
     "DOKARKIV_URL": "https://dokarkiv.prod-fss-pub.nais.io",
     "DOKARKIV_SCOPE": "api://prod-fss.teamdokumenthandtering.dokarkiv/.default",
-    "SYFOOPPDFGEN_URL": "https://syfooppdfgen.intern.nav.no"
+    "SYFOOPPDFGEN_URL": "https://syfooppdfgen.intern.nav.no",
+    "SYFOTILGANGSKONTROLL_URL": "https://syfo-tilgangskontroll.prod-fss-pub.nais.io",
+    "SYFOTILGANGSKONTROLL_SCOPE": "api://prod-fss.teamsykefravr.syfo-tilgangskontroll/.default"
   },
   "job": {
     "KTOR_ENV": "remote",

--- a/src/main/kotlin/no/nav/syfo/BootstrapApplication.kt
+++ b/src/main/kotlin/no/nav/syfo/BootstrapApplication.kt
@@ -34,6 +34,7 @@ import no.nav.syfo.consumer.pdfgen.PdfgenConsumer
 import no.nav.syfo.consumer.pdl.LocalPdlConsumer
 import no.nav.syfo.consumer.pdl.PdlConsumer
 import no.nav.syfo.consumer.syfosmregister.SykmeldingerConsumer
+import no.nav.syfo.consumer.veiledertilgang.VeilederTilgangskontrollConsumer
 import no.nav.syfo.db.Database
 import no.nav.syfo.db.DatabaseInterface
 import no.nav.syfo.db.grantAccessToIAMUsers
@@ -151,6 +152,9 @@ fun main() {
                         microFrontendService
                     )
 
+                val veilederTilgangskontrollConsumer =
+                    VeilederTilgangskontrollConsumer(env.urlEnv, azureAdTokenConsumer)
+
                 connector {
                     port = env.appEnv.applicationPort
                 }
@@ -169,6 +173,7 @@ fun main() {
                         sykepengerMaxDateService,
                         sykmeldingService,
                         pdlConsumer,
+                        veilederTilgangskontrollConsumer,
                     )
 
                     kafkaModule(
@@ -218,6 +223,7 @@ fun Application.serverModule(
     sykepengerMaxDateService: SykepengerMaxDateService,
     sykmeldingService: SykmeldingService,
     pdlConsumer: PdlConsumer,
+    veilederTilgangskontrollConsumer: VeilederTilgangskontrollConsumer,
 ) {
 
     val sendVarselService =
@@ -264,11 +270,23 @@ fun Application.serverModule(
     }
 
     runningRemotely {
-        setupRoutesWithAuthentication(varselSender, replanleggingService, sykepengerMaxDateService, env.authEnv)
+        setupRoutesWithAuthentication(
+            varselSender,
+            replanleggingService,
+            sykepengerMaxDateService,
+            veilederTilgangskontrollConsumer,
+            env.authEnv
+        )
     }
 
     runningLocally {
-        setupLocalRoutesWithAuthentication(varselSender, replanleggingService, sykepengerMaxDateService, env.authEnv)
+        setupLocalRoutesWithAuthentication(
+            varselSender,
+            replanleggingService,
+            sykepengerMaxDateService,
+            veilederTilgangskontrollConsumer,
+            env.authEnv
+        )
     }
 
     routing {

--- a/src/main/kotlin/no/nav/syfo/Environment.kt
+++ b/src/main/kotlin/no/nav/syfo/Environment.kt
@@ -59,6 +59,8 @@ fun getEnv(): Environment {
                 dokarkivUrl = getEnvVar("DOKARKIV_URL"),
                 dokarkivScope = getEnvVar("DOKARKIV_SCOPE"),
                 syfooppdfgenUrl = getEnvVar("SYFOOPPDFGEN_URL"),
+                syfoTilgangskontrollUrl = getEnvVar("SYFOTILGANGSKONTROLL_URL"),
+                syfoTilgangskontrollScope = getEnvVar("SYFOTILGANGSKONTROLL_SCOPE"),
             ),
             KafkaEnv(
                 bootstrapServersUrl = getEnvVar("KAFKA_BOOTSTRAP_SERVERS_URL"),
@@ -141,6 +143,8 @@ data class UrlEnv(
     val dokarkivUrl: String,
     val dokarkivScope: String,
     val syfooppdfgenUrl: String,
+    val syfoTilgangskontrollUrl: String,
+    val syfoTilgangskontrollScope: String,
 )
 
 data class KafkaEnv(

--- a/src/main/kotlin/no/nav/syfo/api/maxdate/SykepengerMaxDateAzureApi.kt
+++ b/src/main/kotlin/no/nav/syfo/api/maxdate/SykepengerMaxDateAzureApi.kt
@@ -4,31 +4,41 @@ import io.ktor.application.*
 import io.ktor.http.*
 import io.ktor.response.*
 import io.ktor.routing.*
-import no.nav.syfo.consumer.dkif.DkifConsumer.Companion.NAV_PERSONIDENT_HEADER
+import net.logstash.logback.argument.StructuredArguments
+import no.nav.syfo.consumer.veiledertilgang.VeilederTilgangskontrollConsumer
 import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.service.SykepengerMaxDateService
-import no.nav.syfo.utils.getPersonIdent
+import no.nav.syfo.utils.*
 import org.slf4j.LoggerFactory
 import java.io.Serializable
 import java.time.LocalDate
 
 fun Route.registerSykepengerMaxDateAzureApi(
-    sykepengerMaxDateService: SykepengerMaxDateService
+    sykepengerMaxDateService: SykepengerMaxDateService,
+    veilederTilgangskontrollConsumer: VeilederTilgangskontrollConsumer,
 ) {
     val log = LoggerFactory.getLogger("no.nav.syfo.api.maxdate.SykepengerMaxDateAzureApi")
     get("/api/azure/v1/sykepenger/maxdate") {
         val personIdent = call.personIdent()
+        val token = call.bearerToken()
+        val callId = call.getCallId()
 
-        try {
-            val sykepengerMaxDate = sykepengerMaxDateService.getSykepengerMaxDate(personIdent.value)
-            log.info("Fetched sykepengerMaxDate from database: $sykepengerMaxDate")
-            call.respond(SykepengerMaxDateAzureResponse(sykepengerMaxDate))
-        } catch (e: Exception) {
-            log.error("Encountered exception during fetching sykepengerMaxDate from database: ${e.message}")
-            call.respond(
-                HttpStatusCode.InternalServerError,
-                "Encountered exception during fetching max date from database: ${e.message}"
-            )
+        if (veilederTilgangskontrollConsumer.hasAccess(personIdent, token, callId)) {
+            try {
+                val sykepengerMaxDate = sykepengerMaxDateService.getSykepengerMaxDate(personIdent.value)
+                log.info("Fetched sykepengerMaxDate from database: $sykepengerMaxDate")
+                call.respond(SykepengerMaxDateAzureResponse(sykepengerMaxDate))
+            } catch (e: Exception) {
+                log.error("Encountered exception during fetching sykepengerMaxDate from database: ${e.message}")
+                call.respond(
+                    HttpStatusCode.InternalServerError,
+                    "Encountered exception during fetching max date from database: ${e.message}"
+                )
+            }
+        } else {
+            val message = "Cannot fetch max date: Veileder has no access to person"
+            log.warn("$message, {}", callIdArgument(callId))
+            call.respond(HttpStatusCode.Forbidden, message)
         }
     }
 }
@@ -39,3 +49,8 @@ data class SykepengerMaxDateAzureResponse(
 
 private fun ApplicationCall.personIdent(): PersonIdent = this.getPersonIdent()
     ?: throw IllegalArgumentException("Failed to get maxDate: No $NAV_PERSONIDENT_HEADER supplied in request header")
+
+private fun ApplicationCall.bearerToken(): String = this.getBearerToken()
+    ?: throw IllegalArgumentException("Failed to get maxDate: No Authorization header supplied")
+
+private fun callIdArgument(callId: String) = StructuredArguments.keyValue("callId", callId)!!

--- a/src/main/kotlin/no/nav/syfo/auth/Authentication.kt
+++ b/src/main/kotlin/no/nav/syfo/auth/Authentication.kt
@@ -18,6 +18,7 @@ import no.nav.syfo.api.admin.registerAdminApi
 import no.nav.syfo.api.job.registerJobTriggerApi
 import no.nav.syfo.api.maxdate.registerSykepengerMaxDateAzureApi
 import no.nav.syfo.api.maxdate.registerSykepengerMaxDateRestApi
+import no.nav.syfo.consumer.veiledertilgang.VeilederTilgangskontrollConsumer
 import no.nav.syfo.job.VarselSender
 import no.nav.syfo.service.ReplanleggingService
 import no.nav.syfo.service.SykepengerMaxDateService
@@ -118,6 +119,7 @@ fun Application.setupLocalRoutesWithAuthentication(
     varselSender: VarselSender,
     replanleggingService: ReplanleggingService,
     sykepengerMaxDateService: SykepengerMaxDateService,
+    veilederTilgangskontrollConsumer: VeilederTilgangskontrollConsumer,
     authEnv: AuthEnv,
 ) {
     install(Authentication) {
@@ -140,7 +142,7 @@ fun Application.setupLocalRoutesWithAuthentication(
             registerJobTriggerApi(varselSender)
         }
         authenticate(JwtIssuerType.INTERNAL_AZUREAD.name) {
-            registerSykepengerMaxDateAzureApi(sykepengerMaxDateService)
+            registerSykepengerMaxDateAzureApi(sykepengerMaxDateService, veilederTilgangskontrollConsumer)
         }
     }
 }
@@ -149,6 +151,7 @@ fun Application.setupRoutesWithAuthentication(
     varselSender: VarselSender,
     replanleggingService: ReplanleggingService,
     sykepengerMaxDateService: SykepengerMaxDateService,
+    veilederTilgangskontrollConsumer: VeilederTilgangskontrollConsumer,
     authEnv: AuthEnv,
 ) {
     val wellKnownTokenX = getWellKnown(authEnv.tokenXWellKnownUrl)
@@ -165,7 +168,7 @@ fun Application.setupRoutesWithAuthentication(
             registerJobTriggerApi(varselSender)
         }
         authenticate(JwtIssuerType.INTERNAL_AZUREAD.name) {
-            registerSykepengerMaxDateAzureApi(sykepengerMaxDateService)
+            registerSykepengerMaxDateAzureApi(sykepengerMaxDateService, veilederTilgangskontrollConsumer)
         }
         authenticate("tokenx") {
             registerSykepengerMaxDateRestApi(sykepengerMaxDateService)

--- a/src/main/kotlin/no/nav/syfo/consumer/dkif/DkifConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/consumer/dkif/DkifConsumer.kt
@@ -9,9 +9,9 @@ import no.nav.syfo.UrlEnv
 import no.nav.syfo.auth.AzureAdTokenConsumer
 import no.nav.syfo.consumer.domain.Kontaktinfo
 import no.nav.syfo.consumer.domain.KontaktinfoMapper
-import no.nav.syfo.utils.httpClient
+import no.nav.syfo.utils.*
 import org.slf4j.LoggerFactory
-import java.util.UUID.randomUUID
+import java.util.*
 
 class DkifConsumer(private val urlEnv: UrlEnv, private val azureAdTokenConsumer: AzureAdTokenConsumer) {
     private val client = httpClient()
@@ -50,12 +50,10 @@ class DkifConsumer(private val urlEnv: UrlEnv, private val azureAdTokenConsumer:
     }
 
     companion object {
-        private const val NAV_CALL_ID_HEADER = "Nav-Call-Id"
         private val log = LoggerFactory.getLogger("no.nav.syfo.consumer.dkif.DkifConsumer")
-        const val NAV_PERSONIDENT_HEADER = "Nav-Personident"
 
         private fun createCallId(): String {
-            val randomUUID = randomUUID().toString()
+            val randomUUID = UUID.randomUUID().toString()
             return "esyfovarsel-$randomUUID"
         }
     }

--- a/src/main/kotlin/no/nav/syfo/consumer/veiledertilgang/Tilgang.kt
+++ b/src/main/kotlin/no/nav/syfo/consumer/veiledertilgang/Tilgang.kt
@@ -1,0 +1,5 @@
+package no.nav.syfo.consumer.veiledertilgang
+
+data class Tilgang(
+    val harTilgang: Boolean,
+)

--- a/src/main/kotlin/no/nav/syfo/consumer/veiledertilgang/VeilederTilgangskontrollConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/consumer/veiledertilgang/VeilederTilgangskontrollConsumer.kt
@@ -1,0 +1,52 @@
+package no.nav.syfo.consumer.veiledertilgang
+
+import io.ktor.client.call.*
+import io.ktor.client.features.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.*
+import no.nav.syfo.UrlEnv
+import no.nav.syfo.auth.AzureAdTokenConsumer
+import no.nav.syfo.domain.PersonIdent
+import no.nav.syfo.utils.*
+import org.slf4j.LoggerFactory
+
+class VeilederTilgangskontrollConsumer(urlEnv: UrlEnv, private val azureAdTokenConsumer: AzureAdTokenConsumer) {
+    private val client = httpClient()
+    private val basepath = urlEnv.syfoTilgangskontrollUrl
+    private val log = LoggerFactory.getLogger("no.nav.syfo.consumer.veileder.VeilederTilgangskontrollConsumer")
+    private val scope = urlEnv.syfoTilgangskontrollScope
+
+    suspend fun hasAccess(personIdent: PersonIdent, token: String, callId: String): Boolean {
+        val requestURL = "$basepath/syfo-tilgangskontroll/api/tilgang/navident/person"
+
+        try {
+            val onBehalfOfToken = azureAdTokenConsumer.getOnBehalfOfToken(
+                resource = scope,
+                token = token,
+            ) ?: throw RuntimeException("Failed to request access to Person: Failed to get OBO token")
+
+            val response = client.get<HttpResponse>(requestURL) {
+                header(HttpHeaders.Authorization, "Bearer $onBehalfOfToken")
+                header(HttpHeaders.ContentType, ContentType.Application.Json)
+                header(NAV_PERSONIDENT_HEADER, personIdent.value)
+                header(NAV_CALL_ID_HEADER, callId)
+            }
+
+            return response.receive<Tilgang>().harTilgang
+        } catch (e: ClientRequestException) {
+            if (e.response.status == HttpStatusCode.Forbidden) {
+                log.warn("Denied veileder access to person: ${e.message}")
+            } else {
+                log.error("Encountered exception during call to tilgangskontroll: ${e.message}")
+            }
+            return false
+        } catch (e: Exception) {
+            log.error("Encountered exception during call to tilgangskontroll: ${e.message}")
+            return false
+        } catch (e: Error) {
+            log.error("Encountered error!!: ${e.message}")
+            throw e
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/utils/PipelineUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/utils/PipelineUtil.kt
@@ -1,8 +1,15 @@
 package no.nav.syfo.utils
 
 import io.ktor.application.*
-import no.nav.syfo.consumer.dkif.DkifConsumer.Companion.NAV_PERSONIDENT_HEADER
+import io.ktor.http.*
 import no.nav.syfo.domain.PersonIdent
 
 fun ApplicationCall.getPersonIdent(): PersonIdent? =
     this.request.headers[NAV_PERSONIDENT_HEADER]?.let { PersonIdent(it) }
+
+fun ApplicationCall.getBearerToken(): String? =
+    this.request.headers[HttpHeaders.Authorization]?.removePrefix("Bearer ")
+
+fun ApplicationCall.getCallId(): String {
+    return this.request.headers[NAV_CALL_ID_HEADER].toString()
+}

--- a/src/main/kotlin/no/nav/syfo/utils/RequestUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/utils/RequestUtil.kt
@@ -1,0 +1,4 @@
+package no.nav.syfo.utils
+
+const val NAV_CALL_ID_HEADER = "Nav-Call-Id"
+const val NAV_PERSONIDENT_HEADER = "nav-personident"

--- a/src/main/resources/localEnvApp.json
+++ b/src/main/resources/localEnvApp.json
@@ -32,7 +32,9 @@
     "dokdistfordelingScope": "dokdistfordelingScope",
     "dokarkivUrl": "http://dokarkivUrl:9099",
     "dokarkivScope": "dokarkivScope",
-    "syfooppdfgenUrl": "http://localhost:4545"
+    "syfooppdfgenUrl": "http://localhost:4545",
+    "syfoTilgangskontrollUrl": "http://syfotilgangskontrollUrl:9099",
+    "syfoTilgangskontrollScope": "syfotilgangskontrollScope"
   },
   "kafkaEnv": {
     "bootstrapServersUrl": "http://localhost:9092",

--- a/src/test/kotlin/no/nav/syfo/testutil/mocks/MockServers.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/mocks/MockServers.kt
@@ -18,17 +18,17 @@ import io.ktor.server.netty.Netty
 import io.ktor.server.netty.NettyApplicationEngine
 import no.nav.syfo.AuthEnv
 import no.nav.syfo.UrlEnv
-import no.nav.syfo.consumer.dkif.DkifConsumer
 import no.nav.syfo.testutil.extractPortFromUrl
+import no.nav.syfo.utils.NAV_PERSONIDENT_HEADER
 
 class MockServers(val urlEnv: UrlEnv, val authEnv: AuthEnv) {
 
     fun mockDkifServer(): NettyApplicationEngine {
         return mockServer(urlEnv.dkifUrl) {
             get("/rest/v1/person") {
-                if (call.request.headers[DkifConsumer.NAV_PERSONIDENT_HEADER]?.isValidHeader() == true) {
+                if (call.request.headers[NAV_PERSONIDENT_HEADER]?.isValidHeader() == true) {
                     call.respond(
-                        dkifResponseMap[call.request.headers[DkifConsumer.NAV_PERSONIDENT_HEADER]]
+                        dkifResponseMap[call.request.headers[NAV_PERSONIDENT_HEADER]]
                             ?: dkifResponseSuccessKanVarslesResponseJSON
                     )
                 } else {


### PR DESCRIPTION
Legger til veiledertilgangskontroll (sjekker at veileder har tilgang til person) på maxDato veileder-api. Har også gitt esyfovarsel tilgang til syfo-tilgangskontroll her: https://github.com/navikt/syfo-tilgangskontroll/pull/172