### PR TITLE
Use Q2 dokarkiv

### DIFF
--- a/nais/nais-dev.yaml
+++ b/nais/nais-dev.yaml
@@ -142,7 +142,7 @@ spec:
     - name: DOKDIST_FORDELING_SCOPE
       value: api://dev-fss.teamdokumenthandtering.saf/.default
     - name: DOKARKIV_URL
-      value: https://dokarkiv.dev-fss-pub.nais.io
+      value: https://dokarkiv-q2.dev-fss-pub.nais.io
     - name: DOKARKIV_SCOPE
       value: api://dev-fss.teamdokumenthandtering.dokarkiv/.default
     - name: SYFOOPPDFGEN_URL


### PR DESCRIPTION
Dokarkiv i dev må bruke Q2, da dokdistfordeling også bruker Q2