### PR TITLE
Oppdaterer scope for dokdistfordeling

### DIFF
--- a/nais/nais-dev.yaml
+++ b/nais/nais-dev.yaml
@@ -138,7 +138,7 @@ spec:
     - name: DOKDIST_FORDELING_URL
       value: https://dokdistfordeling-q1.dev-fss-pub.nais.io
     - name: DOKDIST_FORDELING_SCOPE
-      value: api://dev-fss.teamdokumenthandtering.saf-q1/.default
+      value: api://dev-fss.teamdokumenthandtering.dokdistfordeling-q1/.default
     - name: ISTILGANGSKONTROLL_URL
       value: http://istilgangskontroll.teamsykefravr
     - name: ISTILGANGSKONTROLL_SCOPE

--- a/nais/nais-prod.yaml
+++ b/nais/nais-prod.yaml
@@ -141,7 +141,7 @@ spec:
     - name: DOKDIST_FORDELING_URL
       value: https://dokdistfordeling.prod-fss-pub.nais.io
     - name: DOKDIST_FORDELING_SCOPE
-      value: api://prod-fss.teamdokumenthandtering.saf/.default
+      value: api://prod-fss.teamdokumenthandtering.dokdistfordeling/.default
     - name: ISTILGANGSKONTROLL_URL
       value: http://istilgangskontroll.teamsykefravr
     - name: ISTILGANGSKONTROLL_SCOPE


### PR DESCRIPTION
* Fra saf-scope til dokdistfordeling-scope for dokdistfordeling integrasjonen

> Vi gjør endringer på autentisering i dokdistfordeling, for å sørge for at autentisering med EntraID er implementert som tiltenkt. Pr i dag kalles distribuerJournalpost med EntraID tokens scopet mot SAF, hvor dokdistfordeling proxyer dette tokenet videre i kall til SAF. Vi ønsker på sikt å endre dette til av dokdistfordeling kun kan kalles med tokens som er scopet mot seg selv. Steg 1 av denne endringen innføres nå, hvor dokdistfordeling i en overgangsperiode vil akseptere tokens med enten saf- eller dokdistfordeling-scope. Dette innebærer at konsumenter ikke trenger å gjøre noe umiddelbart, men på sikt (helst så snart som mulig) må endre scope for tokenet de kaller dokdistfordeling med. Vi kommer til å bistå konsumenter med denne endringen. Liste med pre-autentiserte applikasjoner er populert for hvert miljø basert på kall mot distribuertJournalpost siste 7 dager.

Har dobbeltsjekket dokdistfordeling config og `prod-gcp:team-esyfo:esyfovarsel` ligger inne i dokdistfordeling sin preauthorized liste. Så dere skal ikke merke noe. 🙇