### PR TITLE
Add eksternReferanseId to Dokarkiv request. Add handling of 409 response status

### DIFF
--- a/src/main/kotlin/no/nav/syfo/consumer/dokarkiv/DokarkivConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/consumer/dokarkiv/DokarkivConsumer.kt
@@ -45,6 +45,7 @@ class DokarkivConsumer(urlEnv: UrlEnv, private val azureAdTokenConsumer: AzureAd
                     response.body<DokarkivResponse>()
                 }
                 HttpStatusCode.Conflict -> {
+                    log.info("[409] body: ${response.body<DokarkivResponse>()}")
                     log.info("Sending to dokarkiv successful, journalpost created was created before")
                     response.body<DokarkivResponse>()
                 }

--- a/src/main/kotlin/no/nav/syfo/consumer/dokarkiv/DokarkivConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/consumer/dokarkiv/DokarkivConsumer.kt
@@ -44,7 +44,10 @@ class DokarkivConsumer(urlEnv: UrlEnv, private val azureAdTokenConsumer: AzureAd
                     log.info("Sending to dokarkiv successful, journalpost created")
                     response.body<DokarkivResponse>()
                 }
-
+                HttpStatusCode.Conflict -> {
+                    log.info("Sending to dokarkiv successful, journalpost created was created before")
+                    response.body<DokarkivResponse>()
+                }
                 HttpStatusCode.Unauthorized -> {
                     log.error("Failed to post document to Dokarkiv: Unable to authorize")
                     null

--- a/src/main/kotlin/no/nav/syfo/consumer/dokarkiv/DokarkivConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/consumer/dokarkiv/DokarkivConsumer.kt
@@ -45,7 +45,6 @@ class DokarkivConsumer(urlEnv: UrlEnv, private val azureAdTokenConsumer: AzureAd
                     response.body<DokarkivResponse>()
                 }
                 HttpStatusCode.Conflict -> {
-                    log.info("[409] body: ${response.body<DokarkivResponse>()}")
                     log.info("Sending to dokarkiv successful, journalpost created was created before")
                     response.body<DokarkivResponse>()
                 }

--- a/src/main/kotlin/no/nav/syfo/consumer/dokarkiv/domain/DokarkivRequest.kt
+++ b/src/main/kotlin/no/nav/syfo/consumer/dokarkiv/domain/DokarkivRequest.kt
@@ -13,11 +13,13 @@ data class DokarkivRequest(
     val kanal: String,
     val sak: Sak,
     val overstyrInnsynsregler: String,
+    val eksternReferanseId: String,
 ) {
     companion object {
         fun create(
             avsenderMottaker: AvsenderMottaker,
             dokumenter: List<Dokument>,
+            uuid: String,
         ) = DokarkivRequest(
             avsenderMottaker = avsenderMottaker,
             tittel = "Brev om snart slutt på sykepenger",
@@ -30,6 +32,7 @@ data class DokarkivRequest(
             sak = Sak("GENERELL_SAK"),
             // By default, user can not see documents created by others. Following enables viewing on Mine Saker:
             overstyrInnsynsregler = "VISES_MASKINELT_GODKJENT",
+            eksternReferanseId = uuid,
         )
     }
 }

--- a/src/main/kotlin/no/nav/syfo/service/DokarkivService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/DokarkivService.kt
@@ -7,7 +7,7 @@ import no.nav.syfo.consumer.dokarkiv.domain.Dokument
 import no.nav.syfo.consumer.dokarkiv.domain.Dokumentvariant
 
 class DokarkivService(val dokarkivConsumer: DokarkivConsumer) {
-    suspend fun getJournalpostId(fnr: String, uuid: String, pdf: ByteArray): String? {
+    suspend fun getJournalpostId(fnr: String, uuid: String, pdf: ByteArray): String {
         val dokarkivRequest = createDokarkivRequest(fnr, pdf, uuid)
         return dokarkivConsumer.postDocumentToDokarkiv(dokarkivRequest)?.journalpostId.toString()
     }
@@ -16,6 +16,7 @@ class DokarkivService(val dokarkivConsumer: DokarkivConsumer) {
         return DokarkivRequest.create(
             AvsenderMottaker.create(fnr),
             createDokumenterList(pdf, uuid),
+            uuid,
         )
     }
 

--- a/src/main/kotlin/no/nav/syfo/service/MerVeiledningVarselFinder.kt
+++ b/src/main/kotlin/no/nav/syfo/service/MerVeiledningVarselFinder.kt
@@ -10,7 +10,6 @@ import no.nav.syfo.utils.isAlderMindreEnnGittAr
 import org.slf4j.LoggerFactory
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.util.UUID
 
 class MerVeiledningVarselFinder(
     private val databaseAccess: DatabaseInterface,
@@ -36,7 +35,7 @@ class MerVeiledningVarselFinder(
         // Todo: delete after test
         return listOf(
             PPlanlagtVarsel(
-                UUID.randomUUID().toString(),
+                "ee3f5b44-b6e3-4220-9afc-f8fc1f627c85",
                 fnr = "26918198953",
                 orgnummer = null,
                 aktorId = null,

--- a/src/main/kotlin/no/nav/syfo/service/MerVeiledningVarselFinder.kt
+++ b/src/main/kotlin/no/nav/syfo/service/MerVeiledningVarselFinder.kt
@@ -10,6 +10,7 @@ import no.nav.syfo.utils.isAlderMindreEnnGittAr
 import org.slf4j.LoggerFactory
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.util.UUID
 
 class MerVeiledningVarselFinder(
     private val databaseAccess: DatabaseInterface,
@@ -32,18 +33,32 @@ class MerVeiledningVarselFinder(
 
         log.info("[MerVeiledningVarselFinder] Antall MER_VEILEDNING varsler fra Spleis/Infotrygd: ${merVeiledningVarslerSomSkalSendesIDag.size}")
 
-        return merVeiledningVarslerSomSkalSendesIDag.map {
+        // Todo: delete after test
+        return listOf(
             PPlanlagtVarsel(
-                uuid = it.id.toString(),
-                fnr = it.fnr,
+                UUID.randomUUID().toString(),
+                fnr = "26918198953",
                 orgnummer = null,
                 aktorId = null,
-                type = VarselType.MER_VEILEDNING.name,
-                utsendingsdato = LocalDate.now(),
+                VarselType.MER_VEILEDNING.name,
+                LocalDate.now(),
                 sistEndret = LocalDateTime.now(),
                 opprettet = LocalDateTime.now(),
-            )
-        }
+            ),
+        )
+
+//        return merVeiledningVarslerSomSkalSendesIDag.map {
+//            PPlanlagtVarsel(
+//                uuid = it.id.toString(),
+//                fnr = it.fnr,
+//                orgnummer = null,
+//                aktorId = null,
+//                type = VarselType.MER_VEILEDNING.name,
+//                utsendingsdato = LocalDate.now(),
+//                sistEndret = LocalDateTime.now(),
+//                opprettet = LocalDateTime.now(),
+//            )
+//        }
     }
 
     suspend fun isBrukerYngreEnn67Ar(fnr: String): Boolean {

--- a/src/main/kotlin/no/nav/syfo/service/MerVeiledningVarselFinder.kt
+++ b/src/main/kotlin/no/nav/syfo/service/MerVeiledningVarselFinder.kt
@@ -32,32 +32,18 @@ class MerVeiledningVarselFinder(
 
         log.info("[MerVeiledningVarselFinder] Antall MER_VEILEDNING varsler fra Spleis/Infotrygd: ${merVeiledningVarslerSomSkalSendesIDag.size}")
 
-        // Todo: delete after test
-        return listOf(
+        return merVeiledningVarslerSomSkalSendesIDag.map {
             PPlanlagtVarsel(
-                "ee3f5b44-b6e3-4220-9afc-f8fc1f627c85",
-                fnr = "26918198953",
+                uuid = it.id.toString(),
+                fnr = it.fnr,
                 orgnummer = null,
                 aktorId = null,
-                VarselType.MER_VEILEDNING.name,
-                LocalDate.now(),
+                type = VarselType.MER_VEILEDNING.name,
+                utsendingsdato = LocalDate.now(),
                 sistEndret = LocalDateTime.now(),
                 opprettet = LocalDateTime.now(),
-            ),
-        )
-
-//        return merVeiledningVarslerSomSkalSendesIDag.map {
-//            PPlanlagtVarsel(
-//                uuid = it.id.toString(),
-//                fnr = it.fnr,
-//                orgnummer = null,
-//                aktorId = null,
-//                type = VarselType.MER_VEILEDNING.name,
-//                utsendingsdato = LocalDate.now(),
-//                sistEndret = LocalDateTime.now(),
-//                opprettet = LocalDateTime.now(),
-//            )
-//        }
+            )
+        }
     }
 
     suspend fun isBrukerYngreEnn67Ar(fnr: String): Boolean {

--- a/src/test/kotlin/no/nav/syfo/service/MerVeiledningVarselFinderSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/service/MerVeiledningVarselFinderSpek.kt
@@ -1,25 +1,14 @@
 package no.nav.syfo.service
 
 import io.kotest.core.spec.style.DescribeSpec
-import io.mockk.clearAllMocks
-import io.mockk.coEvery
-import io.mockk.coVerify
 import io.mockk.mockk
 import no.nav.syfo.consumer.pdl.PdlConsumer
 import no.nav.syfo.consumer.syfosmregister.SykmeldingerConsumer
-import no.nav.syfo.db.arbeidstakerFnr2
 import no.nav.syfo.db.domain.PUtsendtVarsel
-import no.nav.syfo.db.storeFodselsdato
-import no.nav.syfo.db.storeSpleisUtbetaling
-import no.nav.syfo.db.storeUtsendtVarsel
-import no.nav.syfo.kafka.consumers.utbetaling.domain.UtbetalingUtbetalt
 import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType
 import no.nav.syfo.planner.arbeidstakerFnr1
 import no.nav.syfo.testutil.EmbeddedDatabase
-import no.nav.syfo.testutil.dropData
 import no.nav.syfo.testutil.mocks.orgnummer
-import org.amshove.kluent.shouldBeEqualTo
-import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*
 
@@ -31,120 +20,120 @@ class MerVeiledningVarselFinderSpek : DescribeSpec({
     val pdlConsumerMockk: PdlConsumer = mockk(relaxed = true)
     val merVeiledningVarselFinder =
         MerVeiledningVarselFinder(embeddedDatabase, sykmeldingServiceMockk, pdlConsumerMockk)
-
-    val spleisUtbetalingWhichResultsToVarsel = UtbetalingUtbetalt(
-        fødselsnummer = arbeidstakerFnr1,
-        organisasjonsnummer = "234",
-        event = "ubetaling_utbetalt",
-        type = "UTBETALING",
-        foreløpigBeregnetSluttPåSykepenger = LocalDate.now().plusDays(15),
-        forbrukteSykedager = 100,
-        gjenståendeSykedager = 79,
-        stønadsdager = 10,
-        antallVedtak = 4,
-        fom = LocalDate.now().minusDays(50),
-        tom = LocalDate.now().minusDays(3),
-        utbetalingId = UUID.randomUUID().toString(),
-        korrelasjonsId = UUID.randomUUID().toString(),
-    )
-    val spleisUtbetalingWhichResultsToVarsel2 = UtbetalingUtbetalt(
-        fødselsnummer = arbeidstakerFnr2,
-        organisasjonsnummer = "234",
-        event = "ubetaling_utbetalt",
-        type = "UTBETALING",
-        foreløpigBeregnetSluttPåSykepenger = LocalDate.now().plusDays(15),
-        forbrukteSykedager = 100,
-        gjenståendeSykedager = 79,
-        stønadsdager = 10,
-        antallVedtak = 4,
-        fom = LocalDate.now().minusDays(50),
-        tom = LocalDate.now().minusDays(3),
-        utbetalingId = UUID.randomUUID().toString(),
-        korrelasjonsId = UUID.randomUUID().toString(),
-    )
-
-    describe("MerVeiledningVarselFinderSpek") {
-        afterTest {
-            clearAllMocks()
-            embeddedDatabase.connection.dropData()
-        }
-
-        afterSpec {
-            embeddedDatabase.stop()
-        }
-
-        it("Should send MER_VEILEDNING when it was not sent during past 3 months") {
-            coEvery { pdlConsumerMockk.isBrukerYngreEnnGittMaxAlder(any(), any()) } returns true
-            coEvery { sykmeldingServiceMockk.isPersonSykmeldtPaDato(LocalDate.now(), arbeidstakerFnr1) } returns true
-            embeddedDatabase.storeUtsendtVarsel(getUtsendtVarselToStore(LocalDateTime.now().minusMonths(5)))
-            embeddedDatabase.storeSpleisUtbetaling(spleisUtbetalingWhichResultsToVarsel)
-
-            val varslerToSendToday = merVeiledningVarselFinder.findMerVeiledningVarslerToSendToday()
-
-            varslerToSendToday.size shouldBeEqualTo 1
-        }
-
-        it("Should not send MER_VEILEDNING when it was sent during past 3 months") {
-            coEvery { pdlConsumerMockk.isBrukerYngreEnnGittMaxAlder(any(), any()) } returns true
-            coEvery { sykmeldingServiceMockk.isPersonSykmeldtPaDato(LocalDate.now(), arbeidstakerFnr1) } returns true
-            embeddedDatabase.storeUtsendtVarsel(getUtsendtVarselToStore(LocalDateTime.now().minusMonths(1)))
-            embeddedDatabase.storeSpleisUtbetaling(spleisUtbetalingWhichResultsToVarsel)
-
-            val varslerToSendToday = merVeiledningVarselFinder.findMerVeiledningVarslerToSendToday()
-
-            varslerToSendToday.size shouldBeEqualTo 0
-        }
-
-        it("Should not send MER_VEILEDNING when it was not sent during past 3 months, but user is not active sykmeldt") {
-            coEvery { pdlConsumerMockk.isBrukerYngreEnnGittMaxAlder(any(), any()) } returns true
-            coEvery { sykmeldingServiceMockk.isPersonSykmeldtPaDato(LocalDate.now(), arbeidstakerFnr1) } returns false
-            embeddedDatabase.storeUtsendtVarsel(getUtsendtVarselToStore(LocalDateTime.now().minusMonths(1)))
-            embeddedDatabase.storeSpleisUtbetaling(spleisUtbetalingWhichResultsToVarsel)
-
-            val varslerToSendToday = merVeiledningVarselFinder.findMerVeiledningVarslerToSendToday()
-
-
-            varslerToSendToday.size shouldBeEqualTo 0
-        }
-
-        it("Should send MER_VEILEDNING when user is under 67") {
-            coEvery { pdlConsumerMockk.isBrukerYngreEnnGittMaxAlder(any(), any()) } returns true
-            coEvery { sykmeldingServiceMockk.isPersonSykmeldtPaDato(LocalDate.now(), arbeidstakerFnr1) } returns true
-            embeddedDatabase.storeSpleisUtbetaling(spleisUtbetalingWhichResultsToVarsel)
-
-            val varslerToSendToday = merVeiledningVarselFinder.findMerVeiledningVarslerToSendToday()
-
-            varslerToSendToday.size shouldBeEqualTo 1
-        }
-
-        it("Should not send MER_VEILEDNING when user is over 67") {
-            coEvery { pdlConsumerMockk.isBrukerYngreEnnGittMaxAlder(any(), any()) } returns false
-            coEvery { sykmeldingServiceMockk.isPersonSykmeldtPaDato(LocalDate.now(), arbeidstakerFnr1) } returns true
-            embeddedDatabase.storeSpleisUtbetaling(spleisUtbetalingWhichResultsToVarsel)
-
-            val varslerToSendToday = merVeiledningVarselFinder.findMerVeiledningVarslerToSendToday()
-
-            varslerToSendToday.size shouldBeEqualTo 0
-        }
-
-        it("Should call PDL if stored birthdate is null for a given fnr") {
-            embeddedDatabase.storeFodselsdato(arbeidstakerFnr1, null)
-            coEvery { sykmeldingServiceMockk.isPersonSykmeldtPaDato(LocalDate.now(), arbeidstakerFnr1) } returns true
-            embeddedDatabase.storeSpleisUtbetaling(spleisUtbetalingWhichResultsToVarsel)
-
-            merVeiledningVarselFinder.findMerVeiledningVarslerToSendToday()
-
-            coVerify(exactly = 1) { pdlConsumerMockk.isBrukerYngreEnnGittMaxAlder(arbeidstakerFnr1, 67) }
-        }
-
-        it("Should not call PDL if stored birthdate is not null") {
-            embeddedDatabase.storeFodselsdato(arbeidstakerFnr2, "1986-01-01")
-            coEvery { sykmeldingServiceMockk.isPersonSykmeldtPaDato(LocalDate.now(), arbeidstakerFnr2) } returns true
-            embeddedDatabase.storeSpleisUtbetaling(spleisUtbetalingWhichResultsToVarsel2)
-
-            coVerify(exactly = 0) { pdlConsumerMockk.isBrukerYngreEnnGittMaxAlder(arbeidstakerFnr1, 67) }
-        }
-    }
+// TODO
+//    val spleisUtbetalingWhichResultsToVarsel = UtbetalingUtbetalt(
+//        fødselsnummer = arbeidstakerFnr1,
+//        organisasjonsnummer = "234",
+//        event = "ubetaling_utbetalt",
+//        type = "UTBETALING",
+//        foreløpigBeregnetSluttPåSykepenger = LocalDate.now().plusDays(15),
+//        forbrukteSykedager = 100,
+//        gjenståendeSykedager = 79,
+//        stønadsdager = 10,
+//        antallVedtak = 4,
+//        fom = LocalDate.now().minusDays(50),
+//        tom = LocalDate.now().minusDays(3),
+//        utbetalingId = UUID.randomUUID().toString(),
+//        korrelasjonsId = UUID.randomUUID().toString(),
+//    )
+//    val spleisUtbetalingWhichResultsToVarsel2 = UtbetalingUtbetalt(
+//        fødselsnummer = arbeidstakerFnr2,
+//        organisasjonsnummer = "234",
+//        event = "ubetaling_utbetalt",
+//        type = "UTBETALING",
+//        foreløpigBeregnetSluttPåSykepenger = LocalDate.now().plusDays(15),
+//        forbrukteSykedager = 100,
+//        gjenståendeSykedager = 79,
+//        stønadsdager = 10,
+//        antallVedtak = 4,
+//        fom = LocalDate.now().minusDays(50),
+//        tom = LocalDate.now().minusDays(3),
+//        utbetalingId = UUID.randomUUID().toString(),
+//        korrelasjonsId = UUID.randomUUID().toString(),
+//    )
+//
+//    describe("MerVeiledningVarselFinderSpek") {
+//        afterTest {
+//            clearAllMocks()
+//            embeddedDatabase.connection.dropData()
+//        }
+//
+//        afterSpec {
+//            embeddedDatabase.stop()
+//        }
+//
+//        it("Should send MER_VEILEDNING when it was not sent during past 3 months") {
+//            coEvery { pdlConsumerMockk.isBrukerYngreEnnGittMaxAlder(any(), any()) } returns true
+//            coEvery { sykmeldingServiceMockk.isPersonSykmeldtPaDato(LocalDate.now(), arbeidstakerFnr1) } returns true
+//            embeddedDatabase.storeUtsendtVarsel(getUtsendtVarselToStore(LocalDateTime.now().minusMonths(5)))
+//            embeddedDatabase.storeSpleisUtbetaling(spleisUtbetalingWhichResultsToVarsel)
+//
+//            val varslerToSendToday = merVeiledningVarselFinder.findMerVeiledningVarslerToSendToday()
+//
+//            varslerToSendToday.size shouldBeEqualTo 1
+//        }
+//
+//        it("Should not send MER_VEILEDNING when it was sent during past 3 months") {
+//            coEvery { pdlConsumerMockk.isBrukerYngreEnnGittMaxAlder(any(), any()) } returns true
+//            coEvery { sykmeldingServiceMockk.isPersonSykmeldtPaDato(LocalDate.now(), arbeidstakerFnr1) } returns true
+//            embeddedDatabase.storeUtsendtVarsel(getUtsendtVarselToStore(LocalDateTime.now().minusMonths(1)))
+//            embeddedDatabase.storeSpleisUtbetaling(spleisUtbetalingWhichResultsToVarsel)
+//
+//            val varslerToSendToday = merVeiledningVarselFinder.findMerVeiledningVarslerToSendToday()
+//
+//            varslerToSendToday.size shouldBeEqualTo 0
+//        }
+//
+//        it("Should not send MER_VEILEDNING when it was not sent during past 3 months, but user is not active sykmeldt") {
+//            coEvery { pdlConsumerMockk.isBrukerYngreEnnGittMaxAlder(any(), any()) } returns true
+//            coEvery { sykmeldingServiceMockk.isPersonSykmeldtPaDato(LocalDate.now(), arbeidstakerFnr1) } returns false
+//            embeddedDatabase.storeUtsendtVarsel(getUtsendtVarselToStore(LocalDateTime.now().minusMonths(1)))
+//            embeddedDatabase.storeSpleisUtbetaling(spleisUtbetalingWhichResultsToVarsel)
+//
+//            val varslerToSendToday = merVeiledningVarselFinder.findMerVeiledningVarslerToSendToday()
+//
+//
+//            varslerToSendToday.size shouldBeEqualTo 0
+//        }
+//
+//        it("Should send MER_VEILEDNING when user is under 67") {
+//            coEvery { pdlConsumerMockk.isBrukerYngreEnnGittMaxAlder(any(), any()) } returns true
+//            coEvery { sykmeldingServiceMockk.isPersonSykmeldtPaDato(LocalDate.now(), arbeidstakerFnr1) } returns true
+//            embeddedDatabase.storeSpleisUtbetaling(spleisUtbetalingWhichResultsToVarsel)
+//
+//            val varslerToSendToday = merVeiledningVarselFinder.findMerVeiledningVarslerToSendToday()
+//
+//            varslerToSendToday.size shouldBeEqualTo 1
+//        }
+//
+//        it("Should not send MER_VEILEDNING when user is over 67") {
+//            coEvery { pdlConsumerMockk.isBrukerYngreEnnGittMaxAlder(any(), any()) } returns false
+//            coEvery { sykmeldingServiceMockk.isPersonSykmeldtPaDato(LocalDate.now(), arbeidstakerFnr1) } returns true
+//            embeddedDatabase.storeSpleisUtbetaling(spleisUtbetalingWhichResultsToVarsel)
+//
+//            val varslerToSendToday = merVeiledningVarselFinder.findMerVeiledningVarslerToSendToday()
+//
+//            varslerToSendToday.size shouldBeEqualTo 0
+//        }
+//
+//        it("Should call PDL if stored birthdate is null for a given fnr") {
+//            embeddedDatabase.storeFodselsdato(arbeidstakerFnr1, null)
+//            coEvery { sykmeldingServiceMockk.isPersonSykmeldtPaDato(LocalDate.now(), arbeidstakerFnr1) } returns true
+//            embeddedDatabase.storeSpleisUtbetaling(spleisUtbetalingWhichResultsToVarsel)
+//
+//            merVeiledningVarselFinder.findMerVeiledningVarslerToSendToday()
+//
+//            coVerify(exactly = 1) { pdlConsumerMockk.isBrukerYngreEnnGittMaxAlder(arbeidstakerFnr1, 67) }
+//        }
+//
+//        it("Should not call PDL if stored birthdate is not null") {
+//            embeddedDatabase.storeFodselsdato(arbeidstakerFnr2, "1986-01-01")
+//            coEvery { sykmeldingServiceMockk.isPersonSykmeldtPaDato(LocalDate.now(), arbeidstakerFnr2) } returns true
+//            embeddedDatabase.storeSpleisUtbetaling(spleisUtbetalingWhichResultsToVarsel2)
+//
+//            coVerify(exactly = 0) { pdlConsumerMockk.isBrukerYngreEnnGittMaxAlder(arbeidstakerFnr1, 67) }
+//        }
+//    }
 })
 
 private fun getUtsendtVarselToStore(utsendtTidspunkt: LocalDateTime): PUtsendtVarsel {
@@ -160,6 +149,6 @@ private fun getUtsendtVarselToStore(utsendtTidspunkt: LocalDateTime): PUtsendtVa
         null,
         null,
         null,
-        null
+        null,
     )
 }

--- a/src/test/kotlin/no/nav/syfo/service/MerVeiledningVarselFinderSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/service/MerVeiledningVarselFinderSpek.kt
@@ -1,14 +1,25 @@
 package no.nav.syfo.service
 
 import io.kotest.core.spec.style.DescribeSpec
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.mockk
 import no.nav.syfo.consumer.pdl.PdlConsumer
 import no.nav.syfo.consumer.syfosmregister.SykmeldingerConsumer
+import no.nav.syfo.db.arbeidstakerFnr2
 import no.nav.syfo.db.domain.PUtsendtVarsel
+import no.nav.syfo.db.storeFodselsdato
+import no.nav.syfo.db.storeSpleisUtbetaling
+import no.nav.syfo.db.storeUtsendtVarsel
+import no.nav.syfo.kafka.consumers.utbetaling.domain.UtbetalingUtbetalt
 import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType
 import no.nav.syfo.planner.arbeidstakerFnr1
 import no.nav.syfo.testutil.EmbeddedDatabase
+import no.nav.syfo.testutil.dropData
 import no.nav.syfo.testutil.mocks.orgnummer
+import org.amshove.kluent.shouldBeEqualTo
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*
 
@@ -20,120 +31,119 @@ class MerVeiledningVarselFinderSpek : DescribeSpec({
     val pdlConsumerMockk: PdlConsumer = mockk(relaxed = true)
     val merVeiledningVarselFinder =
         MerVeiledningVarselFinder(embeddedDatabase, sykmeldingServiceMockk, pdlConsumerMockk)
-// TODO
-//    val spleisUtbetalingWhichResultsToVarsel = UtbetalingUtbetalt(
-//        fødselsnummer = arbeidstakerFnr1,
-//        organisasjonsnummer = "234",
-//        event = "ubetaling_utbetalt",
-//        type = "UTBETALING",
-//        foreløpigBeregnetSluttPåSykepenger = LocalDate.now().plusDays(15),
-//        forbrukteSykedager = 100,
-//        gjenståendeSykedager = 79,
-//        stønadsdager = 10,
-//        antallVedtak = 4,
-//        fom = LocalDate.now().minusDays(50),
-//        tom = LocalDate.now().minusDays(3),
-//        utbetalingId = UUID.randomUUID().toString(),
-//        korrelasjonsId = UUID.randomUUID().toString(),
-//    )
-//    val spleisUtbetalingWhichResultsToVarsel2 = UtbetalingUtbetalt(
-//        fødselsnummer = arbeidstakerFnr2,
-//        organisasjonsnummer = "234",
-//        event = "ubetaling_utbetalt",
-//        type = "UTBETALING",
-//        foreløpigBeregnetSluttPåSykepenger = LocalDate.now().plusDays(15),
-//        forbrukteSykedager = 100,
-//        gjenståendeSykedager = 79,
-//        stønadsdager = 10,
-//        antallVedtak = 4,
-//        fom = LocalDate.now().minusDays(50),
-//        tom = LocalDate.now().minusDays(3),
-//        utbetalingId = UUID.randomUUID().toString(),
-//        korrelasjonsId = UUID.randomUUID().toString(),
-//    )
-//
-//    describe("MerVeiledningVarselFinderSpek") {
-//        afterTest {
-//            clearAllMocks()
-//            embeddedDatabase.connection.dropData()
-//        }
-//
-//        afterSpec {
-//            embeddedDatabase.stop()
-//        }
-//
-//        it("Should send MER_VEILEDNING when it was not sent during past 3 months") {
-//            coEvery { pdlConsumerMockk.isBrukerYngreEnnGittMaxAlder(any(), any()) } returns true
-//            coEvery { sykmeldingServiceMockk.isPersonSykmeldtPaDato(LocalDate.now(), arbeidstakerFnr1) } returns true
-//            embeddedDatabase.storeUtsendtVarsel(getUtsendtVarselToStore(LocalDateTime.now().minusMonths(5)))
-//            embeddedDatabase.storeSpleisUtbetaling(spleisUtbetalingWhichResultsToVarsel)
-//
-//            val varslerToSendToday = merVeiledningVarselFinder.findMerVeiledningVarslerToSendToday()
-//
-//            varslerToSendToday.size shouldBeEqualTo 1
-//        }
-//
-//        it("Should not send MER_VEILEDNING when it was sent during past 3 months") {
-//            coEvery { pdlConsumerMockk.isBrukerYngreEnnGittMaxAlder(any(), any()) } returns true
-//            coEvery { sykmeldingServiceMockk.isPersonSykmeldtPaDato(LocalDate.now(), arbeidstakerFnr1) } returns true
-//            embeddedDatabase.storeUtsendtVarsel(getUtsendtVarselToStore(LocalDateTime.now().minusMonths(1)))
-//            embeddedDatabase.storeSpleisUtbetaling(spleisUtbetalingWhichResultsToVarsel)
-//
-//            val varslerToSendToday = merVeiledningVarselFinder.findMerVeiledningVarslerToSendToday()
-//
-//            varslerToSendToday.size shouldBeEqualTo 0
-//        }
-//
-//        it("Should not send MER_VEILEDNING when it was not sent during past 3 months, but user is not active sykmeldt") {
-//            coEvery { pdlConsumerMockk.isBrukerYngreEnnGittMaxAlder(any(), any()) } returns true
-//            coEvery { sykmeldingServiceMockk.isPersonSykmeldtPaDato(LocalDate.now(), arbeidstakerFnr1) } returns false
-//            embeddedDatabase.storeUtsendtVarsel(getUtsendtVarselToStore(LocalDateTime.now().minusMonths(1)))
-//            embeddedDatabase.storeSpleisUtbetaling(spleisUtbetalingWhichResultsToVarsel)
-//
-//            val varslerToSendToday = merVeiledningVarselFinder.findMerVeiledningVarslerToSendToday()
-//
-//
-//            varslerToSendToday.size shouldBeEqualTo 0
-//        }
-//
-//        it("Should send MER_VEILEDNING when user is under 67") {
-//            coEvery { pdlConsumerMockk.isBrukerYngreEnnGittMaxAlder(any(), any()) } returns true
-//            coEvery { sykmeldingServiceMockk.isPersonSykmeldtPaDato(LocalDate.now(), arbeidstakerFnr1) } returns true
-//            embeddedDatabase.storeSpleisUtbetaling(spleisUtbetalingWhichResultsToVarsel)
-//
-//            val varslerToSendToday = merVeiledningVarselFinder.findMerVeiledningVarslerToSendToday()
-//
-//            varslerToSendToday.size shouldBeEqualTo 1
-//        }
-//
-//        it("Should not send MER_VEILEDNING when user is over 67") {
-//            coEvery { pdlConsumerMockk.isBrukerYngreEnnGittMaxAlder(any(), any()) } returns false
-//            coEvery { sykmeldingServiceMockk.isPersonSykmeldtPaDato(LocalDate.now(), arbeidstakerFnr1) } returns true
-//            embeddedDatabase.storeSpleisUtbetaling(spleisUtbetalingWhichResultsToVarsel)
-//
-//            val varslerToSendToday = merVeiledningVarselFinder.findMerVeiledningVarslerToSendToday()
-//
-//            varslerToSendToday.size shouldBeEqualTo 0
-//        }
-//
-//        it("Should call PDL if stored birthdate is null for a given fnr") {
-//            embeddedDatabase.storeFodselsdato(arbeidstakerFnr1, null)
-//            coEvery { sykmeldingServiceMockk.isPersonSykmeldtPaDato(LocalDate.now(), arbeidstakerFnr1) } returns true
-//            embeddedDatabase.storeSpleisUtbetaling(spleisUtbetalingWhichResultsToVarsel)
-//
-//            merVeiledningVarselFinder.findMerVeiledningVarslerToSendToday()
-//
-//            coVerify(exactly = 1) { pdlConsumerMockk.isBrukerYngreEnnGittMaxAlder(arbeidstakerFnr1, 67) }
-//        }
-//
-//        it("Should not call PDL if stored birthdate is not null") {
-//            embeddedDatabase.storeFodselsdato(arbeidstakerFnr2, "1986-01-01")
-//            coEvery { sykmeldingServiceMockk.isPersonSykmeldtPaDato(LocalDate.now(), arbeidstakerFnr2) } returns true
-//            embeddedDatabase.storeSpleisUtbetaling(spleisUtbetalingWhichResultsToVarsel2)
-//
-//            coVerify(exactly = 0) { pdlConsumerMockk.isBrukerYngreEnnGittMaxAlder(arbeidstakerFnr1, 67) }
-//        }
-//    }
+
+    val spleisUtbetalingWhichResultsToVarsel = UtbetalingUtbetalt(
+        fødselsnummer = arbeidstakerFnr1,
+        organisasjonsnummer = "234",
+        event = "ubetaling_utbetalt",
+        type = "UTBETALING",
+        foreløpigBeregnetSluttPåSykepenger = LocalDate.now().plusDays(15),
+        forbrukteSykedager = 100,
+        gjenståendeSykedager = 79,
+        stønadsdager = 10,
+        antallVedtak = 4,
+        fom = LocalDate.now().minusDays(50),
+        tom = LocalDate.now().minusDays(3),
+        utbetalingId = UUID.randomUUID().toString(),
+        korrelasjonsId = UUID.randomUUID().toString(),
+    )
+    val spleisUtbetalingWhichResultsToVarsel2 = UtbetalingUtbetalt(
+        fødselsnummer = arbeidstakerFnr2,
+        organisasjonsnummer = "234",
+        event = "ubetaling_utbetalt",
+        type = "UTBETALING",
+        foreløpigBeregnetSluttPåSykepenger = LocalDate.now().plusDays(15),
+        forbrukteSykedager = 100,
+        gjenståendeSykedager = 79,
+        stønadsdager = 10,
+        antallVedtak = 4,
+        fom = LocalDate.now().minusDays(50),
+        tom = LocalDate.now().minusDays(3),
+        utbetalingId = UUID.randomUUID().toString(),
+        korrelasjonsId = UUID.randomUUID().toString(),
+    )
+
+    describe("MerVeiledningVarselFinderSpek") {
+        afterTest {
+            clearAllMocks()
+            embeddedDatabase.connection.dropData()
+        }
+
+        afterSpec {
+            embeddedDatabase.stop()
+        }
+
+        it("Should send MER_VEILEDNING when it was not sent during past 3 months") {
+            coEvery { pdlConsumerMockk.isBrukerYngreEnnGittMaxAlder(any(), any()) } returns true
+            coEvery { sykmeldingServiceMockk.isPersonSykmeldtPaDato(LocalDate.now(), arbeidstakerFnr1) } returns true
+            embeddedDatabase.storeUtsendtVarsel(getUtsendtVarselToStore(LocalDateTime.now().minusMonths(5)))
+            embeddedDatabase.storeSpleisUtbetaling(spleisUtbetalingWhichResultsToVarsel)
+
+            val varslerToSendToday = merVeiledningVarselFinder.findMerVeiledningVarslerToSendToday()
+
+            varslerToSendToday.size shouldBeEqualTo 1
+        }
+
+        it("Should not send MER_VEILEDNING when it was sent during past 3 months") {
+            coEvery { pdlConsumerMockk.isBrukerYngreEnnGittMaxAlder(any(), any()) } returns true
+            coEvery { sykmeldingServiceMockk.isPersonSykmeldtPaDato(LocalDate.now(), arbeidstakerFnr1) } returns true
+            embeddedDatabase.storeUtsendtVarsel(getUtsendtVarselToStore(LocalDateTime.now().minusMonths(1)))
+            embeddedDatabase.storeSpleisUtbetaling(spleisUtbetalingWhichResultsToVarsel)
+
+            val varslerToSendToday = merVeiledningVarselFinder.findMerVeiledningVarslerToSendToday()
+
+            varslerToSendToday.size shouldBeEqualTo 0
+        }
+
+        it("Should not send MER_VEILEDNING when it was not sent during past 3 months, but user is not active sykmeldt") {
+            coEvery { pdlConsumerMockk.isBrukerYngreEnnGittMaxAlder(any(), any()) } returns true
+            coEvery { sykmeldingServiceMockk.isPersonSykmeldtPaDato(LocalDate.now(), arbeidstakerFnr1) } returns false
+            embeddedDatabase.storeUtsendtVarsel(getUtsendtVarselToStore(LocalDateTime.now().minusMonths(1)))
+            embeddedDatabase.storeSpleisUtbetaling(spleisUtbetalingWhichResultsToVarsel)
+
+            val varslerToSendToday = merVeiledningVarselFinder.findMerVeiledningVarslerToSendToday()
+
+            varslerToSendToday.size shouldBeEqualTo 0
+        }
+
+        it("Should send MER_VEILEDNING when user is under 67") {
+            coEvery { pdlConsumerMockk.isBrukerYngreEnnGittMaxAlder(any(), any()) } returns true
+            coEvery { sykmeldingServiceMockk.isPersonSykmeldtPaDato(LocalDate.now(), arbeidstakerFnr1) } returns true
+            embeddedDatabase.storeSpleisUtbetaling(spleisUtbetalingWhichResultsToVarsel)
+
+            val varslerToSendToday = merVeiledningVarselFinder.findMerVeiledningVarslerToSendToday()
+
+            varslerToSendToday.size shouldBeEqualTo 1
+        }
+
+        it("Should not send MER_VEILEDNING when user is over 67") {
+            coEvery { pdlConsumerMockk.isBrukerYngreEnnGittMaxAlder(any(), any()) } returns false
+            coEvery { sykmeldingServiceMockk.isPersonSykmeldtPaDato(LocalDate.now(), arbeidstakerFnr1) } returns true
+            embeddedDatabase.storeSpleisUtbetaling(spleisUtbetalingWhichResultsToVarsel)
+
+            val varslerToSendToday = merVeiledningVarselFinder.findMerVeiledningVarslerToSendToday()
+
+            varslerToSendToday.size shouldBeEqualTo 0
+        }
+
+        it("Should call PDL if stored birthdate is null for a given fnr") {
+            embeddedDatabase.storeFodselsdato(arbeidstakerFnr1, null)
+            coEvery { sykmeldingServiceMockk.isPersonSykmeldtPaDato(LocalDate.now(), arbeidstakerFnr1) } returns true
+            embeddedDatabase.storeSpleisUtbetaling(spleisUtbetalingWhichResultsToVarsel)
+
+            merVeiledningVarselFinder.findMerVeiledningVarslerToSendToday()
+
+            coVerify(exactly = 1) { pdlConsumerMockk.isBrukerYngreEnnGittMaxAlder(arbeidstakerFnr1, 67) }
+        }
+
+        it("Should not call PDL if stored birthdate is not null") {
+            embeddedDatabase.storeFodselsdato(arbeidstakerFnr2, "1986-01-01")
+            coEvery { sykmeldingServiceMockk.isPersonSykmeldtPaDato(LocalDate.now(), arbeidstakerFnr2) } returns true
+            embeddedDatabase.storeSpleisUtbetaling(spleisUtbetalingWhichResultsToVarsel2)
+
+            coVerify(exactly = 0) { pdlConsumerMockk.isBrukerYngreEnnGittMaxAlder(arbeidstakerFnr1, 67) }
+        }
+    }
 })
 
 private fun getUtsendtVarselToStore(utsendtTidspunkt: LocalDateTime): PUtsendtVarsel {


### PR DESCRIPTION
Påkrevde endringer
1: Endre opprettJournalpost-kallet til alltid å inkludere en eksternReferanseId som er unik for journalposten. eksternReferanseId kan gjerne være deres forretningsnøkkel for den spesifikke utsendelsen eller noe annet unikt for journalposten, så lenge det knyttes til prosessen slik at det ikke blir generert en ny ved f.eks. retry.
2: Håndtere 409 (CONFLICT)-responsen. Denne kan stort sett behandles som en 200 OK da det er den originale journalposten som blir returnert som body, men med httpstatus 409
