### PR TITLE
Move ferdigstill field to EsyfovarselHendelse - part 1

### DIFF
--- a/src/main/kotlin/no/nav/syfo/kafka/consumers/varselbus/domain/EsyfovarselHendelse.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/consumers/varselbus/domain/EsyfovarselHendelse.kt
@@ -9,11 +9,13 @@ private val objectMapper = createObjectMapper()
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME)
 sealed interface EsyfovarselHendelse : Serializable {
     val type: HendelseType
+    val ferdigstill: Boolean?
     var data: Any?
 }
 
 data class NarmesteLederHendelse(
     override val type: HendelseType,
+    override val ferdigstill: Boolean?,
     override var data: Any?,
     val narmesteLederFnr: String,
     val arbeidstakerFnr: String,
@@ -22,6 +24,7 @@ data class NarmesteLederHendelse(
 
 data class ArbeidstakerHendelse(
     override val type: HendelseType,
+    override val ferdigstill: Boolean?,
     override var data: Any?,
     val arbeidstakerFnr: String,
     val orgnummer: String?

--- a/src/main/kotlin/no/nav/syfo/service/SendVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/SendVarselService.kt
@@ -149,6 +149,7 @@ class SendVarselService(
         merVeiledningVarselService.sendVarselTilArbeidstaker(
             ArbeidstakerHendelse(
                 HendelseType.SM_MER_VEILEDNING,
+                false,
                 null,
                 pPlanlagtVarsel.fnr,
                 null

--- a/src/main/kotlin/no/nav/syfo/service/VarselBusService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/VarselBusService.kt
@@ -69,6 +69,7 @@ class VarselBusService(
                 SM_DIALOGMOTE_NYTT_TID_STED -> mikrofrontendService.updateDialogmoteFrontendForUser(event)
                 SM_DIALOGMOTE_AVLYST,
                 SM_DIALOGMOTE_REFERAT -> mikrofrontendService.disableDialogmoteFrontendForUser(event)
+
                 else -> return
             }
         }
@@ -89,10 +90,15 @@ class VarselBusService(
     private fun EsyfovarselHendelse.isArbeidstakerHendelse(): Boolean {
         return this is ArbeidstakerHendelse
     }
-    
+
     private fun EsyfovarselHendelse.skalFerdigstilles() =
-        data?.let { data ->
-            val varseldata = data.toVarselData()
-            varseldata.status?.ferdigstilt
-        } ?: false
+        if (ferdigstill == true) {
+            true
+        } else {
+            data?.let { data ->
+                val varseldata = data.toVarselData()
+                varseldata.status?.ferdigstilt
+            } ?: false
+        }
+
 }

--- a/src/test/kotlin/no/nav/syfo/service/MikrofrontendServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/service/MikrofrontendServiceSpek.kt
@@ -50,6 +50,7 @@ object MikrofrontendServiceSpek : Spek({
 
         val arbeidstakerHendelseDialogmoteInnkalt = ArbeidstakerHendelse(
             type = HendelseType.SM_DIALOGMOTE_INNKALT,
+            ferdigstill = false,
             data = dataTidspunktTomorrow,
             arbeidstakerFnr = arbeidstakerFnr1,
             orgnummer = orgnummer1


### PR DESCRIPTION
To make it backwards compatible the field will first be added to EsyfovarselHendelse, and when the client is updated to use the new field, the old field will later be removed from VarselData.