### PR TITLE
ignore resend to deceased sykemeldt when getting statuscode 410

### DIFF
--- a/src/main/kotlin/no/nav/syfo/consumer/distribuerjournalpost/JournalpostdistribusjonConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/consumer/distribuerjournalpost/JournalpostdistribusjonConsumer.kt
@@ -82,6 +82,7 @@ class JournalpostdistribusjonConsumer(urlEnv: UrlEnv, private val azureAdTokenCo
             log.error("Network error while distributing journalpost $journalpostId: ${e.message}", e)
             throw JournalpostNetworkException("Network error distributing journalpost", uuid, journalpostId, e)
         } catch (e: Exception) {
+            if (e is JournalpostDistribusjonGoneException) throw e
             log.error("Exception while distributing journalpost $journalpostId: ${e.javaClass.name}: ${e.message}", e)
             throw JournalpostDistribusjonException("Failed to distribute journalpost", uuid, journalpostId, e)
         }

--- a/src/main/kotlin/no/nav/syfo/consumer/distribuerjournalpost/JournalpostdistribusjonConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/consumer/distribuerjournalpost/JournalpostdistribusjonConsumer.kt
@@ -11,6 +11,7 @@ import io.ktor.http.append
 import no.nav.syfo.UrlEnv
 import no.nav.syfo.auth.AzureAdTokenConsumer
 import no.nav.syfo.exceptions.JournalpostDistribusjonException
+import no.nav.syfo.exceptions.JournalpostDistribusjonGoneException
 import no.nav.syfo.exceptions.JournalpostNetworkException
 import no.nav.syfo.utils.httpClientWithRetry
 import org.slf4j.LoggerFactory
@@ -58,9 +59,14 @@ class JournalpostdistribusjonConsumer(urlEnv: UrlEnv, private val azureAdTokenCo
                     response.body()
                 }
                 HttpStatusCode.Gone -> {
-                    log.info("Document with UUID: $uuid and journalpostId: $journalpostId  Will never be sent. " +
-                            "The receiver is dead.")
-                    response.body()
+                    log.info(
+                        "Document with UUID: $uuid and journalpostId: $journalpostId  will never be sent. " +
+                            "The receiver is dead."
+                    )
+                    throw JournalpostDistribusjonGoneException(
+                        "Failed to distribution journalpostId $journalpostId. Resource is Gone. " +
+                            "Status: ${response.status}"
+                    )
                 }
                 else -> {
                     log.error(

--- a/src/main/kotlin/no/nav/syfo/consumer/distribuerjournalpost/JournalpostdistribusjonConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/consumer/distribuerjournalpost/JournalpostdistribusjonConsumer.kt
@@ -78,11 +78,12 @@ class JournalpostdistribusjonConsumer(urlEnv: UrlEnv, private val azureAdTokenCo
                     )
                 }
             }
+        } catch (e: JournalpostDistribusjonGoneException) {
+            throw e
         } catch (e: IOException) {
             log.error("Network error while distributing journalpost $journalpostId: ${e.message}", e)
             throw JournalpostNetworkException("Network error distributing journalpost", uuid, journalpostId, e)
         } catch (e: Exception) {
-            if (e is JournalpostDistribusjonGoneException) throw e
             log.error("Exception while distributing journalpost $journalpostId: ${e.javaClass.name}: ${e.message}", e)
             throw JournalpostDistribusjonException("Failed to distribute journalpost", uuid, journalpostId, e)
         }

--- a/src/main/kotlin/no/nav/syfo/consumer/distribuerjournalpost/JournalpostdistribusjonConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/consumer/distribuerjournalpost/JournalpostdistribusjonConsumer.kt
@@ -61,7 +61,7 @@ class JournalpostdistribusjonConsumer(urlEnv: UrlEnv, private val azureAdTokenCo
                 HttpStatusCode.Gone -> {
                     log.info(
                         "Document with UUID: $uuid and journalpostId: $journalpostId  will never be sent. " +
-                            "The receiver is dead."
+                            "The receiver is flagged as Gone."
                     )
                     throw JournalpostDistribusjonGoneException(
                         "Failed to distribution journalpostId $journalpostId. Resource is Gone. " +

--- a/src/main/kotlin/no/nav/syfo/consumer/distribuerjournalpost/JournalpostdistribusjonConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/consumer/distribuerjournalpost/JournalpostdistribusjonConsumer.kt
@@ -57,6 +57,11 @@ class JournalpostdistribusjonConsumer(urlEnv: UrlEnv, private val azureAdTokenCo
                     log.info("Document with UUID: $uuid and journalpostId: $journalpostId already sent to print")
                     response.body()
                 }
+                HttpStatusCode.Gone -> {
+                    log.info("Document with UUID: $uuid and journalpostId: $journalpostId  Will never be sent. " +
+                            "The receiver is dead.")
+                    response.body()
+                }
                 else -> {
                     log.error(
                         "Failed to send document with UUID: $uuid to print. " +

--- a/src/main/kotlin/no/nav/syfo/db/DatabaseUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/db/DatabaseUtil.kt
@@ -52,4 +52,5 @@ fun ResultSet.toPUtsendtVarselFeilet() = PUtsendtVarselFeilet(
     utsendtForsokTidspunkt = getTimestamp("utsendt_forsok_tidspunkt").toLocalDateTime(),
     isForcedLetter = getBoolean("is_forced_letter"),
     isResendt = getBoolean("is_resendt"),
+    resendExhausted = getBoolean("resend_exhausted"),
 )

--- a/src/main/kotlin/no/nav/syfo/db/UtsendtVarselFeiletDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/db/UtsendtVarselFeiletDAO.kt
@@ -11,6 +11,7 @@ fun DatabaseInterface.fetchUtsendtBrukernotifikasjonVarselFeilet(): List<PUtsend
                             WHERE feilet.KANAL = 'BRUKERNOTIFIKASJON'
                             AND feilet.UTSENDT_FORSOK_TIDSPUNKT  >= '2025-02-27'
                             AND feilet.is_resendt = FALSE
+                            AND feilet.resend_exhausted != TRUE
                             AND feilet.hendelsetype_navn in 
                             ('SM_DIALOGMOTE_SVAR_MOTEBEHOV', 'SM_DIALOGMOTE_INNKALT', 'SM_DIALOGMOTE_AVLYST', 'SM_DIALOGMOTE_NYTT_TID_STED', 'SM_MER_VEILEDNING')
                             AND feilet.UUID_EKSTERN_REFERANSE NOT IN (
@@ -36,6 +37,7 @@ fun DatabaseInterface.fetchUtsendtArbeidsgivernotifikasjonVarselFeilet(): List<P
                             WHERE feilet.KANAL = 'ARBEIDSGIVERNOTIFIKASJON'
                             AND feilet.UTSENDT_FORSOK_TIDSPUNKT  >= '2025-05-19'
                             AND feilet.is_resendt = FALSE
+                            AND feilet.resend_exhausted != TRUE
                             AND feilet.hendelsetype_navn in 
                             ('NL_DIALOGMOTE_SVAR_MOTEBEHOV')
                             ORDER BY feilet.utsendt_forsok_tidspunkt ASC
@@ -55,6 +57,7 @@ fun DatabaseInterface.fetchUtsendtDokDistVarselFeilet(): List<PUtsendtVarselFeil
                             WHERE feilet.KANAL = 'BREV'
                             AND feilet.UTSENDT_FORSOK_TIDSPUNKT  >= '2025-03-17'
                             AND feilet.is_resendt = FALSE
+                            AND feilet.resend_exhausted != TRUE
                             and feilet.journalpost_id != '0'
                             AND feilet.UUID_EKSTERN_REFERANSE NOT IN (
                                 SELECT EKSTERN_REF
@@ -89,7 +92,8 @@ fun DatabaseInterface.storeUtsendtVarselFeilet(varsel: PUtsendtVarselFeilet) {
         utsendt_forsok_tidspunkt,
         is_forced_letter,
         is_resendt,
-        resendt_tidspunkt) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        resendt_tidspunkt,
+        resend_exhausted) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     """.trimIndent()
 
     connection.use { connection ->
@@ -109,6 +113,7 @@ fun DatabaseInterface.storeUtsendtVarselFeilet(varsel: PUtsendtVarselFeilet) {
             it.setBoolean(13, varsel.isForcedLetter ?: false)
             it.setBoolean(14, varsel.isResendt ?: false)
             it.setTimestamp(15, null)
+            it.setBoolean(16, varsel.resendExhausted ?: false)
             it.executeUpdate()
         }
 
@@ -123,6 +128,20 @@ fun DatabaseInterface.updateUtsendtVarselFeiletToResendt(uuid: String) {
                    WHERE uuid = ?
     """.trimMargin()
 
+    return connection.use { connection ->
+        connection.prepareStatement(updateStatement).use {
+            it.setObject(1, UUID.fromString(uuid))
+            it.executeUpdate()
+        }
+        connection.commit()
+    }
+}
+
+fun DatabaseInterface.updateUtsendtVarselFeiletToResendExhausted(uuid: String) {
+    val updateStatement = """UPDATE UTSENDING_VARSEL_FEILET
+                   SET resend_exhausted = TRUE
+                   WHERE uuid = ?
+    """.trimMargin()
     return connection.use { connection ->
         connection.prepareStatement(updateStatement).use {
             it.setObject(1, UUID.fromString(uuid))

--- a/src/main/kotlin/no/nav/syfo/db/UtsendtVarselFeiletDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/db/UtsendtVarselFeiletDAO.kt
@@ -11,7 +11,7 @@ fun DatabaseInterface.fetchUtsendtBrukernotifikasjonVarselFeilet(): List<PUtsend
                             WHERE feilet.KANAL = 'BRUKERNOTIFIKASJON'
                             AND feilet.UTSENDT_FORSOK_TIDSPUNKT  >= '2025-02-27'
                             AND feilet.is_resendt = FALSE
-                            AND feilet.resend_exhausted != TRUE
+                            AND feilet.resend_exhausted IS NOT TRUE
                             AND feilet.hendelsetype_navn in 
                             ('SM_DIALOGMOTE_SVAR_MOTEBEHOV', 'SM_DIALOGMOTE_INNKALT', 'SM_DIALOGMOTE_AVLYST', 'SM_DIALOGMOTE_NYTT_TID_STED', 'SM_MER_VEILEDNING')
                             AND feilet.UUID_EKSTERN_REFERANSE NOT IN (
@@ -37,7 +37,7 @@ fun DatabaseInterface.fetchUtsendtArbeidsgivernotifikasjonVarselFeilet(): List<P
                             WHERE feilet.KANAL = 'ARBEIDSGIVERNOTIFIKASJON'
                             AND feilet.UTSENDT_FORSOK_TIDSPUNKT  >= '2025-05-19'
                             AND feilet.is_resendt = FALSE
-                            AND feilet.resend_exhausted != TRUE
+                            AND feilet.resend_exhausted IS NOT TRUE
                             AND feilet.hendelsetype_navn in 
                             ('NL_DIALOGMOTE_SVAR_MOTEBEHOV')
                             ORDER BY feilet.utsendt_forsok_tidspunkt ASC
@@ -57,7 +57,7 @@ fun DatabaseInterface.fetchUtsendtDokDistVarselFeilet(): List<PUtsendtVarselFeil
                             WHERE feilet.KANAL = 'BREV'
                             AND feilet.UTSENDT_FORSOK_TIDSPUNKT  >= '2025-03-17'
                             AND feilet.is_resendt = FALSE
-                            AND feilet.resend_exhausted != TRUE
+                            AND feilet.resend_exhausted IS NOT TRUE
                             and feilet.journalpost_id != '0'
                             AND feilet.UUID_EKSTERN_REFERANSE NOT IN (
                                 SELECT EKSTERN_REF

--- a/src/main/kotlin/no/nav/syfo/db/domain/PUtsendtVarselFeilet.kt
+++ b/src/main/kotlin/no/nav/syfo/db/domain/PUtsendtVarselFeilet.kt
@@ -19,6 +19,7 @@ data class PUtsendtVarselFeilet(
     val utsendtForsokTidspunkt: LocalDateTime,
     val isForcedLetter: Boolean? = false,
     val isResendt: Boolean? = false,
+    val resendExhausted: Boolean? = null,
 )
 
 fun PUtsendtVarselFeilet.toArbeidstakerHendelse(): ArbeidstakerHendelse {

--- a/src/main/kotlin/no/nav/syfo/exceptions/CustomExceptions.kt
+++ b/src/main/kotlin/no/nav/syfo/exceptions/CustomExceptions.kt
@@ -28,6 +28,13 @@ class JournalpostDistribusjonException(
     cause: Throwable? = null
 ) : Exception(message, cause)
 
+class JournalpostDistribusjonGoneException(
+    message: String,
+    val uuid: String? = null,
+    val journalpostId: String? = null,
+    cause: Throwable? = null
+) : Exception(message, cause)
+
 class JournalpostNetworkException(
     message: String,
     val uuid: String,

--- a/src/main/kotlin/no/nav/syfo/job/ResendFailedVarslerJob.kt
+++ b/src/main/kotlin/no/nav/syfo/job/ResendFailedVarslerJob.kt
@@ -16,6 +16,7 @@ import no.nav.syfo.service.MerVeiledningVarselService
 import no.nav.syfo.service.MotebehovVarselService
 import no.nav.syfo.service.SenderFacade
 import org.slf4j.LoggerFactory
+import java.util.UUID
 
 class ResendFailedVarslerJob(
     private val db: DatabaseInterface,
@@ -153,7 +154,7 @@ class ResendFailedVarslerJob(
                 varselHendelse = varselHendelse,
                 journalpostId = failedVarsel.journalpostId,
                 distribusjonsType = HendelseType.valueOf(failedVarsel.hendelsetypeNavn).toDistribusjonsType(),
-                storeFailedUtsending = false,
+                failedUtsendingUUID = UUID.fromString(failedVarsel.uuid)
             )
             if (isResendt) {
                 db.updateUtsendtVarselFeiletToResendt(failedVarsel.uuid)

--- a/src/main/kotlin/no/nav/syfo/service/SenderFacade.kt
+++ b/src/main/kotlin/no/nav/syfo/service/SenderFacade.kt
@@ -405,6 +405,7 @@ class SenderFacade(
             when (e) {
                 is JournalpostDistribusjonGoneException -> {
                     log.warn("Error while sending brev til fysisk print: ${e.message}")
+                    log.info("Trying to set UtsentVarselFeilet to resendExhausted for $uuid")
                     database.updateUtsendtVarselFeiletToResendExhausted(uuid.toString())
                 }
 

--- a/src/main/kotlin/no/nav/syfo/service/SenderFacade.kt
+++ b/src/main/kotlin/no/nav/syfo/service/SenderFacade.kt
@@ -404,13 +404,14 @@ class SenderFacade(
                     brukernotifikasjonerMeldingType = null,
                     isForcedLetter = false,
                 )
-                when (e) {
-                    is JournalpostDistribusjonGoneException -> {
-                        log.warn("Error while sending brev til fysisk print: ${e.message}")
-                        database.updateUtsendtVarselFeiletToResendExhausted(uuid.toString())
-                    }
-                    else -> log.error("Error while sending brev til fysisk print: ${e.message}")
+            }
+            when (e) {
+                is JournalpostDistribusjonGoneException -> {
+                    log.warn("Error while sending brev til fysisk print: ${e.message}")
+                    database.updateUtsendtVarselFeiletToResendExhausted(uuid.toString())
                 }
+
+                else -> log.error("Error while sending brev til fysisk print: ${e.message}")
             }
         }
         if (isSendingSucceed) {

--- a/src/main/kotlin/no/nav/syfo/service/SenderFacade.kt
+++ b/src/main/kotlin/no/nav/syfo/service/SenderFacade.kt
@@ -405,7 +405,6 @@ class SenderFacade(
             when (e) {
                 is JournalpostDistribusjonGoneException -> {
                     log.warn("Error while sending brev til fysisk print: ${e.message}")
-                    log.info("Trying to set UtsentVarselFeilet to resendExhausted for $uuid")
                     database.updateUtsendtVarselFeiletToResendExhausted(uuid.toString())
                 }
 

--- a/src/main/resources/db/migration/V40__Add_column_resend_exhausted_to_utsendt_varsel_feilet.sql
+++ b/src/main/resources/db/migration/V40__Add_column_resend_exhausted_to_utsendt_varsel_feilet.sql
@@ -1,0 +1,3 @@
+ALTER TABLE utsending_varsel_feilet
+    ADD COLUMN if not exists resend_exhausted BOOLEAN DEFAULT null;
+

--- a/src/main/resources/localEnvApp.json
+++ b/src/main/resources/localEnvApp.json
@@ -28,7 +28,7 @@
     "narmestelederUrl": "http://localhost:9097",
     "narmestelederScope": "narmestelederScope",
     "baseUrlDineSykmeldte": "http://dine-sykmeldte:9099",
-    "dokdistfordelingUrl": "http://dokdistfordelingUrl:9099",
+    "dokdistfordelingUrl": "http://localhost:9099",
     "dokdistfordelingScope": "dokdistfordelingScope",
     "istilgangskontrollUrl": "http://istilgangskontrollUrl:9099",
     "istilgangskontrollScope": "istilgangskontrollScope",

--- a/src/test/kotlin/no/nav/syfo/consumer/JournalpostdistribusjonConsumerSpec.kt
+++ b/src/test/kotlin/no/nav/syfo/consumer/JournalpostdistribusjonConsumerSpec.kt
@@ -1,0 +1,52 @@
+package no.nav.syfo.consumer
+
+import com.benasher44.uuid.Uuid
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import no.nav.syfo.auth.AzureAdTokenConsumer
+import no.nav.syfo.consumer.distribuerjournalpost.DistibusjonsType
+import no.nav.syfo.consumer.distribuerjournalpost.JournalpostdistribusjonConsumer
+import no.nav.syfo.exceptions.JournalpostDistribusjonGoneException
+import no.nav.syfo.getTestEnv
+import no.nav.syfo.testutil.mocks.MockServers
+import org.amshove.kluent.shouldBeEqualTo
+
+class JournalpostdistribusjonConsumerSpec : DescribeSpec({
+    val testEnv = getTestEnv()
+    val mockServers = MockServers(testEnv.urlEnv, testEnv.authEnv)
+    val azureAdMockServer = mockServers.mockAADServer()
+    val journalpostDistribusionServer = mockServers.mockJournalpostdistribusjonServer()
+
+    val azureAdConsumer = AzureAdTokenConsumer(testEnv.authEnv)
+    val consumer = JournalpostdistribusjonConsumer(testEnv.urlEnv, azureAdConsumer)
+
+    beforeSpec {
+        azureAdMockServer.start()
+        journalpostDistribusionServer.start()
+    }
+
+    afterSpec {
+        azureAdMockServer.stop(1L, 10L)
+        journalpostDistribusionServer.stop(1L, 10L)
+    }
+
+    describe("JournalpostdistribusjonConsumerSpec") {
+        it("Response with bestillingsId for OK journalpost") {
+            val response =
+                consumer.distribuerJournalpost("100", Uuid.randomUUID().toString(), DistibusjonsType.ANNET, true)
+            response.bestillingsId shouldBeEqualTo "1000"
+        }
+
+        it("Response with bestillingsId for conflict on journalpost") {
+            val response =
+                consumer.distribuerJournalpost("CONFLICT", Uuid.randomUUID().toString(), DistibusjonsType.ANNET, true)
+            response.bestillingsId shouldBeEqualTo "1000"
+        }
+
+        it("Throw exception when distribuerJournalpost respondes with 410 status") {
+            shouldThrow<JournalpostDistribusjonGoneException> {
+                consumer.distribuerJournalpost("GONE", Uuid.randomUUID().toString(), DistibusjonsType.ANNET, true)
+            }
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/syfo/job/ResendFailedVarslerJobTest.kt
+++ b/src/test/kotlin/no/nav/syfo/job/ResendFailedVarslerJobTest.kt
@@ -214,7 +214,7 @@ class ResendFailedVarslerJobTest : DescribeSpec({
                     varselHendelse = merOppfolgingVarselFeilet.toArbeidstakerHendelse(),
                     journalpostId = merOppfolgingVarselFeilet.journalpostId!!,
                     distribusjonsType = DistibusjonsType.VIKTIG,
-                    storeFailedUtsending = false,
+                    failedUtsendingUUID = UUID.fromString(merOppfolgingVarselFeilet.uuid),
                 )
             }
             coVerify(exactly = 1) {
@@ -223,7 +223,7 @@ class ResendFailedVarslerJobTest : DescribeSpec({
                     varselHendelse = dialogmoteVarselFeilet.toArbeidstakerHendelse(),
                     journalpostId = dialogmoteVarselFeilet.journalpostId!!,
                     distribusjonsType = DistibusjonsType.ANNET,
-                    storeFailedUtsending = false,
+                    failedUtsendingUUID = UUID.fromString(dialogmoteVarselFeilet.uuid),
                 )
             }
 

--- a/src/test/kotlin/no/nav/syfo/service/SenderFacadeSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/service/SenderFacadeSpek.kt
@@ -2,6 +2,7 @@ package no.nav.syfo.service
 
 import io.kotest.core.spec.style.DescribeSpec
 import io.mockk.clearAllMocks
+import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.verify
@@ -9,15 +10,21 @@ import no.nav.syfo.db.arbeidstakerAktorId1
 import no.nav.syfo.db.domain.Kanal
 import no.nav.syfo.db.domain.PUtsendtVarsel
 import no.nav.syfo.db.domain.VarselType
+import no.nav.syfo.db.fetchUtsendtVarselFeiletByFnr
 import no.nav.syfo.db.setUtsendtVarselToFerdigstilt
 import no.nav.syfo.db.storeUtsendtVarsel
 import no.nav.syfo.domain.PersonIdent
+import no.nav.syfo.exceptions.JournalpostDistribusjonGoneException
+import no.nav.syfo.kafka.consumers.varselbus.domain.ArbeidstakerHendelse
+import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType
 import no.nav.syfo.kafka.producers.dinesykmeldte.DineSykmeldteHendelseKafkaProducer
 import no.nav.syfo.kafka.producers.dittsykefravaer.DittSykefravaerMeldingKafkaProducer
 import no.nav.syfo.planner.arbeidstakerFnr1
 import no.nav.syfo.testutil.EmbeddedDatabase
 import java.time.LocalDateTime
-import java.util.*
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class SenderFacadeSpek : DescribeSpec({
     describe("SenderFacadeSpek") {
@@ -136,6 +143,31 @@ class SenderFacadeSpek : DescribeSpec({
             verify(exactly = 0) { dineSykmeldteHendelseKafkaProducer.ferdigstillVarsel(any()) }
             verify(exactly = 0) { brukernotifikasjonerService.ferdigstillVarsel(any()) }
             verify(exactly = 0) { dittSykefravaerMeldingKafkaProducer.ferdigstillMelding(any(), any()) }
+        }
+
+        it("Set resend_avsluttet from sendBrevTilFysiskPrint when archive rejects with 410") {
+            val journalpostId = UUID.randomUUID().toString()
+            val uuid = UUID.randomUUID().toString()
+            val arbeidstakerHendelse = ArbeidstakerHendelse(
+                type = HendelseType.SM_DIALOGMOTE_INNKALT,
+                ferdigstill = true,
+                arbeidstakerFnr = arbeidstakerFnr1,
+                data = emptyMap<String, Any>(),
+                orgnummer = null,
+            )
+
+            coEvery {
+                fysiskBrevUtsendingService.sendBrev(
+                    eq(uuid),
+                    journalpostId = eq(journalpostId),
+                    any(),
+                    any()
+                )
+            } throws JournalpostDistribusjonGoneException("Recipient is Gone", uuid, journalpostId)
+            senderFacade.sendBrevTilFysiskPrint(uuid, arbeidstakerHendelse, journalpostId)
+            val feiletUtsending = embeddedDatabase.fetchUtsendtVarselFeiletByFnr(arbeidstakerFnr1)
+            assertEquals(1, feiletUtsending.size)
+            assertTrue(feiletUtsending.first().resendExhausted!!)
         }
     }
 })

--- a/src/test/kotlin/no/nav/syfo/testutil/mocks/MockServers.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/mocks/MockServers.kt
@@ -85,6 +85,28 @@ class MockServers(val urlEnv: UrlEnv, val authEnv: AuthEnv) {
         }
     }
 
+    @Suppress("MaxLineLength")
+    fun mockJournalpostdistribusjonServer(): EmbeddedServer<NettyApplicationEngine, NettyApplicationEngine.Configuration> {
+        return mockServer(urlEnv.dokdistfordelingUrl) {
+            val bestillingsId = """
+                {
+                  "bestillingsId": "1000"
+                }
+            """
+            post("/rest/v1/distribuerjournalpost") {
+                val body = call.receiveText()
+                if (body.contains("GONE")) {
+                    call.response.status(HttpStatusCode(410, "Recipient is gone"))
+                } else if (body.contains("CONFLICT")) {
+                    call.response.status(HttpStatusCode(410, "Recipient is gone"))
+                    call.respondText(bestillingsId, ContentType.Application.Json, HttpStatusCode.Conflict)
+                } else {
+                    call.respondText(bestillingsId, ContentType.Application.Json, HttpStatusCode.OK)
+                }
+            }
+        }
+    }
+
     fun mockServer(
         url: String,
         route: Route.() -> Unit


### PR DESCRIPTION
Catch 410 response from distribuerJournalpost due to deceased recipient.
Throw throw custom exception and use that to determine that we should
write to utsending_varsel_feilet with field resend_exhausted as true.

resend_exhausted != true is added to condition when fetching items we
will try to resend.