### PR TITLE
disable-job

### DIFF
--- a/nais/job-trigger-prod.yaml
+++ b/nais/job-trigger-prod.yaml
@@ -11,7 +11,7 @@ spec:
     outbound:
       rules:
         - application: esyfovarsel
-  schedule: "05 18 * * *" #  runs at 18:05 daily
+  schedule: "05 09 * * *" #  runs at 09:05 daily
   filesFrom:
     - secret: esyfovarsel-serviceuser
   env:

--- a/nais/job-trigger-prod.yaml
+++ b/nais/job-trigger-prod.yaml
@@ -11,7 +11,7 @@ spec:
     outbound:
       rules:
         - application: esyfovarsel
-  schedule: "05 09,18 * * *" #  runs at 9:05 and 18:05 daily
+  schedule: "05 18 * * *" #  runs at 18:05 daily
   filesFrom:
     - secret: esyfovarsel-serviceuser
   env:
@@ -22,4 +22,4 @@ spec:
     - name: ESYFOVARSEL_JOB_TRIGGER_URL
       value: http://esyfovarsel/job/trigger
     - name: REVARSLE_UNREAD_AKTIVITETSKRAV
-      value: "true"
+      value: "false"

--- a/src/main/kotlin/no/nav/syfo/db/UtsendtVarselDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/db/UtsendtVarselDAO.kt
@@ -66,6 +66,7 @@ fun DatabaseInterface.fetchAlleUferdigstilteAktivitetspliktVarsler(
                             WHERE type = 'SM_AKTIVITETSPLIKT'
                               AND kanal = 'BRUKERNOTIFIKASJON'
                               AND ferdigstilt_tidspunkt IS NULL
+                              AND journalpost_id IS NOT NULL
                               AND (is_forced_letter IS FALSE OR is_forced_letter IS NULL)
                               AND utsendt_tidspunkt >= CURRENT_DATE - 14
                               AND utsendt_tidspunkt < CURRENT_DATE - 1;


### PR DESCRIPTION
1. Many entries in DB does not have journalpost_id because it is a new field. I forgot to include filter for it in the query in the previous PR, which resulted in some exceptions for missing journalpost_id. Fixing it here.
2.The job is ment to run 2 times a day, at 9:05 and 18:05, which is probably redundant. Reducing 
3. Each time job is triggered, it is running 2 times, and I'm not sure why. This will not cause 2 letters per person because distribusjon is checking for duplicates and returns 409 in such cases. We should probably temporarily disable job until we find out why it is running 2 time per trigger?