### PR TITLE
only fetch hendelsestype which is handled by resend job.

### DIFF
--- a/src/main/kotlin/no/nav/syfo/db/UtsendtVarselFeiletDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/db/UtsendtVarselFeiletDAO.kt
@@ -37,7 +37,7 @@ fun DatabaseInterface.fetchUtsendtArbeidsgivernotifikasjonVarselFeilet(): List<P
                             AND feilet.UTSENDT_FORSOK_TIDSPUNKT  >= '2025-05-19'
                             AND feilet.is_resendt = FALSE
                             AND feilet.hendelsetype_navn in 
-                            ('NL_DIALOGMOTE_SVAR_MOTEBEHOV', 'NL_DIALOGMOTE_NYTT_TID_STED', 'NL_DIALOGMOTE_REFERAT')
+                            ('NL_DIALOGMOTE_SVAR_MOTEBEHOV')
                             ORDER BY feilet.utsendt_forsok_tidspunkt ASC
                             LIMIT 1000
     """.trimIndent()

--- a/src/main/kotlin/no/nav/syfo/job/ResendFailedVarslerJob.kt
+++ b/src/main/kotlin/no/nav/syfo/job/ResendFailedVarslerJob.kt
@@ -113,7 +113,7 @@ class ResendFailedVarslerJob(
                 "NL_DIALOGMOTE_SVAR_MOTEBEHOV" -> tryResendArbeidsgivernotifikasjonMoteBehov(failedVarsel)
                 else -> {
                     log.warn("Not resending varsel for hendelsetypeNavn: ${failedVarsel.hendelsetypeNavn}")
-                    return 0
+                    return@map 0
                 }
             }
         }.sum()


### PR DESCRIPTION
And Fix bug which caused resendFailedArbeidsgivernotifikasjonVarsler to end early