### PR TITLE
Fix transition to kalenderavtale

### DIFF
--- a/src/main/kotlin/no/nav/syfo/service/DialogmoteInnkallingNarmestelederVarselServiceOLD.kt
+++ b/src/main/kotlin/no/nav/syfo/service/DialogmoteInnkallingNarmestelederVarselServiceOLD.kt
@@ -1,0 +1,136 @@
+package no.nav.syfo.service
+
+import no.nav.syfo.ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_AVLYST_EMAIL_BODY
+import no.nav.syfo.ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_AVLYST_EMAIL_TITLE
+import no.nav.syfo.ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_AVLYST_MESSAGE_TEXT
+import no.nav.syfo.ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_INNKALT_EMAIL_BODY
+import no.nav.syfo.ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_INNKALT_EMAIL_TITLE
+import no.nav.syfo.ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_INNKALT_MESSAGE_TEXT
+import no.nav.syfo.ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_MERKELAPP
+import no.nav.syfo.ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_NYTT_TID_STED_EMAIL_BODY
+import no.nav.syfo.ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_NYTT_TID_STED_EMAIL_TITLE
+import no.nav.syfo.ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_NYTT_TID_STED_MESSAGE_TEXT
+import no.nav.syfo.ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_REFERAT_EMAIL_BODY
+import no.nav.syfo.ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_REFERAT_EMAIL_TITLE
+import no.nav.syfo.ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_REFERAT_MESSAGE_TEXT
+import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType.NL_DIALOGMOTE_AVLYST
+import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType.NL_DIALOGMOTE_INNKALT
+import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType.NL_DIALOGMOTE_NYTT_TID_STED
+import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType.NL_DIALOGMOTE_REFERAT
+import no.nav.syfo.kafka.consumers.varselbus.domain.NarmesteLederHendelse
+import no.nav.syfo.kafka.consumers.varselbus.domain.VarselDataNarmesteLeder
+import no.nav.syfo.kafka.consumers.varselbus.domain.toVarselData
+import org.slf4j.LoggerFactory
+import java.io.IOException
+import java.time.LocalDateTime
+import java.util.*
+
+/**
+ * This class handles dialogmøte-changes "the old way" (without kalenderavtale and sak).
+ * This is purely to handle the transition between the old way and the new way.
+ * Should be deleted when no longer needed
+ */
+@Suppress("VariableNaming")
+class DialogmoteInnkallingNarmestelederVarselServiceOLD(
+    val senderFacade: SenderFacade,
+) {
+    val WEEKS_BEFORE_DELETE = 4L
+    val SMS_KEY = "smsText"
+    val EMAIL_TITLE_KEY = "emailTitle"
+    val EMAIL_BODY_KEY = "emailBody"
+    private val log = LoggerFactory.getLogger(DialogmoteInnkallingNarmestelederVarselServiceOLD::class.qualifiedName)
+
+    suspend fun sendVarselTilNarmesteLeder(varselHendelse: NarmesteLederHendelse) {
+        log.info("[Handle OLD varselutsending]: ${varselHendelse.type}")
+        varselHendelse.data = dataToVarselDataNarmesteLeder(varselHendelse.data)
+        sendVarselTilArbeidsgiverNotifikasjon(varselHendelse)
+    }
+
+    private suspend fun sendVarselTilArbeidsgiverNotifikasjon(varselHendelse: NarmesteLederHendelse) {
+        val texts = getArbeisgiverTexts(varselHendelse)
+        val sms = texts[SMS_KEY]
+        val emailTitle = texts[EMAIL_TITLE_KEY]
+        val emailBody = texts[EMAIL_BODY_KEY]
+
+        if (!sms.isNullOrBlank() && !emailTitle.isNullOrBlank() && !emailBody.isNullOrBlank()) {
+            val input = ArbeidsgiverNotifikasjonInput(
+                uuid = UUID.randomUUID(),
+                virksomhetsnummer = varselHendelse.orgnummer,
+                narmesteLederFnr = varselHendelse.narmesteLederFnr,
+                ansattFnr = varselHendelse.arbeidstakerFnr,
+                merkelapp = ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_MERKELAPP,
+                messageText = sms,
+                epostTittel = emailTitle,
+                epostHtmlBody = emailBody,
+                hardDeleteDate = LocalDateTime.now().plusWeeks(WEEKS_BEFORE_DELETE),
+                meldingstype = Meldingstype.OPPGAVE,
+                grupperingsid = UUID.randomUUID().toString(),
+            )
+
+            senderFacade.sendTilArbeidsgiverNotifikasjon(
+                varselHendelse,
+                input,
+            )
+        } else {
+            log.warn(
+                "Kunne ikke mappe tekstene til arbeidsgiver-tekst " +
+                    "for dialogmote varsel av type: ${varselHendelse.type.name}"
+            )
+        }
+    }
+
+    private fun getArbeisgiverTexts(hendelse: NarmesteLederHendelse): HashMap<String, String> {
+        return when (hendelse.type) {
+            NL_DIALOGMOTE_INNKALT -> hashMapOf(
+                SMS_KEY to ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_INNKALT_MESSAGE_TEXT,
+                EMAIL_TITLE_KEY to ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_INNKALT_EMAIL_TITLE,
+                EMAIL_BODY_KEY to getEmailBody(hendelse),
+            )
+
+            NL_DIALOGMOTE_AVLYST -> hashMapOf(
+                SMS_KEY to ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_AVLYST_MESSAGE_TEXT,
+                EMAIL_TITLE_KEY to ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_AVLYST_EMAIL_TITLE,
+                EMAIL_BODY_KEY to getEmailBody(hendelse),
+            )
+
+            NL_DIALOGMOTE_NYTT_TID_STED -> hashMapOf(
+                SMS_KEY to ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_NYTT_TID_STED_MESSAGE_TEXT,
+                EMAIL_TITLE_KEY to ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_NYTT_TID_STED_EMAIL_TITLE,
+                EMAIL_BODY_KEY to getEmailBody(hendelse),
+            )
+
+            NL_DIALOGMOTE_REFERAT -> hashMapOf(
+                SMS_KEY to ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_REFERAT_MESSAGE_TEXT,
+                EMAIL_TITLE_KEY to ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_REFERAT_EMAIL_TITLE,
+                EMAIL_BODY_KEY to getEmailBody(hendelse),
+            )
+
+            else -> hashMapOf()
+        }
+    }
+
+    private fun getEmailBody(hendelse: NarmesteLederHendelse): String {
+        var greeting = "<body>Hei.<br><br>"
+
+        val narmesteLeder = hendelse.data as VarselDataNarmesteLeder
+        if (!narmesteLeder.navn.isNullOrBlank()) {
+            greeting = "Til <body>${narmesteLeder.navn},<br><br>"
+        }
+
+        return when (hendelse.type) {
+            NL_DIALOGMOTE_INNKALT -> greeting + ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_INNKALT_EMAIL_BODY
+            NL_DIALOGMOTE_AVLYST -> greeting + ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_AVLYST_EMAIL_BODY
+            NL_DIALOGMOTE_REFERAT -> greeting + ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_REFERAT_EMAIL_BODY
+            NL_DIALOGMOTE_NYTT_TID_STED -> greeting + ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_NYTT_TID_STED_EMAIL_BODY
+            else -> ""
+        }
+    }
+
+    fun dataToVarselDataNarmesteLeder(data: Any?): VarselDataNarmesteLeder {
+        return data?.let {
+            val varselData = data.toVarselData()
+            varselData.narmesteLeder
+                ?: throw IOException("VarselDataNarmesteLeder har feil format")
+        } ?: throw IllegalArgumentException("EsyfovarselHendelse mangler 'data'-felt")
+    }
+}

--- a/src/test/kotlin/no/nav/syfo/service/DialogmoteInnkallingNarmesteLederVarselServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/service/DialogmoteInnkallingNarmesteLederVarselServiceSpek.kt
@@ -14,7 +14,13 @@ import no.nav.syfo.consumer.pdl.HentPersonData
 import no.nav.syfo.consumer.pdl.Navn
 import no.nav.syfo.consumer.pdl.PdlClient
 import no.nav.syfo.kafka.common.createObjectMapper
-import no.nav.syfo.kafka.consumers.varselbus.domain.*
+import no.nav.syfo.kafka.consumers.varselbus.domain.DialogmoteSvarType
+import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType
+import no.nav.syfo.kafka.consumers.varselbus.domain.NarmesteLederHendelse
+import no.nav.syfo.kafka.consumers.varselbus.domain.VarselData
+import no.nav.syfo.kafka.consumers.varselbus.domain.VarselDataDialogmoteSvar
+import no.nav.syfo.kafka.consumers.varselbus.domain.VarselDataMotetidspunkt
+import no.nav.syfo.kafka.consumers.varselbus.domain.VarselDataNarmesteLeder
 import no.nav.syfo.kafka.producers.dinesykmeldte.DineSykmeldteHendelseKafkaProducer
 import no.nav.syfo.kafka.producers.dittsykefravaer.DittSykefravaerMeldingKafkaProducer
 import no.nav.syfo.planner.arbeidstakerFnr1
@@ -151,6 +157,20 @@ class DialogmoteInnkallingNarmesteLederVarselServiceSpek : DescribeSpec({
             }
             coVerify(exactly = 0) {
                 arbeidsgiverNotifikasjonService.sendNotifikasjon(any())
+            }
+        }
+
+        it("Sends varsel the old way for changes, if there is no sak") {
+            coEvery { arbeidsgiverNotifikasjonService.createNewSak(any()) } returns null
+
+            val varselHendelseInnkalling = createHendelse(type = HendelseType.NL_DIALOGMOTE_NYTT_TID_STED)
+            dialogmoteInnkallingNarmesteLederVarselService.sendVarselTilNarmesteLeder(varselHendelseInnkalling)
+
+            coVerify(exactly = 1) {
+                arbeidsgiverNotifikasjonService.sendNotifikasjon(any())
+            }
+            coVerify(exactly = 0) {
+                arbeidsgiverNotifikasjonService.createNewKalenderavtale(any())
             }
         }
     }


### PR DESCRIPTION
Har bare kopiert tilbake den gamle koden for den gamle servicen, og piper det inn dit dersom det ikke finnes en sak. 

Dvs - dersom ikke sak finnes for en "endring" av møtet, så sendes det dit. (med unntak av "svar" som er ny, den skipper vi)

I praksis betyr dette at det da sendes ut som en oppgave uten sak og kalenderavtale, dersom det kommer inn endringer på møteinnkalling uten sak.