### PR TITLE
Allow isyfomock to publish events in dev

### DIFF
--- a/.github/workflows/topic.yaml
+++ b/.github/workflows/topic.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   deploy-topic-to-dev:
     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/varselbus-')
-    name: Deploy topic to  dev
+    name: Deploy topic to dev
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/topic.yaml
+++ b/.github/workflows/topic.yaml
@@ -17,8 +17,7 @@ jobs:
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: dev-gcp
-          RESOURCE: .nais/topics/varselbus-topic.yaml
-          VARS: .nais/topics/dev.json
+          RESOURCE: .nais/topics/varselbus-topic-dev.yaml
 
   deploy-topic-to-prod:
     if: github.ref == 'refs/heads/master'
@@ -32,5 +31,4 @@ jobs:
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: prod-gcp
-          RESOURCE: .nais/topics/varselbus-topic.yaml
-          VARS: .nais/topics/prod.json
+          RESOURCE: .nais/topics/varselbus-topic-prod.yaml

--- a/.github/workflows/topic.yaml
+++ b/.github/workflows/topic.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   deploy-topic-to-dev:
     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/varselbus-')
-    name: Deploy topic to dev
+    name: Deploy topic to  dev
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.nais/topics/dev.json
+++ b/.nais/topics/dev.json
@@ -1,3 +1,0 @@
-{
-  "kafkaPool": "nav-dev"
-}

--- a/.nais/topics/prod.json
+++ b/.nais/topics/prod.json
@@ -1,3 +1,0 @@
-{
-  "kafkaPool": "nav-prod"
-}

--- a/.nais/topics/varselbus-topic-dev.yaml
+++ b/.nais/topics/varselbus-topic-dev.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: team-esyfo
 spec:
-  pool: {{kafkaPool}}
+  pool: nav-dev
   config:
     cleanupPolicy: delete
     minimumInSyncReplicas: 1
@@ -26,4 +26,7 @@ spec:
       access: write
     - team: teamsykefravr
       application: isdialogmote
+      access: write
+    - team: teamsykefravr
+      application: isyfomock
       access: write

--- a/.nais/topics/varselbus-topic-prod.yaml
+++ b/.nais/topics/varselbus-topic-prod.yaml
@@ -1,0 +1,29 @@
+apiVersion: kafka.nais.io/v1
+kind: Topic
+metadata:
+  name: varselbus
+  namespace: team-esyfo
+  labels:
+    team: team-esyfo
+spec:
+  pool: nav-prod
+  config:
+    cleanupPolicy: delete
+    minimumInSyncReplicas: 1
+    partitions: 20
+    replication: 3
+    retentionBytes: -1  # Messages will never be deleted because of disk space
+    retentionHours: -1  # Messages will never be timed out
+  acl:
+    - team: team-esyfo
+      application: esyfovarsel
+      access: read
+    - team: team-esyfo
+      application: syfooppfolgingsplanservice
+      access: write
+    - team: team-esyfo
+      application: syfomotebehov
+      access: write
+    - team: teamsykefravr
+      application: isdialogmote
+      access: write


### PR DESCRIPTION
For at isyfomock skal kunne sende events i dev.
Pr i dag var det en felles topic + propertiesfil for dev og prod som kun inneholdt en property (kafka-pool).
Siden isyfomock kun skal kunne sende i dev så valgte jeg derfor å lage separate topic-yaml for dev og prod.