### PR TITLE
Add journalføring of all SSPS in dokarkiv

### DIFF
--- a/src/main/kotlin/no/nav/syfo/consumer/dokarkiv/domain/DokarkivRequest.kt
+++ b/src/main/kotlin/no/nav/syfo/consumer/dokarkiv/domain/DokarkivRequest.kt
@@ -12,6 +12,7 @@ data class DokarkivRequest(
     val tema: String,
     val kanal: String,
     val sak: Sak,
+    val overstyrInnsynsregler: String,
 ) {
     companion object {
         fun create(
@@ -27,6 +28,8 @@ data class DokarkivRequest(
             tema = "OPP", // Oppfolging
             kanal = "S",
             sak = Sak("GENERELL_SAK"),
+            // By default, user can not see documents created by others. Following enables viewing on Mine Saker:
+            overstyrInnsynsregler = "VISES_MASKINELT_GODKJENT",
         )
     }
 }

--- a/src/main/kotlin/no/nav/syfo/service/MerVeiledningVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/MerVeiledningVarselService.kt
@@ -37,7 +37,7 @@ class MerVeiledningVarselService(
                 it,
             )
         }
-        log.info("Har journalført SSPS i dokarkiv, journalpostId er $journalpostId")
+        log.info("Forsøkte å journalføre SSPS i dokarkiv, journalpostId er $journalpostId")
         if (userAccessStatus.canUserBeDigitallyNotified) {
             sendDigitaltVarselTilArbeidstaker(arbeidstakerHendelse)
         } else {

--- a/src/main/kotlin/no/nav/syfo/service/MerVeiledningVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/MerVeiledningVarselService.kt
@@ -1,8 +1,5 @@
 package no.nav.syfo.service
 
-import java.net.URL
-import java.time.ZoneOffset
-import java.util.*
 import no.nav.syfo.*
 import no.nav.syfo.access.domain.UserAccessStatus
 import no.nav.syfo.consumer.pdfgen.PdfgenConsumer
@@ -13,6 +10,9 @@ import no.nav.syfo.kafka.producers.dittsykefravaer.domain.OpprettMelding
 import no.nav.syfo.kafka.producers.dittsykefravaer.domain.Variant
 import no.nav.syfo.syketilfelle.SyketilfellebitService
 import org.slf4j.LoggerFactory
+import java.net.URL
+import java.time.ZoneOffset
+import java.util.*
 
 const val DITT_SYKEFRAVAER_HENDELSE_TYPE_MER_VEILEDNING = "ESYFOVARSEL_MER_VEILEDNING"
 
@@ -29,12 +29,18 @@ class MerVeiledningVarselService(
         planlagtVarselUuid: String,
         userAccessStatus: UserAccessStatus,
     ) {
+        val pdf = pdfgenConsumer.getMerVeiledningPDF(arbeidstakerHendelse.arbeidstakerFnr)
+        val journalpostId = pdf?.let {
+            dokarkivService.getJournalpostId(
+                arbeidstakerHendelse.arbeidstakerFnr,
+                planlagtVarselUuid,
+                it,
+            )
+        }
+        log.info("Har journalført SSPS i dokarkiv, journalpostId er $journalpostId")
         if (userAccessStatus.canUserBeDigitallyNotified) {
             sendDigitaltVarselTilArbeidstaker(arbeidstakerHendelse)
         } else {
-            val pdf = pdfgenConsumer.getMerVeiledningPDF(arbeidstakerHendelse.arbeidstakerFnr)
-            val journalpostId = pdf?.let { dokarkivService.getJournalpostId(arbeidstakerHendelse.arbeidstakerFnr, planlagtVarselUuid, it) }
-            log.info("Forsøkte å sende data til dokarkiv, journalpostId er $journalpostId")
             sendBrevVarselTilArbeidstaker(planlagtVarselUuid, arbeidstakerHendelse, journalpostId!!)
         }
         sendOppgaveTilDittSykefravaer(arbeidstakerHendelse.arbeidstakerFnr, planlagtVarselUuid, arbeidstakerHendelse)
@@ -50,7 +56,7 @@ class MerVeiledningVarselService(
             fnr,
             BRUKERNOTIFIKASJONER_MER_VEILEDNING_MESSAGE_TEXT,
             url,
-            arbeidstakerHendelse
+            arbeidstakerHendelse,
         )
     }
 
@@ -69,7 +75,7 @@ class MerVeiledningVarselService(
     private fun sendOppgaveTilDittSykefravaer(
         fnr: String,
         uuid: String,
-        arbeidstakerHendelse: ArbeidstakerHendelse
+        arbeidstakerHendelse: ArbeidstakerHendelse,
     ) {
         val syketilfelleEndDate = syketilfellebitService.sisteDagISyketilfelle(fnr)
         if (syketilfelleEndDate == null) {
@@ -83,17 +89,17 @@ class MerVeiledningVarselService(
                 Variant.INFO,
                 true,
                 DITT_SYKEFRAVAER_HENDELSE_TYPE_MER_VEILEDNING,
-                syketilfelleEndDate.atStartOfDay().toInstant(ZoneOffset.UTC)
+                syketilfelleEndDate.atStartOfDay().toInstant(ZoneOffset.UTC),
             ),
             null,
-            fnr
+            fnr,
         )
         senderFacade.sendTilDittSykefravaer(
             arbeidstakerHendelse,
             DittSykefravaerVarsel(
                 uuid,
-                melding
-            )
+                melding,
+            ),
         )
     }
 }


### PR DESCRIPTION
Changed to journaløring of all SSPS regardless of user's reservation status. Added field overstyrInnsynsregler to Dokarkiv request to enable user actually see the PDF on Mine Saker as it is not visible by default in cases when user is not authored document.
Peace! ✌🏻