### PR TITLE
Fix socket timeout for requests to azure ad

### DIFF
--- a/src/main/kotlin/no/nav/syfo/auth/AzureAdTokenConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/auth/AzureAdTokenConsumer.kt
@@ -10,6 +10,8 @@ import io.ktor.client.HttpClientConfig
 import io.ktor.client.call.body
 import io.ktor.client.engine.apache.Apache
 import io.ktor.client.engine.apache.ApacheEngineConfig
+import io.ktor.client.plugins.ClientRequestException
+import io.ktor.client.plugins.HttpRequestRetry
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.accept
 import io.ktor.client.request.forms.FormDataContent
@@ -46,6 +48,12 @@ class AzureAdTokenConsumer(authEnv: AuthEnv) {
 
     val proxyConfig: HttpClientConfig<ApacheEngineConfig>.() -> Unit = {
         config()
+        install(HttpRequestRetry) {
+            retryOnExceptionIf(2) { _, cause ->
+                cause !is ClientRequestException
+            }
+            constantDelay(500L)
+        }
         engine {
             customizeClient {
                 setRoutePlanner(SystemDefaultRoutePlanner(ProxySelector.getDefault()))


### PR DESCRIPTION
Det er endel timeouts mot Azure Ad i loggene:
```
Encountered exception during call to tilgangskontroll: Socket timeout has expired [url=https://login.microsoftonline.com/62366534-1ec3-4962-8869-9b5535279d0b/oauth2/v2.0/token, socket_timeout=unknown] ms
```

Prøver å sette opp retry for å se om det bedrer seg.