### PR TITLE
Handle when maxDate is before utebetTom  date

### DIFF
--- a/src/main/kotlin/no/nav/syfo/kafka/consumers/infotrygd/GjenstaendeSykepengedager.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/consumers/infotrygd/GjenstaendeSykepengedager.kt
@@ -1,16 +1,18 @@
 package no.nav.syfo.kafka.consumers.infotrygd
 
+import no.nav.syfo.utils.isEqualOrBefore
 import java.time.DayOfWeek
 import java.time.LocalDate
 import kotlin.streams.toList
 
 fun LocalDate.gjenstaendeSykepengedager(other: LocalDate): Int {
-    return this
+    // datesUntil teller med startdato og ikke sluttdato, mens vi ikke vil telle med startdato, men sluttdato, derfor er det lagt til en dag på begge datoene
+    return if (this.isEqualOrBefore(other)) this
         .plusDays(1)
         .datesUntil(other.plusDays(1))
         .toList()
         .count(LocalDate::erIkkeHelg)
-        .coerceAtLeast(0)
+        .coerceAtLeast(0) else 0
 }
 
 private fun LocalDate.erIkkeHelg() = dayOfWeek !in arrayOf(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY)

--- a/src/test/kotlin/no/nav/syfo/kafka/consumers/infotrygd/GjenstaendeSykepengedagerSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/kafka/consumers/infotrygd/GjenstaendeSykepengedagerSpek.kt
@@ -35,7 +35,7 @@ object GjenstaendeSykepengedagerSpek : Spek({
             assertEquals(0, ubetTomDate.gjenstaendeSykepengedager(maxDate))
         }
 
-        it("Should handle when other date is in the past") {
+        it("Should handle when other date is before this") {
             val maxDate = LocalDate.of(2023, MAY, 15)
             val ubetTomDate = LocalDate.of(2023, MAY, 16)
             assertEquals(0, ubetTomDate.gjenstaendeSykepengedager(maxDate))

--- a/src/test/kotlin/no/nav/syfo/kafka/consumers/infotrygd/GjenstaendeSykepengedagerSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/kafka/consumers/infotrygd/GjenstaendeSykepengedagerSpek.kt
@@ -5,6 +5,7 @@ import org.spekframework.spek2.style.specification.describe
 import java.time.LocalDate
 import java.time.Month.DECEMBER
 import java.time.Month.NOVEMBER
+import java.util.Calendar.MAY
 import kotlin.test.assertEquals
 
 object GjenstaendeSykepengedagerSpek : Spek({
@@ -34,5 +35,10 @@ object GjenstaendeSykepengedagerSpek : Spek({
             assertEquals(0, ubetTomDate.gjenstaendeSykepengedager(maxDate))
         }
 
+        it("Should handle when other date is in the past") {
+            val maxDate = LocalDate.of(2023, MAY, 15)
+            val ubetTomDate = LocalDate.of(2023, MAY, 16)
+            assertEquals(0, ubetTomDate.gjenstaendeSykepengedager(maxDate))
+        }
     }
 })


### PR DESCRIPTION
Det har vært noen feil av denne typen der maxdatoen vi får fra infotrygd er før utbettom. Har håndtert dette så 0 returneres i disse tilfellene
`Exception in [aap.sykepengedager.infotrygd.v1]-listener: 2023-05-16 < 2023-05-17`

Dessverre er ikke denne mulig å teste i dev tror jeg, ettersom vi ikke får generert noen testmeldinger på topicen


