### PR TITLE
Extend ResendFailedVarslerJob to handle some arbeidsgivernotifikasjoner

### DIFF
--- a/src/main/kotlin/no/nav/syfo/api/job/JobRest.kt
+++ b/src/main/kotlin/no/nav/syfo/api/job/JobRest.kt
@@ -32,6 +32,9 @@ fun Route.registerJobTriggerApi(
                 resendFailedVarslerJob.resendFailedBrukernotifikasjonVarsler()
             }
             launch {
+                resendFailedVarslerJob.resendFailedArbeidsgivernotifikasjonVarsler()
+            }
+            launch {
                 resendFailedVarslerJob.resendFailedDokDistVarsler()
             }
         }

--- a/src/main/kotlin/no/nav/syfo/db/UtsendtVarselDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/db/UtsendtVarselDAO.kt
@@ -179,7 +179,8 @@ fun DatabaseInterface.fetchDineSykemeldteMotebehovOppgaverFor(
         AND utsendt_varsel.orgnummer = ?
         AND utsendt_varsel.utsendt_tidspunkt >= '2025-05-19'
         AND utsendt_varsel.kanal = 'DINE_SYKMELDTE'
-        AND utsending_varsel_feilet.hendelsetype_navn = 'NL_DIALOGMOTE_SVAR_MOTEBEHOV';
+        AND utsending_varsel_feilet.hendelsetype_navn = 'NL_DIALOGMOTE_SVAR_MOTEBEHOV'
+        ORDER BY utsendt_varsel.utsendt_tidspunkt DESC;
     """.trimIndent()
 
     return connection.use { connection ->

--- a/src/main/kotlin/no/nav/syfo/db/UtsendtVarselDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/db/UtsendtVarselDAO.kt
@@ -168,19 +168,20 @@ fun DatabaseInterface.fetchDineSykemeldteMotebehovOppgaverFor(
     orgnummer: String,
 ): PUtsendtVarsel? {
     val queryStatement = """
-        SELECT *
-        FROM utsendt_varsel
-        INNER JOIN utsending_varsel_feilet
-        ON utsendt_varsel.orgnummer = utsending_varsel_feilet.orgnummer
-            AND utsendt_varsel.fnr = utsending_varsel_feilet.arbeidstaker_fnr
-            AND utsendt_varsel.narmesteleder_fnr = utsending_varsel_feilet.narmesteleder_fnr
-        WHERE utsendt_varsel.fnr = ?
-        AND utsendt_varsel.narmesteleder_fnr = ?
-        AND utsendt_varsel.orgnummer = ?
-        AND utsendt_varsel.utsendt_tidspunkt >= '2025-05-19'
-        AND utsendt_varsel.kanal = 'DINE_SYKMELDTE'
-        AND utsending_varsel_feilet.hendelsetype_navn = 'NL_DIALOGMOTE_SVAR_MOTEBEHOV'
-        ORDER BY utsendt_varsel.utsendt_tidspunkt DESC;
+        SELECT * FROM utsendt_varsel 
+        WHERE fnr = ? 
+        AND narmesteleder_fnr = ? 
+        AND orgnummer = ? 
+        AND utsendt_tidspunkt >= '2025-05-19' 
+        AND kanal = 'DINE_SYKMELDTE' 
+        AND EXISTS ( 
+            SELECT 1 FROM utsending_varsel_feilet 
+            WHERE utsending_varsel_feilet.orgnummer = utsendt_varsel.orgnummer 
+            AND utsending_varsel_feilet.arbeidstaker_fnr = utsendt_varsel.fnr 
+            AND utsending_varsel_feilet.narmesteleder_fnr = utsendt_varsel.narmesteleder_fnr 
+            AND utsending_varsel_feilet.hendelsetype_navn = 'NL_DIALOGMOTE_SVAR_MOTEBEHOV' 
+        ) 
+        ORDER BY utsendt_tidspunkt DESC;
     """.trimIndent()
 
     return connection.use { connection ->

--- a/src/main/kotlin/no/nav/syfo/db/UtsendtVarselFeiletDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/db/UtsendtVarselFeiletDAO.kt
@@ -30,6 +30,25 @@ fun DatabaseInterface.fetchUtsendtBrukernotifikasjonVarselFeilet(): List<PUtsend
     }
 }
 
+fun DatabaseInterface.fetchUtsendtArbeidsgivernotifikasjonVarselFeilet(): List<PUtsendtVarselFeilet> {
+    val queryStatement = """SELECT *
+                            FROM UTSENDING_VARSEL_FEILET feilet
+                            WHERE feilet.KANAL = 'ARBEIDSGIVERNOTIFIKASJON'
+                            AND feilet.UTSENDT_FORSOK_TIDSPUNKT  >= '2025-05-19'
+                            AND feilet.is_resendt = FALSE
+                            AND feilet.hendelsetype_navn in 
+                            ('NL_DIALOGMOTE_SVAR_MOTEBEHOV', 'NL_DIALOGMOTE_NYTT_TID_STED', 'NL_DIALOGMOTE_REFERAT')
+                            ORDER BY feilet.utsendt_forsok_tidspunkt ASC
+                            LIMIT 1000
+    """.trimIndent()
+
+    return connection.use { connection ->
+        connection.prepareStatement(queryStatement).use {
+            it.executeQuery().toList { toPUtsendtVarselFeilet() }
+        }
+    }
+}
+
 fun DatabaseInterface.fetchUtsendtDokDistVarselFeilet(): List<PUtsendtVarselFeilet> {
     val queryStatement = """SELECT *
                             FROM UTSENDING_VARSEL_FEILET feilet

--- a/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonProdusent.kt
+++ b/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonProdusent.kt
@@ -41,11 +41,11 @@ import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.toOppdaterKalenderav
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.response.nyoppgave.NyOppgaveErrorResponse
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.response.nyoppgave.NyOppgaveResponse
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.response.nyoppgave.NyoppgaveMutationStatus.NY_OPPGAVE_VELLYKKET
-import no.nav.syfo.utils.httpClient
+import no.nav.syfo.utils.httpClientWithRetry
 import org.slf4j.LoggerFactory
 
 open class ArbeidsgiverNotifikasjonProdusent(urlEnv: UrlEnv, private val azureAdTokenConsumer: AzureAdTokenConsumer) {
-    private val client = httpClient()
+    private val httpClientWithRetry = httpClientWithRetry()
     private val arbeidsgiverNotifikasjonProdusentBasepath = urlEnv.arbeidsgiverNotifikasjonProdusentApiUrl
     private val log = LoggerFactory.getLogger(ArbeidsgiverNotifikasjonProdusent::class.qualifiedName)
     private val scope = urlEnv.arbeidsgiverNotifikasjonProdusentApiScope
@@ -305,7 +305,7 @@ open class ArbeidsgiverNotifikasjonProdusent(urlEnv: UrlEnv, private val azureAd
         val requestBody = graphQuery?.let { NotificationAgRequest(it, variables) }
 
         try {
-            val response = client.post(arbeidsgiverNotifikasjonProdusentBasepath) {
+            val response = httpClientWithRetry.post(arbeidsgiverNotifikasjonProdusentBasepath) {
                 headers {
                     append(HttpHeaders.Accept, ContentType.Application.Json)
                     append(HttpHeaders.ContentType, ContentType.Application.Json)

--- a/src/main/kotlin/no/nav/syfo/service/MotebehovVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/MotebehovVarselService.kt
@@ -137,9 +137,16 @@ class MotebehovVarselService(
     }
 
     suspend fun resendVarselTilArbeidsgiverNotifikasjon(utsendtvarselFeilet: PUtsendtVarselFeilet): Boolean {
+        if (utsendtvarselFeilet.orgnummer == null || utsendtvarselFeilet.narmesteLederFnr == null) {
+            log.error(
+                "Skip resending arbeidsgivernotifikasjon varsel:" +
+                    " narmesteLederFnr or orgnummer is null for failedVarsel with uuid ${utsendtvarselFeilet.uuid}"
+            )
+            return false
+        }
         val notifikasjon = ArbeidsgiverNotifikasjonInput(
             UUID.randomUUID(),
-            utsendtvarselFeilet.orgnummer!!,
+            utsendtvarselFeilet.orgnummer,
             utsendtvarselFeilet.narmesteLederFnr,
             utsendtvarselFeilet.arbeidstakerFnr,
             ARBEIDSGIVERNOTIFIKASJON_OPPFOLGING_MERKELAPP,
@@ -151,7 +158,7 @@ class MotebehovVarselService(
             UUID.randomUUID().toString()
         )
         try {
-            senderFacade.sendTilArbeidsgiverNotifikasjon(notifikasjon = notifikasjon)
+            senderFacade.sendTilArbeidsgiverNotifikasjon(utsendtvarselFeilet, notifikasjon)
             return true
         } catch (e: Exception) {
             log.error(

--- a/src/main/kotlin/no/nav/syfo/service/SenderFacade.kt
+++ b/src/main/kotlin/no/nav/syfo/service/SenderFacade.kt
@@ -156,30 +156,30 @@ class SenderFacade(
     }
 
     suspend fun sendTilArbeidsgiverNotifikasjon(
-        varselHendelse: NarmesteLederHendelse,
-        varsel: ArbeidsgiverNotifikasjonInput,
+        varselHendelse: NarmesteLederHendelse? = null,
+        notifikasjon: ArbeidsgiverNotifikasjonInput,
     ) {
-        var isSendingSucceed = true
         try {
-            arbeidsgiverNotifikasjonService.sendNotifikasjon(varsel)
+            arbeidsgiverNotifikasjonService.sendNotifikasjon(notifikasjon)
+            if (varselHendelse != null) {
+                lagreUtsendtNarmesteLederVarsel(
+                    ARBEIDSGIVERNOTIFIKASJON,
+                    varselHendelse,
+                    notifikasjon.uuid.toString(),
+                    notifikasjon.merkelapp,
+                )
+            }
         } catch (e: Exception) {
             log.error("Error while sending varsel to ARBEIDSGIVERNOTIFIKASJON: ${e.message}")
-            isSendingSucceed = false
-            lagreIkkeUtsendtNarmesteLederVarsel(
-                kanal = ARBEIDSGIVERNOTIFIKASJON,
-                varselHendelse = varselHendelse,
-                eksternReferanse = varsel.uuid.toString(),
-                feilmelding = e.message,
-                merkelapp = varsel.merkelapp,
-            )
-        }
-        if (isSendingSucceed) {
-            lagreUtsendtNarmesteLederVarsel(
-                ARBEIDSGIVERNOTIFIKASJON,
-                varselHendelse,
-                varsel.uuid.toString(),
-                varsel.merkelapp,
-            )
+            if (varselHendelse != null) {
+                lagreIkkeUtsendtNarmesteLederVarsel(
+                    kanal = ARBEIDSGIVERNOTIFIKASJON,
+                    varselHendelse = varselHendelse,
+                    eksternReferanse = notifikasjon.uuid.toString(),
+                    feilmelding = e.message,
+                    merkelapp = notifikasjon.merkelapp,
+                )
+            }
         }
     }
 

--- a/src/test/kotlin/no/nav/syfo/job/ResendFailedVarslerJobTest.kt
+++ b/src/test/kotlin/no/nav/syfo/job/ResendFailedVarslerJobTest.kt
@@ -12,6 +12,7 @@ import no.nav.syfo.db.domain.PUtsendtVarselFeilet
 import no.nav.syfo.db.domain.toArbeidstakerHendelse
 import no.nav.syfo.db.fetchUtsendtBrukernotifikasjonVarselFeilet
 import no.nav.syfo.db.fetchUtsendtDokDistVarselFeilet
+import no.nav.syfo.db.setUtsendtVarselToFerdigstilt
 import no.nav.syfo.db.storeUtsendtVarsel
 import no.nav.syfo.db.storeUtsendtVarselFeilet
 import no.nav.syfo.service.DialogmoteInnkallingSykmeldtVarselService
@@ -279,6 +280,55 @@ class ResendFailedVarslerJobTest : DescribeSpec({
             val result = runBlocking { job.resendFailedArbeidsgivernotifikasjonVarsler() }
 
             result shouldBeEqualTo 1
+        }
+        it(
+            """Does not resends failed varsler to arbeidsgivernotifikasjoner for NL_DIALOGMOTE_SVAR_MOTEBEHOV,
+                when utsendtVarsel to DINE_SYKEMELDTE is fedigstilt
+            """.trimMargin()
+        ) {
+            val arbeidstakerFnr = "12121212121"
+            val narmesteLederFnr = "32121212121"
+            val orgnummer = "32143242"
+
+            val dialogmoteVarselFeilet = PUtsendtVarselFeilet(
+                uuid = UUID.randomUUID().toString(),
+                uuidEksternReferanse = UUID.randomUUID().toString(),
+                arbeidstakerFnr = arbeidstakerFnr,
+                orgnummer = orgnummer,
+                hendelsetypeNavn = "NL_DIALOGMOTE_SVAR_MOTEBEHOV",
+                kanal = "ARBEIDSGIVERNOTIFIKASJON",
+                arbeidsgivernotifikasjonMerkelapp = null,
+                journalpostId = null,
+                narmesteLederFnr = narmesteLederFnr,
+                brukernotifikasjonerMeldingType = null,
+                feilmelding = "noe galt skjedde",
+                utsendtForsokTidspunkt = LocalDateTime.now().minusHours(2),
+            )
+
+            val utsendtVarsel = PUtsendtVarsel(
+                uuid = UUID.randomUUID().toString(),
+                fnr = arbeidstakerFnr,
+                aktorId = null,
+                narmesteLederFnr = narmesteLederFnr,
+                orgnummer = orgnummer,
+                type = "NL_DIALOGMOTE_SVAR_MOTEBEHOV",
+                kanal = "DINE_SYKMELDTE",
+                utsendtTidspunkt = LocalDateTime.now(),
+                planlagtVarselId = null,
+                eksternReferanse = UUID.randomUUID().toString(),
+                ferdigstiltTidspunkt = null,
+                arbeidsgivernotifikasjonMerkelapp = null,
+                isForcedLetter = false,
+                journalpostId = null
+            )
+
+            embeddedDatabase.storeUtsendtVarselFeilet(dialogmoteVarselFeilet)
+            embeddedDatabase.storeUtsendtVarsel(utsendtVarsel)
+            embeddedDatabase.setUtsendtVarselToFerdigstilt(utsendtVarsel.eksternReferanse!!)
+
+            val result = runBlocking { job.resendFailedArbeidsgivernotifikasjonVarsler() }
+
+            result shouldBeEqualTo 0
         }
     }
 })

--- a/src/test/kotlin/no/nav/syfo/job/ResendFailedVarslerJobTest.kt
+++ b/src/test/kotlin/no/nav/syfo/job/ResendFailedVarslerJobTest.kt
@@ -234,35 +234,54 @@ class ResendFailedVarslerJobTest : DescribeSpec({
 
     describe("Resend arbeidsgivernotifikasjoner") {
         it(
-            """Resends failed varsler to arbeidsgivernotifikasjoner for NL_DIALOGMOTE_SVAR_MOTEBEHOV,
+            """Resends multiple failed varsler to arbeidsgivernotifikasjoner for NL_DIALOGMOTE_SVAR_MOTEBEHOV,
                 when utsendtVarsel to DINE_SYKEMELDTE is not fedigstilt
             """.trimMargin()
         ) {
-            val arbeidstakerFnr = "12121212121"
-            val narmesteLederFnr = "32121212121"
-            val orgnummer = "32143242"
+            val arbeidstakerFnr1 = "12121212121"
+            val narmesteLederFnr1 = "32121212121"
+            val orgnummer1 = "32143242"
 
-            val dialogmoteVarselFeilet = PUtsendtVarselFeilet(
+            val arbeidstakerFnr2 = "22121212121"
+            val narmesteLederFnr2 = "42121212121"
+            val orgnummer2 = "42143242"
+
+            val dialogmoteVarselFeilet1 = PUtsendtVarselFeilet(
                 uuid = UUID.randomUUID().toString(),
                 uuidEksternReferanse = UUID.randomUUID().toString(),
-                arbeidstakerFnr = arbeidstakerFnr,
-                orgnummer = orgnummer,
+                arbeidstakerFnr = arbeidstakerFnr1,
+                orgnummer = orgnummer1,
                 hendelsetypeNavn = "NL_DIALOGMOTE_SVAR_MOTEBEHOV",
                 kanal = "ARBEIDSGIVERNOTIFIKASJON",
                 arbeidsgivernotifikasjonMerkelapp = null,
                 journalpostId = null,
-                narmesteLederFnr = narmesteLederFnr,
+                narmesteLederFnr = narmesteLederFnr1,
                 brukernotifikasjonerMeldingType = null,
                 feilmelding = "noe galt skjedde",
                 utsendtForsokTidspunkt = LocalDateTime.now().minusHours(2),
             )
 
-            val utsendtVarsel = PUtsendtVarsel(
+            val dialogmoteVarselFeilet2 = PUtsendtVarselFeilet(
                 uuid = UUID.randomUUID().toString(),
-                fnr = arbeidstakerFnr,
+                uuidEksternReferanse = UUID.randomUUID().toString(),
+                arbeidstakerFnr = arbeidstakerFnr2,
+                orgnummer = orgnummer2,
+                hendelsetypeNavn = "NL_DIALOGMOTE_SVAR_MOTEBEHOV",
+                kanal = "ARBEIDSGIVERNOTIFIKASJON",
+                arbeidsgivernotifikasjonMerkelapp = null,
+                journalpostId = null,
+                narmesteLederFnr = narmesteLederFnr2,
+                brukernotifikasjonerMeldingType = null,
+                feilmelding = "noe galt skjedde",
+                utsendtForsokTidspunkt = LocalDateTime.now().minusHours(2),
+            )
+
+            val utsendtVarsel1 = PUtsendtVarsel(
+                uuid = UUID.randomUUID().toString(),
+                fnr = arbeidstakerFnr1,
                 aktorId = null,
-                narmesteLederFnr = narmesteLederFnr,
-                orgnummer = orgnummer,
+                narmesteLederFnr = narmesteLederFnr1,
+                orgnummer = orgnummer1,
                 type = "NL_DIALOGMOTE_SVAR_MOTEBEHOV",
                 kanal = "DINE_SYKMELDTE",
                 utsendtTidspunkt = LocalDateTime.now(),
@@ -274,12 +293,32 @@ class ResendFailedVarslerJobTest : DescribeSpec({
                 journalpostId = null
             )
 
-            embeddedDatabase.storeUtsendtVarselFeilet(dialogmoteVarselFeilet)
-            embeddedDatabase.storeUtsendtVarsel(utsendtVarsel)
+            val utsendtVarsel2 = PUtsendtVarsel(
+                uuid = UUID.randomUUID().toString(),
+                fnr = arbeidstakerFnr2,
+                aktorId = null,
+                narmesteLederFnr = narmesteLederFnr2,
+                orgnummer = orgnummer2,
+                type = "NL_DIALOGMOTE_SVAR_MOTEBEHOV",
+                kanal = "DINE_SYKMELDTE",
+                utsendtTidspunkt = LocalDateTime.now(),
+                planlagtVarselId = null,
+                eksternReferanse = UUID.randomUUID().toString(),
+                ferdigstiltTidspunkt = null,
+                arbeidsgivernotifikasjonMerkelapp = null,
+                isForcedLetter = false,
+                journalpostId = null
+            )
+
+            embeddedDatabase.storeUtsendtVarselFeilet(dialogmoteVarselFeilet1)
+            embeddedDatabase.storeUtsendtVarselFeilet(dialogmoteVarselFeilet2)
+
+            embeddedDatabase.storeUtsendtVarsel(utsendtVarsel1)
+            embeddedDatabase.storeUtsendtVarsel(utsendtVarsel2)
 
             val result = runBlocking { job.resendFailedArbeidsgivernotifikasjonVarsler() }
 
-            result shouldBeEqualTo 1
+            result shouldBeEqualTo 2
         }
         it(
             """Does not resends failed varsler to arbeidsgivernotifikasjoner for NL_DIALOGMOTE_SVAR_MOTEBEHOV,


### PR DESCRIPTION
Støtte for resending av arbeidsgivernotifikasjoner. Foreløpig bare for NL_DIALOGMOTE_SVAR_MOTEBEHOV.
La også til httpClientWithRetry i ArbeidsgiverNotifikasjonProdusentin i et forsøk på å unngå flere feil knyttet til timeout.