### PR TITLE
Restructure aktivitetskrav event format

### DIFF
--- a/src/main/kotlin/no/nav/syfo/kafka/consumers/varselbus/VarselBusKafkaConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/consumers/varselbus/VarselBusKafkaConsumer.kt
@@ -1,7 +1,6 @@
 package no.nav.syfo.kafka.consumers.varselbus
 
 import com.fasterxml.jackson.module.kotlin.readValue
-import java.io.IOException
 import no.nav.syfo.ApplicationState
 import no.nav.syfo.Environment
 import no.nav.syfo.kafka.common.*

--- a/src/main/kotlin/no/nav/syfo/service/AktivitetskravVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/AktivitetskravVarselService.kt
@@ -1,15 +1,11 @@
 package no.nav.syfo.service
 
-import no.nav.syfo.ToggleEnv
 import no.nav.syfo.consumer.distribuerjournalpost.DistibusjonsType
 import no.nav.syfo.kafka.consumers.varselbus.domain.ArbeidstakerHendelse
 import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType.SM_FORHANDSVARSEL_STANS
-import no.nav.syfo.kafka.consumers.varselbus.domain.VarselData
-import no.nav.syfo.kafka.consumers.varselbus.domain.toVarselData
 import no.nav.syfo.metrics.tellAktivitetskravFraIsAktivitetskrav
-import org.apache.commons.cli.MissingArgumentException
+import no.nav.syfo.utils.dataToVarselData
 import org.slf4j.LoggerFactory
-import java.io.IOException
 
 class AktivitetskravVarselService(
     val senderFacade: SenderFacade,
@@ -46,15 +42,4 @@ class AktivitetskravVarselService(
             log.info("Feil i sending av fysisk brev om dialogmote: ${e.message} for hendelsetype: ${arbeidstakerHendelse.type.name}")
         }
     }
-
-    private fun dataToVarselData(data: Any?): VarselData {
-        return data?.let {
-            try {
-                return data.toVarselData()
-            } catch (e: IOException) {
-                throw IOException("ArbeidstakerHendelse har feil format")
-            }
-        } ?: throw MissingArgumentException("EsyfovarselHendelse mangler 'data'-felt")
-    }
-
 }

--- a/src/main/kotlin/no/nav/syfo/service/VarselBusService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/VarselBusService.kt
@@ -64,7 +64,7 @@ class VarselBusService(
                 // TODO: Må håndtere at denne kan komme inn flere ganger før
                 //  man skrur på ekstern varsling (e.g. sjekk mikrofrontend
                 //  state i database før utsending)
-                HendelseType.SM_AKTIVITETSPLIKT_STATUS_FORHANDSVARSEL -> aktivitetspliktForhandsvarselVarselService.sendVarselTilArbeidstaker(varselHendelse.toArbeidstakerHendelse())
+                HendelseType.SM_AKTIVITETSPLIKT -> aktivitetspliktForhandsvarselVarselService.sendVarselTilArbeidstaker(varselHendelse.toArbeidstakerHendelse())
 
                 else -> {
                     log.warn("Klarte ikke mappe varsel av type ${varselHendelse.type} ved behandling forsøk")

--- a/src/main/kotlin/no/nav/syfo/service/microfrontend/MikrofrontendService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/microfrontend/MikrofrontendService.kt
@@ -98,13 +98,7 @@ class MikrofrontendService(
             HendelseType.SM_DIALOGMOTE_REFERAT,
             HendelseType.SM_DIALOGMOTE_AVLYST
                 -> Tjeneste.DIALOGMOTE
-            HendelseType.SM_AKTIVITETSPLIKT_STATUS_FORHANDSVARSEL,
-            HendelseType.SM_AKTIVITETSPLIKT_STATUS_NY,
-            HendelseType.SM_AKTIVITETSPLIKT_STATUS_UNNTAK,
-            HendelseType.SM_AKTIVITETSPLIKT_STATUS_OPPFYLT,
-            HendelseType.SM_AKTIVITETSPLIKT_STATUS_AUTOMATISK_OPPFYLT,
-            HendelseType.SM_AKTIVITETSPLIKT_STATUS_IKKE_OPPFYLT,
-            HendelseType.SM_AKTIVITETSPLIKT_STATUS_IKKE_AKTUELL,
+            HendelseType.SM_AKTIVITETSPLIKT
                 -> Tjeneste.AKTIVITETSKRAV
             else -> throw IllegalArgumentException("$this is not a valid type for updating MF state")
         }

--- a/src/main/kotlin/no/nav/syfo/utils/VarselDataUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/utils/VarselDataUtil.kt
@@ -1,0 +1,16 @@
+package no.nav.syfo.utils
+
+import no.nav.syfo.kafka.consumers.varselbus.domain.VarselData
+import no.nav.syfo.kafka.consumers.varselbus.domain.toVarselData
+import org.apache.commons.cli.MissingArgumentException
+import java.io.IOException
+
+fun dataToVarselData(data: Any?): VarselData {
+    return data?.let {
+        try {
+            return data.toVarselData()
+        } catch (e: IOException) {
+            throw IOException("ArbeidstakerHendelse har feil format")
+        }
+    } ?: throw MissingArgumentException("EsyfovarselHendelse mangler 'data'-felt")
+}

--- a/src/test/kotlin/no/nav/syfo/service/AktivitetspliktForhandsvarselServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/service/AktivitetspliktForhandsvarselServiceTest.kt
@@ -98,10 +98,15 @@ class AktivitetskravVarselServiceTest : DescribeSpec({
                         canUserBeDigitallyNotified = false
                     )
 
-            val jsondata: String = """{
+            val jsondata = """{
                 "@type": "ArbeidstakerHendelse",
-                "type": "SM_AKTIVITETSPLIKT_STATUS_FORHANDSVARSEL",
+                "type": "SM_AKTIVITETSPLIKT",
                 "data": {
+                    "aktivitetskrav": {
+                        "sendForhandsvarsel": true,
+                        "enableMicrofrontend": true,
+                        "extendMicrofrontendDuration": false
+                    },
                     "journalpost": {
                 	    "uuid": "bda0b55a-df72-4888-a5a5-6bfa74cacafe",
                 		"id": "620049753"
@@ -130,7 +135,7 @@ class AktivitetskravVarselServiceTest : DescribeSpec({
 
 private fun createForhandsvarselHendelse(): ArbeidstakerHendelse {
     return ArbeidstakerHendelse(
-        type = HendelseType.SM_AKTIVITETSPLIKT_STATUS_FORHANDSVARSEL,
+        type = HendelseType.SM_AKTIVITETSPLIKT,
         false,
         varselData(journalpostId = "620049753", journalpostUuid = "bda0b55a-df72-4888-a5a5-6bfa74cacafe"),
         SM_FNR,

--- a/src/test/kotlin/no/nav/syfo/service/DialogmoteInnkallingVarselServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/service/DialogmoteInnkallingVarselServiceSpek.kt
@@ -411,8 +411,11 @@ fun varselData(journalpostUuid: String, journalpostId: String) = """{
             "uuid": "$journalpostUuid",
             "id": "$journalpostId"
         },
-        "narmesteLeder": null,
-        "motetidspunkt": null
+        "aktivitetskrav": {
+            "sendForhandsvarsel": true,
+            "enableMicrofrontend": true,
+            "extendMicrofrontendDuration": false
+        }
     }
 """.trimIndent()
 


### PR DESCRIPTION
Add an abstraction-layer on top of 'vurdering'-event statuses through varselbus data-field, and use type to separate 'varsel' from 'vurdering'-events.