### PR TITLE
Remove references to selvbetjening-idtoken and support new acr claim value

### DIFF
--- a/src/main/kotlin/no/nav/syfo/auth/Authentication.kt
+++ b/src/main/kotlin/no/nav/syfo/auth/Authentication.kt
@@ -2,7 +2,6 @@ package no.nav.syfo.auth
 
 import com.auth0.jwk.JwkProvider
 import com.auth0.jwk.JwkProviderBuilder
-import io.ktor.http.auth.HttpAuthHeader
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
 import io.ktor.server.auth.Authentication
@@ -48,12 +47,6 @@ fun Application.setupAuthentication(
             }
         }
         jwt(name = "tokenx") {
-            authHeader {
-                if (it.getToken() == null) {
-                    return@authHeader null
-                }
-                return@authHeader HttpAuthHeader.Single("Bearer", it.getToken()!!)
-            }
             verifier(jwkProviderTokenX, tokenXIssuer)
             validate { credentials ->
                 when {
@@ -62,7 +55,6 @@ fun Application.setupAuthentication(
                         BrukerPrincipal(
                             fnr = finnFnrFraToken(principal),
                             principal = principal,
-                            token = this.getToken()!!,
                         )
                     }
 

--- a/src/main/kotlin/no/nav/syfo/auth/Util.kt
+++ b/src/main/kotlin/no/nav/syfo/auth/Util.kt
@@ -12,12 +12,10 @@ import io.ktor.client.engine.apache.ApacheEngineConfig
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.get
 import io.ktor.serialization.jackson.jackson
-import io.ktor.server.application.ApplicationCall
 import io.ktor.server.auth.Principal
 import io.ktor.server.auth.UserPasswordCredential
 import io.ktor.server.auth.jwt.JWTCredential
 import io.ktor.server.auth.jwt.JWTPrincipal
-import io.ktor.server.request.header
 import kotlinx.coroutines.runBlocking
 import net.logstash.logback.argument.StructuredArguments
 import no.nav.syfo.AuthEnv
@@ -56,13 +54,6 @@ fun isNiva4(credentials: JWTCredential): Boolean {
     return "Level4" == credentials.payload.getClaim("acr").asString()
 }
 
-fun ApplicationCall.getToken(): String? {
-    if (request.header("Authorization") != null) {
-        return request.header("Authorization")!!.removePrefix("Bearer ")
-    }
-    return request.cookies.get(name = "selvbetjening-idtoken")
-}
-
 fun unauthorized(credentials: JWTCredential): Principal? {
     log.warn(
         "Auth: Unexpected audience for jwt {}, {}",
@@ -91,5 +82,4 @@ fun finnFnrFraToken(principal: JWTPrincipal): String {
 data class BrukerPrincipal(
     val fnr: String,
     val principal: JWTPrincipal,
-    val token: String,
 ) : Principal

--- a/src/main/kotlin/no/nav/syfo/auth/Util.kt
+++ b/src/main/kotlin/no/nav/syfo/auth/Util.kt
@@ -51,7 +51,7 @@ fun getWellKnown(wellKnownUrl: String) =
     runBlocking { HttpClient(Apache, proxyConfig).get(wellKnownUrl).body<WellKnown>() }
 
 fun isNiva4(credentials: JWTCredential): Boolean {
-    return "Level4" == credentials.payload.getClaim("acr").asString()
+    return "Level4" == credentials.payload.getClaim("acr").asString() || "idporten-loa-high" == credentials.payload.getClaim("acr").asString()
 }
 
 fun unauthorized(credentials: JWTCredential): Principal? {


### PR DESCRIPTION
- Lagt til støtte for ny verdi "idporten-loa-high" som tilsvarer gammel verdi Level4, ref https://doc.nais.io/security/auth/idporten/#security-levels
- Fjernet bruk av selvbetjening-idtoken