### PR TITLE
Fix ordering in query for maxdate and merveiledning

### DIFF
--- a/src/main/kotlin/no/nav/syfo/db/UtbetalingSpleisDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/db/UtbetalingSpleisDAO.kt
@@ -8,7 +8,10 @@ import java.sql.Timestamp
 import java.time.LocalDateTime
 import java.util.*
 
-fun DatabaseInterface.storeSpleisUtbetaling(utbetaling: UtbetalingSpleis) {
+fun DatabaseInterface.storeSpleisUtbetaling(
+    utbetaling: UtbetalingSpleis,
+    opprettetDato: LocalDateTime = LocalDateTime.now()
+) {
     val insertStatement = """INSERT INTO UTBETALING_SPLEIS  (
         ID, 
         FNR, 
@@ -43,7 +46,7 @@ fun DatabaseInterface.storeSpleisUtbetaling(utbetaling: UtbetalingSpleis) {
                 it.setDate(12, Date.valueOf(utbetaling.tom))
                 it.setString(13, utbetaling.utbetalingId)
                 it.setString(14, utbetaling.korrelasjonsId)
-                it.setTimestamp(15, Timestamp.valueOf(LocalDateTime.now()))
+                it.setTimestamp(15, Timestamp.valueOf(opprettetDato))
                 it.executeUpdate()
             }
             connection.commit()

--- a/src/main/kotlin/no/nav/syfo/db/UtbetalingerDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/db/UtbetalingerDAO.kt
@@ -14,7 +14,7 @@ fun DatabaseInterface.fetchMerVeiledningVarslerToSend(): List<PUtbetaling> {
                                 (SELECT UTBETALINGER2.ID
                                 FROM UTBETALINGER AS UTBETALINGER2
                                 WHERE UTBETALINGER1.FNR = UTBETALINGER2.FNR
-                                ORDER BY UTBETALT_TOM DESC, OPPRETTET DESC
+                                ORDER BY OPPRETTET DESC
                                 LIMIT 1)
                             AND GJENSTAENDE_SYKEDAGER < $gjenstaendeSykedagerLimit
                             AND FORELOPIG_BEREGNET_SLUTT >= current_date + INTERVAL '$maxDateLimit' DAY
@@ -40,7 +40,7 @@ fun DatabaseInterface.fetchMaksDatoByFnr(fnr: String): PMaksDato? {
                                 (SELECT UTBETALINGER2.ID
                                 FROM UTBETALINGER AS UTBETALINGER2
                                 WHERE UTBETALINGER1.FNR = UTBETALINGER2.FNR
-                                ORDER BY UTBETALT_TOM DESC, OPPRETTET DESC
+                                ORDER BY OPPRETTET DESC
                                 LIMIT 1)
                             AND FNR = ?
                             """

--- a/src/test/kotlin/no/nav/syfo/db/FodselsdatoDAOSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/db/FodselsdatoDAOSpek.kt
@@ -8,7 +8,7 @@ class FodselsdatoDAOSpek : DescribeSpec({
     describe("FodselsdatoDAOSpek") {
         val embeddedDatabase = EmbeddedDatabase()
         beforeTest {
-            embeddedDatabase.connection.dropData()
+            embeddedDatabase.dropData()
         }
 
         it("Should fetch birthdate") {

--- a/src/test/kotlin/no/nav/syfo/db/MikrofrontendSynlighetDAOSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/db/MikrofrontendSynlighetDAOSpek.kt
@@ -4,7 +4,6 @@ import io.kotest.core.spec.style.DescribeSpec
 import no.nav.syfo.kafka.producers.mineside_microfrontend.MikrofrontendSynlighet
 import no.nav.syfo.kafka.producers.mineside_microfrontend.Tjeneste
 import no.nav.syfo.testutil.EmbeddedDatabase
-import no.nav.syfo.testutil.dropData
 import no.nav.syfo.testutil.shouldContainMikrofrontendEntry
 import no.nav.syfo.testutil.shouldNotContainMikrofrontendEntryForUser
 import org.amshove.kluent.should
@@ -16,7 +15,7 @@ class MikrofrontendSynlighetDAOSpek : DescribeSpec({
         val embeddedDatabase = EmbeddedDatabase()
 
         beforeTest {
-            embeddedDatabase.connection.dropData()
+            embeddedDatabase.dropData()
         }
 
         val mikrofrontendSynlighet1 = MikrofrontendSynlighet(

--- a/src/test/kotlin/no/nav/syfo/db/PlanlagtVarselDAOSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/db/PlanlagtVarselDAOSpek.kt
@@ -6,7 +6,6 @@ import no.nav.syfo.db.domain.PPlanlagtVarsel
 import no.nav.syfo.db.domain.PlanlagtVarsel
 import no.nav.syfo.db.domain.VarselType
 import no.nav.syfo.testutil.EmbeddedDatabase
-import no.nav.syfo.testutil.dropData
 import no.nav.syfo.testutil.mocks.orgnummer
 import org.amshove.kluent.should
 import org.amshove.kluent.shouldBeEqualTo
@@ -20,7 +19,7 @@ class PlanlagtVarselDAOSpek : DescribeSpec({
         val embeddedDatabase = EmbeddedDatabase()
 
         beforeTest {
-            embeddedDatabase.connection.dropData()
+            embeddedDatabase.dropData()
         }
 
         it("Store and fetch PlanlagtVarsel") {

--- a/src/test/kotlin/no/nav/syfo/db/UtsendtVarselFeiletDAOSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/db/UtsendtVarselFeiletDAOSpek.kt
@@ -6,7 +6,6 @@ import no.nav.syfo.db.domain.Kanal
 import no.nav.syfo.db.domain.PUtsendtVarselFeilet
 import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType
 import no.nav.syfo.testutil.EmbeddedDatabase
-import no.nav.syfo.testutil.dropData
 import org.amshove.kluent.should
 import java.time.LocalDateTime
 import java.util.*
@@ -16,7 +15,7 @@ class UtsendtVarselFeiletDAOSpek : DescribeSpec({
         val embeddedDatabase = EmbeddedDatabase()
 
         beforeTest {
-            embeddedDatabase.connection.dropData()
+            embeddedDatabase.dropData()
         }
 
         it("Store ikke-utsendt varsel til NL i database") {

--- a/src/test/kotlin/no/nav/syfo/job/SendMerVeiledningVarslerJobbSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/job/SendMerVeiledningVarslerJobbSpek.kt
@@ -31,7 +31,7 @@ class SendMerVeiledningVarslerJobbSpek : DescribeSpec({
     )
 
     describe("SendMerVeiledningVarslerJobbSpek") {
-        afterTest {
+        beforeTest {
             clearAllMocks()
         }
 

--- a/src/test/kotlin/no/nav/syfo/service/DialogmoteInnkallingVarselServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/service/DialogmoteInnkallingVarselServiceSpek.kt
@@ -22,7 +22,6 @@ import no.nav.syfo.kafka.producers.dittsykefravaer.domain.Variant
 import no.nav.syfo.planner.arbeidstakerFnr1
 import no.nav.syfo.service.SenderFacade.InternalBrukernotifikasjonType.DONE
 import no.nav.syfo.testutil.EmbeddedDatabase
-import no.nav.syfo.testutil.dropData
 import no.nav.syfo.testutil.mocks.fnr1
 import no.nav.syfo.testutil.mocks.fnr2
 import no.nav.syfo.testutil.mocks.fnr3
@@ -64,7 +63,7 @@ class DialogmoteInnkallingVarselServiceSpek : DescribeSpec({
 
         beforeTest {
             clearAllMocks()
-            embeddedDatabase.connection.dropData()
+            embeddedDatabase.dropData()
         }
 
         it("Non-reserved users should be notified externally") {

--- a/src/test/kotlin/no/nav/syfo/service/MerVeiledningVarselFinderSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/service/MerVeiledningVarselFinderSpek.kt
@@ -17,7 +17,6 @@ import no.nav.syfo.kafka.consumers.utbetaling.domain.UtbetalingSpleis
 import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType
 import no.nav.syfo.planner.arbeidstakerFnr1
 import no.nav.syfo.testutil.EmbeddedDatabase
-import no.nav.syfo.testutil.dropData
 import no.nav.syfo.testutil.mocks.orgnummer
 import org.amshove.kluent.shouldBeEqualTo
 import java.time.LocalDate
@@ -67,7 +66,7 @@ class MerVeiledningVarselFinderSpek : DescribeSpec({
     describe("MerVeiledningVarselFinderSpek") {
         beforeTest {
             clearAllMocks()
-            embeddedDatabase.connection.dropData()
+            embeddedDatabase.dropData()
         }
 
         it("Should send MER_VEILEDNING when it was not sent during past 3 months") {

--- a/src/test/kotlin/no/nav/syfo/service/MikrofrontendServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/service/MikrofrontendServiceSpek.kt
@@ -39,7 +39,7 @@ class MikrofrontendServiceSpek : DescribeSpec({
 
     beforeTest {
         clearAllMocks()
-        embeddedDatabase.connection.dropData()
+        embeddedDatabase.dropData()
     }
 
     describe("MikrofrontendServiceSpek") {

--- a/src/test/kotlin/no/nav/syfo/service/MotebehovVarselServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/service/MotebehovVarselServiceSpek.kt
@@ -22,7 +22,7 @@ class MotebehovVarselServiceSpek : DescribeSpec({
         MotebehovVarselService(senderFacade, accessControlService, sykmeldingService, "http://localhost")
 
     describe("MotebehovVarselServiceSpek") {
-        afterTest {
+        beforeTest {
             clearAllMocks()
         }
 

--- a/src/test/kotlin/no/nav/syfo/service/SenderFacadeSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/service/SenderFacadeSpek.kt
@@ -16,7 +16,6 @@ import no.nav.syfo.kafka.producers.dinesykmeldte.DineSykmeldteHendelseKafkaProdu
 import no.nav.syfo.kafka.producers.dittsykefravaer.DittSykefravaerMeldingKafkaProducer
 import no.nav.syfo.planner.arbeidstakerFnr1
 import no.nav.syfo.testutil.EmbeddedDatabase
-import no.nav.syfo.testutil.dropData
 import java.time.LocalDateTime
 import java.util.*
 
@@ -88,7 +87,7 @@ class SenderFacadeSpek : DescribeSpec({
 
         beforeTest {
             clearAllMocks()
-            embeddedDatabase.connection.dropData()
+            embeddedDatabase.dropData()
         }
 
         it("Complete notifications for user") {

--- a/src/test/kotlin/no/nav/syfo/service/SykepengerMaxDateServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/service/SykepengerMaxDateServiceSpek.kt
@@ -10,7 +10,6 @@ import no.nav.syfo.consumer.pdl.PdlPerson
 import no.nav.syfo.kafka.consumers.utbetaling.domain.UTBETALING_UTBETALT
 import no.nav.syfo.kafka.consumers.utbetaling.domain.UtbetalingSpleis
 import no.nav.syfo.testutil.EmbeddedDatabase
-import no.nav.syfo.testutil.dropData
 import java.time.LocalDate
 import java.util.*
 import kotlin.test.assertEquals
@@ -28,7 +27,7 @@ class SykepengerMaxDateServiceSpek : DescribeSpec({
             )
         )
         beforeTest {
-            embeddedDatabase.connection.dropData()
+            embeddedDatabase.dropData()
         }
 
         it("Should store spleis utbetaling") {

--- a/src/test/kotlin/no/nav/syfo/service/TestdataResetServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/service/TestdataResetServiceSpek.kt
@@ -4,8 +4,23 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.verify
-import no.nav.syfo.db.*
-import no.nav.syfo.db.domain.*
+import no.nav.syfo.db.arbeidstakerAktorId1
+import no.nav.syfo.db.domain.Kanal
+import no.nav.syfo.db.domain.PUtsendtVarsel
+import no.nav.syfo.db.domain.PUtsendtVarselFeilet
+import no.nav.syfo.db.domain.PlanlagtVarsel
+import no.nav.syfo.db.domain.VarselType
+import no.nav.syfo.db.fetchInfotrygdUtbetalingByFnr
+import no.nav.syfo.db.fetchMikrofrontendSynlighetEntriesByFnr
+import no.nav.syfo.db.fetchPlanlagtVarselByFnr
+import no.nav.syfo.db.fetchUtsendtVarselByFnr
+import no.nav.syfo.db.fetchUtsendtVarselFeiletByFnr
+import no.nav.syfo.db.storeInfotrygdUtbetaling
+import no.nav.syfo.db.storeMikrofrontendSynlighetEntry
+import no.nav.syfo.db.storePlanlagtVarsel
+import no.nav.syfo.db.storeSpleisUtbetaling
+import no.nav.syfo.db.storeUtsendtVarsel
+import no.nav.syfo.db.storeUtsendtVarselFeilet
 import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.kafka.consumers.infotrygd.domain.InfotrygdSource
 import no.nav.syfo.kafka.consumers.utbetaling.domain.UtbetalingSpleis
@@ -16,7 +31,6 @@ import no.nav.syfo.planner.arbeidstakerFnr1
 import no.nav.syfo.planner.narmesteLederFnr1
 import no.nav.syfo.service.microfrontend.MikrofrontendService
 import no.nav.syfo.testutil.EmbeddedDatabase
-import no.nav.syfo.testutil.dropData
 import no.nav.syfo.testutil.mocks.orgnummer
 import org.amshove.kluent.shouldBeEqualTo
 import java.time.LocalDate
@@ -84,7 +98,7 @@ class TestdataResetServiceSpek : DescribeSpec({
             MikrofrontendSynlighet(arbeidstakerFnr1, Tjeneste.DIALOGMOTE, LocalDate.now().plusWeeks(1))
 
         beforeTest {
-            embeddedDatabase.connection.dropData()
+            embeddedDatabase.dropData()
         }
 
         it("Reset all testdata") {

--- a/src/test/kotlin/no/nav/syfo/testutil/EmbeddedDatabase.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/EmbeddedDatabase.kt
@@ -31,27 +31,27 @@ class EmbeddedDatabase : DatabaseInterface {
         }
     }
 
+    fun dropData() {
+        val tables = listOf(
+            "PLANLAGT_VARSEL",
+            "SYKMELDING_IDS",
+            "UTSENDT_VARSEL",
+            "UTBETALING_INFOTRYGD",
+            "UTBETALING_SPLEIS",
+            "MIKROFRONTEND_SYNLIGHET"
+        )
+
+        connection.use { connection ->
+            tables.forEach { table ->
+                connection.prepareStatement("DELETE FROM $table").executeUpdate()
+            }
+            connection.commit()
+        }
+    }
+
     override val connection: Connection
         get() = dataSource.connection.apply { autoCommit = false }
     override val log: Logger
         get() = LoggerFactory.getLogger(EmbeddedDatabase::class.qualifiedName)
 }
 
-fun Connection.dropData() {
-    val query1 = "DELETE FROM PLANLAGT_VARSEL"
-    val query2 = "DELETE FROM SYKMELDING_IDS"
-    val query3 = "DELETE FROM UTSENDT_VARSEL"
-    val query5 = "DELETE FROM UTBETALING_INFOTRYGD"
-    val query6 = "DELETE FROM UTBETALING_SPLEIS"
-    val query7 = "DELETE FROM MIKROFRONTEND_SYNLIGHET"
-
-    use { connection ->
-        connection.prepareStatement(query1).executeUpdate()
-        connection.prepareStatement(query2).executeUpdate()
-        connection.prepareStatement(query3).executeUpdate()
-        connection.prepareStatement(query5).executeUpdate()
-        connection.prepareStatement(query6).executeUpdate()
-        connection.prepareStatement(query7).executeUpdate()
-        connection.commit()
-    }
-}


### PR DESCRIPTION
Ganske sikker på at vi har en bug med uthenting av maksdato og med uthenting av SSPS varsler som skal sendes.

https://jira.adeo.no/browse/FAGSYSTEM-326043

Dette løser denne jiraen