### PR TITLE
Reduce noise in logs

### DIFF
--- a/src/main/kotlin/no/nav/syfo/db/UtbetalingInfotrygdDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/db/UtbetalingInfotrygdDAO.kt
@@ -23,6 +23,7 @@ fun DatabaseInterface.storeInfotrygdUtbetaling(
         GJENSTAENDE_SYKEDAGER,
         OPPRETTET,
         SOURCE) VALUES (?,?,?,?,?,?,?)
+        ON CONFLICT (FNR, MAX_DATE, UTBET_TOM) DO NOTHING
     """.trimIndent()
     connection.use { connection ->
         try {

--- a/src/main/kotlin/no/nav/syfo/db/UtbetalingInfotrygdDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/db/UtbetalingInfotrygdDAO.kt
@@ -23,7 +23,6 @@ fun DatabaseInterface.storeInfotrygdUtbetaling(
         GJENSTAENDE_SYKEDAGER,
         OPPRETTET,
         SOURCE) VALUES (?,?,?,?,?,?,?)
-        ON CONFLICT (FNR, MAX_DATE, UTBET_TOM) DO NOTHING
     """.trimIndent()
     connection.use { connection ->
         try {
@@ -39,7 +38,7 @@ fun DatabaseInterface.storeInfotrygdUtbetaling(
             }
             connection.commit()
         } catch (e: Exception) {
-            log.error("[INFOTRYGD KAFKA] Ignoring inserting a message from Infotrygd with max date $sykepengerMaxDate,  utbet tom $utbetaltTilDate and gjenstaendeSykepengedager $gjenstaendeSykepengedager")
+            log.info("[INFOTRYGD KAFKA] Ignoring inserting a message from Infotrygd with max date $sykepengerMaxDate,  utbet tom $utbetaltTilDate and gjenstaendeSykepengedager $gjenstaendeSykepengedager")
         }
     }
 }


### PR DESCRIPTION
Degrade log level to info as there are a lot of duplicate data form infotrygd, and this is "normal" and only creates noise