### PR TITLE
feat(varselbus): legg til arbeidsgiver varselhendelse

### DIFF
--- a/src/main/kotlin/no/nav/syfo/BootstrapApplication.kt
+++ b/src/main/kotlin/no/nav/syfo/BootstrapApplication.kt
@@ -47,6 +47,7 @@ import no.nav.syfo.producer.arbeidsgivernotifikasjon.ArbeidsgiverNotifikasjonPro
 import no.nav.syfo.service.AccessControlService
 import no.nav.syfo.service.AktivitetspliktForhandsvarselService
 import no.nav.syfo.service.ArbeidsgiverNotifikasjonService
+import no.nav.syfo.service.ArbeidsgiverVarselService
 import no.nav.syfo.service.ArbeidsuforhetForhandsvarselService
 import no.nav.syfo.service.BrukernotifikasjonerService
 import no.nav.syfo.service.DialogmoteInnkallingNarmesteLederVarselService
@@ -152,6 +153,7 @@ fun setModule(env: Environment): Application.() -> Unit =
                 fysiskBrevUtsendingService,
                 database,
             )
+        val arbeidsgiverVarselService = ArbeidsgiverVarselService()
         val motebehovVarselService =
             MotebehovVarselService(
                 senderFacade,
@@ -239,6 +241,7 @@ fun setModule(env: Environment): Application.() -> Unit =
         val varselBusService =
             VarselBusService(
                 senderFacade,
+                arbeidsgiverVarselService,
                 motebehovVarselService,
                 oppfolgingsplanVarselService,
                 nyOppfolgingsplanVarselService,

--- a/src/main/kotlin/no/nav/syfo/kafka/consumers/varselbus/domain/EsyfovarselHendelse.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/consumers/varselbus/domain/EsyfovarselHendelse.kt
@@ -8,6 +8,12 @@ import java.time.LocalDateTime
 
 private val objectMapper = createObjectMapper()
 
+/**
+ * Denne annotasjonen vil legge til et felt "@type" i JSON-representasjonen av EsyfovarselHendelse,
+ * som vil inneholde navnet på den konkrete implementasjonen (for eksempel NarmesteLederHendelse).
+ * Den vil også brukes ved deserialisering fra json til object,
+ * så vi får en NarmesteLederHendelse kun med objectMapper.readValue(hendelseAsJson).
+ */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME)
 sealed interface EsyfovarselHendelse : Serializable {
     val type: HendelseType

--- a/src/main/kotlin/no/nav/syfo/kafka/consumers/varselbus/domain/EsyfovarselHendelse.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/consumers/varselbus/domain/EsyfovarselHendelse.kt
@@ -94,6 +94,7 @@ data class VarselDataDialogmoteSvar(
  * Forskjellige typer hendelser som kan sendes til esyfovarsel.
  * "SM_" forkortelse indikerer at det sendes til sykmeldt
  * "NL_" forkortelse indikerer at det sendes til nærmeste leder
+ * "AG_" forkortelse indikerer at det sendes til arbeidsgiver (virksomheten)
  */
 enum class HendelseType {
     AG_VARSEL_ALTINN_RESSURS,

--- a/src/main/kotlin/no/nav/syfo/kafka/consumers/varselbus/domain/EsyfovarselHendelse.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/consumers/varselbus/domain/EsyfovarselHendelse.kt
@@ -32,12 +32,29 @@ data class ArbeidstakerHendelse(
     val orgnummer: String?,
 ) : EsyfovarselHendelse
 
+data class ArbeidsgiverHendelse(
+    override val type: HendelseType,
+    override val ferdigstill: Boolean?,
+    override var data: Any?,
+    val orgnummer: String,
+    /** Altinn 3 ressurs-id, for eksempel nav_syfo_dialogmote. */
+    val ressursId: String,
+    val ressursUrl: String,
+) : EsyfovarselHendelse
+
 data class VarselData(
     val journalpost: VarselDataJournalpost? = null,
     val narmesteLeder: VarselDataNarmesteLeder? = null,
     val motetidspunkt: VarselDataMotetidspunkt? = null,
     val aktivitetskrav: VarselDataAktivitetskrav? = null,
     val dialogmoteSvar: VarselDataDialogmoteSvar? = null,
+    val notifikasjonInnhold: VarselDataNotifikasjonInnhold? = null,
+)
+
+data class VarselDataNotifikasjonInnhold(
+    val epostTittel: String,
+    val epostBody: String,
+    val smsTekst: String,
 )
 
 data class VarselDataJournalpost(
@@ -79,6 +96,7 @@ data class VarselDataDialogmoteSvar(
  * "NL_" forkortelse indikerer at det sendes til nærmeste leder
  */
 enum class HendelseType {
+    AG_VARSEL_ALTINN_RESSURS,
     NL_OPPFOLGINGSPLAN_SENDT_TIL_GODKJENNING,
     SM_OPPFOLGINGSPLAN_SENDT_TIL_GODKJENNING,
     NL_DIALOGMOTE_SVAR_MOTEBEHOV,
@@ -139,6 +157,8 @@ fun Any.toVarselData(): VarselData =
 
 fun EsyfovarselHendelse.isArbeidstakerHendelse(): Boolean = this is ArbeidstakerHendelse
 
+fun EsyfovarselHendelse.isArbeidsgiverHendelse(): Boolean = this is ArbeidsgiverHendelse
+
 fun EsyfovarselHendelse.toNarmestelederHendelse(): NarmesteLederHendelse =
     if (this is NarmesteLederHendelse) {
         this
@@ -153,7 +173,21 @@ fun EsyfovarselHendelse.toArbeidstakerHendelse(): ArbeidstakerHendelse =
         throw IllegalArgumentException("Wrong type of EsyfovarselHendelse, should be of type ArbeidstakerHendelse")
     }
 
-fun EsyfovarselHendelse.skalFerdigstilles() = ferdigstill ?: false
+fun EsyfovarselHendelse.toArbeidsgiverHendelse(): ArbeidsgiverHendelse =
+    if (this is ArbeidsgiverHendelse) {
+        this
+    } else {
+        throw IllegalArgumentException("Wrong type of EsyfovarselHendelse, should be of type ArbeidsgiverHendelse")
+    }
+
+fun EsyfovarselHendelse.skalFerdigstilles(): Boolean =
+    when (this) {
+        is ArbeidstakerHendelse,
+        is NarmesteLederHendelse,
+        -> ferdigstill ?: false
+        // Arbeidsgiverhendelser i V1 skal ikke ferdigstilles via eksisterende arbeidstaker/narmeste-leder-spor.
+        is ArbeidsgiverHendelse -> false
+    }
 
 fun HendelseType.isAktivitetspliktType() = this == HendelseType.SM_AKTIVITETSPLIKT
 

--- a/src/main/kotlin/no/nav/syfo/kafka/consumers/varselbus/domain/EsyfovarselHendelse.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/consumers/varselbus/domain/EsyfovarselHendelse.kt
@@ -32,10 +32,13 @@ data class ArbeidstakerHendelse(
     val orgnummer: String?,
 ) : EsyfovarselHendelse
 
-data class ArbeidsgiverHendelse(
+data class ArbeidsgiverNotifikasjonTilAltinnRessursHendelse(
     override val type: HendelseType,
     override val ferdigstill: Boolean?,
     override var data: Any?,
+    val arbeidstakerFnr: String? = null,
+    val eksternReferanseId: String,
+    val kilde: String,
     val orgnummer: String,
     /** Altinn 3 ressurs-id, for eksempel nav_syfo_dialogmote. */
     val ressursId: String,
@@ -158,7 +161,7 @@ fun Any.toVarselData(): VarselData =
 
 fun EsyfovarselHendelse.isArbeidstakerHendelse(): Boolean = this is ArbeidstakerHendelse
 
-fun EsyfovarselHendelse.isArbeidsgiverHendelse(): Boolean = this is ArbeidsgiverHendelse
+fun EsyfovarselHendelse.isArbeidsgiverHendelse(): Boolean = this is ArbeidsgiverNotifikasjonTilAltinnRessursHendelse
 
 fun EsyfovarselHendelse.toNarmestelederHendelse(): NarmesteLederHendelse =
     if (this is NarmesteLederHendelse) {
@@ -174,8 +177,8 @@ fun EsyfovarselHendelse.toArbeidstakerHendelse(): ArbeidstakerHendelse =
         throw IllegalArgumentException("Wrong type of EsyfovarselHendelse, should be of type ArbeidstakerHendelse")
     }
 
-fun EsyfovarselHendelse.toArbeidsgiverHendelse(): ArbeidsgiverHendelse =
-    if (this is ArbeidsgiverHendelse) {
+fun EsyfovarselHendelse.toArbeidsgiverNotifikasjonTilAltinnRessursHendelse(): ArbeidsgiverNotifikasjonTilAltinnRessursHendelse =
+    if (this is ArbeidsgiverNotifikasjonTilAltinnRessursHendelse) {
         this
     } else {
         throw IllegalArgumentException("Wrong type of EsyfovarselHendelse, should be of type ArbeidsgiverHendelse")
@@ -185,9 +188,8 @@ fun EsyfovarselHendelse.skalFerdigstilles(): Boolean =
     when (this) {
         is ArbeidstakerHendelse,
         is NarmesteLederHendelse,
+        is ArbeidsgiverNotifikasjonTilAltinnRessursHendelse,
         -> ferdigstill ?: false
-        // Arbeidsgiverhendelser i V1 skal ikke ferdigstilles via eksisterende arbeidstaker/narmeste-leder-spor.
-        is ArbeidsgiverHendelse -> false
     }
 
 fun HendelseType.isAktivitetspliktType() = this == HendelseType.SM_AKTIVITETSPLIKT

--- a/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverVarselService.kt
@@ -1,7 +1,7 @@
 package no.nav.syfo.service
 
 import com.fasterxml.jackson.databind.JsonMappingException
-import no.nav.syfo.kafka.consumers.varselbus.domain.ArbeidsgiverHendelse
+import no.nav.syfo.kafka.consumers.varselbus.domain.ArbeidsgiverNotifikasjonTilAltinnRessursHendelse
 import no.nav.syfo.kafka.consumers.varselbus.domain.toVarselData
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -9,7 +9,7 @@ import org.slf4j.LoggerFactory
 class ArbeidsgiverVarselService {
     private val log: Logger = LoggerFactory.getLogger(ArbeidsgiverVarselService::class.qualifiedName)
 
-    suspend fun sendVarselTilArbeidsgiver(hendelse: ArbeidsgiverHendelse) {
+    suspend fun sendVarselTilArbeidsgiver(hendelse: ArbeidsgiverNotifikasjonTilAltinnRessursHendelse) {
         val data =
             requireNotNull(hendelse.data) {
                 "ArbeidsgiverHendelse mangler feltet: data"

--- a/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverVarselService.kt
@@ -23,12 +23,11 @@ class ArbeidsgiverVarselService {
                     hendelse.type,
                     hendelse.orgnummer,
                     hendelse.ressursId,
-                    exception,
+                    exception.toVarselDataPath(),
                 )
             }.getOrElse { exception ->
                 throw IllegalArgumentException(
                     "ArbeidsgiverHendelse har ugyldig format i feltet: ${exception.toVarselDataPath()}",
-                    exception,
                 )
             }
         val notifikasjonInnhold =

--- a/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverVarselService.kt
@@ -1,0 +1,73 @@
+package no.nav.syfo.service
+
+import com.fasterxml.jackson.databind.JsonMappingException
+import no.nav.syfo.kafka.consumers.varselbus.domain.ArbeidsgiverHendelse
+import no.nav.syfo.kafka.consumers.varselbus.domain.toVarselData
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class ArbeidsgiverVarselService {
+    private val log: Logger = LoggerFactory.getLogger(ArbeidsgiverVarselService::class.qualifiedName)
+
+    suspend fun sendVarselTilArbeidsgiver(hendelse: ArbeidsgiverHendelse) {
+        val data =
+            requireNotNull(hendelse.data) {
+                "ArbeidsgiverHendelse mangler feltet: data"
+            }
+        val varselData =
+            runCatching {
+                data.toVarselData()
+            }.onFailure { exception ->
+                log.warn(
+                    "ArbeidsgiverVarselService stub klarte ikke å parse varselData for type={}, orgnummer={}, ressursId={}",
+                    hendelse.type,
+                    hendelse.orgnummer,
+                    hendelse.ressursId,
+                    exception,
+                )
+            }.getOrElse { exception ->
+                throw IllegalArgumentException(
+                    "ArbeidsgiverHendelse har ugyldig format i feltet: ${exception.toVarselDataPath()}",
+                    exception,
+                )
+            }
+        val notifikasjonInnhold =
+            requireNotNull(varselData.notifikasjonInnhold) {
+                "ArbeidsgiverHendelse mangler feltet: data.notifikasjonInnhold"
+            }
+        with(notifikasjonInnhold) {
+            log.info(
+                "ArbeidsgiverVarselService stub kalt: type={}, orgnummer={}, ressursId={}, ressursUrl={}, harEpostTittel={}, epostTittelLengde={}, harEpostBody={}, epostBodyLengde={}, harSmsTekst={}, smsTekstLengde={}",
+                hendelse.type,
+                hendelse.orgnummer,
+                hendelse.ressursId,
+                hendelse.ressursUrl,
+                epostTittel.isNotBlank(),
+                epostTittel.length,
+                epostBody.isNotBlank(),
+                epostBody.length,
+                smsTekst.isNotBlank(),
+                smsTekst.length,
+            )
+        }
+    }
+}
+
+private fun Throwable.toVarselDataPath(): String {
+    val mappingPath =
+        (this as? JsonMappingException)
+            ?.path
+            ?.let { path ->
+                path.joinToString(".") { reference ->
+                    reference.fieldName
+                        ?: reference.index
+                            .takeIf { it >= 0 }
+                            ?.let { "[$it]" }
+                            .orEmpty()
+                }
+            }
+    if (mappingPath.isNullOrBlank()) {
+        return "data"
+    }
+    return "data.$mappingPath"
+}

--- a/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverVarselService.kt
@@ -36,11 +36,13 @@ class ArbeidsgiverVarselService {
             }
         with(notifikasjonInnhold) {
             log.info(
-                "ArbeidsgiverVarselService stub kalt: type={}, orgnummer={}, ressursId={}, ressursUrl={}, harEpostTittel={}, epostTittelLengde={}, harEpostBody={}, epostBodyLengde={}, harSmsTekst={}, smsTekstLengde={}",
+                "ArbeidsgiverVarselService stub kalt: type={}, orgnummer={}, kilde={}, ressursId={}, ressursUrl={}, eksternRefereanseId={}, harEpostTittel={}, epostTittelLengde={}, harEpostBody={}, epostBodyLengde={}, harSmsTekst={}, smsTekstLengde={}",
                 hendelse.type,
                 hendelse.orgnummer,
+                hendelse.kilde,
                 hendelse.ressursId,
                 hendelse.ressursUrl,
+                hendelse.eksternReferanseId,
                 epostTittel.isNotBlank(),
                 epostTittel.length,
                 epostBody.isNotBlank(),

--- a/src/main/kotlin/no/nav/syfo/service/VarselBusService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/VarselBusService.kt
@@ -30,7 +30,7 @@ import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType.SM_VEDTAK_FRISK
 import no.nav.syfo.kafka.consumers.varselbus.domain.isArbeidsgiverHendelse
 import no.nav.syfo.kafka.consumers.varselbus.domain.isArbeidstakerHendelse
 import no.nav.syfo.kafka.consumers.varselbus.domain.skalFerdigstilles
-import no.nav.syfo.kafka.consumers.varselbus.domain.toArbeidsgiverHendelse
+import no.nav.syfo.kafka.consumers.varselbus.domain.toArbeidsgiverNotifikasjonTilAltinnRessursHendelse
 import no.nav.syfo.kafka.consumers.varselbus.domain.toArbeidstakerHendelse
 import no.nav.syfo.kafka.consumers.varselbus.domain.toNarmestelederHendelse
 import no.nav.syfo.service.microfrontend.MikrofrontendService
@@ -62,7 +62,7 @@ class VarselBusService(
             when (varselHendelse.type) {
                 AG_VARSEL_ALTINN_RESSURS ->
                     arbeidsgiverVarselService.sendVarselTilArbeidsgiver(
-                        varselHendelse.toArbeidsgiverHendelse(),
+                        varselHendelse.toArbeidsgiverNotifikasjonTilAltinnRessursHendelse(),
                     )
 
                 NL_OPPFOLGINGSPLAN_FORESPORSEL ->

--- a/src/main/kotlin/no/nav/syfo/service/VarselBusService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/VarselBusService.kt
@@ -2,6 +2,7 @@ package no.nav.syfo.service
 
 import no.nav.syfo.kafka.consumers.varselbus.domain.ArbeidstakerHendelse
 import no.nav.syfo.kafka.consumers.varselbus.domain.EsyfovarselHendelse
+import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType.AG_VARSEL_ALTINN_RESSURS
 import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType.NL_DIALOGMOTE_AVLYST
 import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType.NL_DIALOGMOTE_INNKALT
 import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType.NL_DIALOGMOTE_MOTEBEHOV_TILBAKEMELDING
@@ -26,8 +27,10 @@ import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType.SM_MER_VEILEDNI
 import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType.SM_OPPFOLGINGSPLAN_OPPRETTET
 import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType.SM_OPPFOLGINGSPLAN_SENDT_TIL_GODKJENNING
 import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType.SM_VEDTAK_FRISKMELDING_TIL_ARBEIDSFORMIDLING
+import no.nav.syfo.kafka.consumers.varselbus.domain.isArbeidsgiverHendelse
 import no.nav.syfo.kafka.consumers.varselbus.domain.isArbeidstakerHendelse
 import no.nav.syfo.kafka.consumers.varselbus.domain.skalFerdigstilles
+import no.nav.syfo.kafka.consumers.varselbus.domain.toArbeidsgiverHendelse
 import no.nav.syfo.kafka.consumers.varselbus.domain.toArbeidstakerHendelse
 import no.nav.syfo.kafka.consumers.varselbus.domain.toNarmestelederHendelse
 import no.nav.syfo.service.microfrontend.MikrofrontendService
@@ -36,6 +39,7 @@ import org.slf4j.LoggerFactory
 
 class VarselBusService(
     val senderFacade: SenderFacade,
+    private val arbeidsgiverVarselService: ArbeidsgiverVarselService,
     private val motebehovVarselService: MotebehovVarselService,
     private val oppfolgingsplanVarselService: OppfolgingsplanVarselService,
     private val nyOppfolgingsplanVarselService: NyOppfolgingsplanVarselService,
@@ -56,6 +60,11 @@ class VarselBusService(
             ferdigstillVarsel(varselHendelse)
         } else {
             when (varselHendelse.type) {
+                AG_VARSEL_ALTINN_RESSURS ->
+                    arbeidsgiverVarselService.sendVarselTilArbeidsgiver(
+                        varselHendelse.toArbeidsgiverHendelse(),
+                    )
+
                 NL_OPPFOLGINGSPLAN_FORESPORSEL ->
                     oppfolgingsplanVarselService.sendOppfolgingsplanForesporselVarselTilNarmesteLeder(
                         varselHendelse.toNarmestelederHendelse(),
@@ -148,6 +157,8 @@ class VarselBusService(
     suspend fun ferdigstillVarsel(varselHendelse: EsyfovarselHendelse) {
         if (varselHendelse.isArbeidstakerHendelse()) {
             senderFacade.ferdigstillArbeidstakerVarsler(varselHendelse.toArbeidstakerHendelse())
+        } else if (varselHendelse.isArbeidsgiverHendelse()) {
+            log.warn("Forsøkte å ferdigstille arbeidsgiverhendelse, ignorerer ferdigstilling")
         } else {
             senderFacade.ferdigstillNarmesteLederVarsler(varselHendelse.toNarmestelederHendelse())
         }

--- a/src/test/kotlin/no/nav/syfo/kafka/consumers/varselbus/domain/EsyfovarselHendelseTest.kt
+++ b/src/test/kotlin/no/nav/syfo/kafka/consumers/varselbus/domain/EsyfovarselHendelseTest.kt
@@ -11,7 +11,7 @@ class EsyfovarselHendelseTest :
         val arbeidsgiverHendelseJson =
             """
             {
-              "@type": "ArbeidsgiverHendelse",
+              "@type": "ArbeidsgiverNotifikasjonTilAltinnRessursHendelse",
               "type": "AG_VARSEL_ALTINN_RESSURS",
               "ferdigstill": false,
               "data": {
@@ -23,7 +23,10 @@ class EsyfovarselHendelseTest :
               },
               "orgnummer": "999888777",
               "ressursId": "nav_syfo_dialogmote",
-              "ressursUrl": "https://www.altinn.no"
+              "ressursUrl": "https://www.altinn.no",
+              "kilde": "dokumentporten.dialogmote",
+              "arbeidstakerFnr": "012345678901",
+              "eksternReferanseId": "123e4567-e89b-12d3-a456-426614174000"
             }
             """.trimIndent()
 
@@ -33,7 +36,7 @@ class EsyfovarselHendelseTest :
                 hendelse.data = objectMapper.readTree(arbeidsgiverHendelseJson)["data"]
                 val varselData = requireNotNull(hendelse.data).toVarselData()
 
-                (hendelse is ArbeidsgiverHendelse) shouldBe true
+                (hendelse is ArbeidsgiverNotifikasjonTilAltinnRessursHendelse) shouldBe true
                 hendelse.type shouldBe HendelseType.AG_VARSEL_ALTINN_RESSURS
                 varselData.notifikasjonInnhold?.epostTittel shouldBe "Du har fått en ny melding"
                 varselData.notifikasjonInnhold?.epostBody shouldBe "Les meldingen i Altinn"

--- a/src/test/kotlin/no/nav/syfo/kafka/consumers/varselbus/domain/EsyfovarselHendelseTest.kt
+++ b/src/test/kotlin/no/nav/syfo/kafka/consumers/varselbus/domain/EsyfovarselHendelseTest.kt
@@ -1,0 +1,49 @@
+package no.nav.syfo.kafka.consumers.varselbus.domain
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import no.nav.syfo.kafka.common.createObjectMapper
+
+class EsyfovarselHendelseTest :
+    DescribeSpec({
+        val objectMapper = createObjectMapper()
+        val arbeidsgiverHendelseJson =
+            """
+            {
+              "@type": "ArbeidsgiverHendelse",
+              "type": "AG_VARSEL_ALTINN_RESSURS",
+              "ferdigstill": false,
+              "data": {
+                "notifikasjonInnhold": {
+                  "epostTittel": "Du har fått en ny melding",
+                  "epostBody": "Les meldingen i Altinn",
+                  "smsTekst": "Du har fått en ny melding i Altinn"
+                }
+              },
+              "orgnummer": "999888777",
+              "ressursId": "nav_syfo_dialogmote",
+              "ressursUrl": "https://www.altinn.no"
+            }
+            """.trimIndent()
+
+        describe("EsyfovarselHendelse") {
+            it("deserialiserer arbeidsgiverhendelse med AG_VARSEL_ALTINN_RESSURS til korrekt type") {
+                val hendelse: EsyfovarselHendelse = objectMapper.readValue(arbeidsgiverHendelseJson)
+                hendelse.data = objectMapper.readTree(arbeidsgiverHendelseJson)["data"]
+                val varselData = requireNotNull(hendelse.data).toVarselData()
+
+                (hendelse is ArbeidsgiverHendelse) shouldBe true
+                hendelse.type shouldBe HendelseType.AG_VARSEL_ALTINN_RESSURS
+                varselData.notifikasjonInnhold?.epostTittel shouldBe "Du har fått en ny melding"
+                varselData.notifikasjonInnhold?.epostBody shouldBe "Les meldingen i Altinn"
+                varselData.notifikasjonInnhold?.smsTekst shouldBe "Du har fått en ny melding i Altinn"
+            }
+
+            it("klassifiserer arbeidsgiverhendelse som ikke-arbeidstakerhendelse for mikrofrontend-guard") {
+                val hendelse: EsyfovarselHendelse = objectMapper.readValue(arbeidsgiverHendelseJson)
+
+                hendelse.isArbeidstakerHendelse() shouldBe false
+            }
+        }
+    })

--- a/src/test/kotlin/no/nav/syfo/service/ArbeidsgiverVarselServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/service/ArbeidsgiverVarselServiceTest.kt
@@ -5,8 +5,9 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import no.nav.syfo.kafka.common.createObjectMapper
-import no.nav.syfo.kafka.consumers.varselbus.domain.ArbeidsgiverHendelse
+import no.nav.syfo.kafka.consumers.varselbus.domain.ArbeidsgiverNotifikasjonTilAltinnRessursHendelse
 import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType
+import java.util.UUID
 
 class ArbeidsgiverVarselServiceTest :
     DescribeSpec({
@@ -14,13 +15,16 @@ class ArbeidsgiverVarselServiceTest :
         val objectMapper = createObjectMapper()
 
         val grunnHendelse =
-            ArbeidsgiverHendelse(
+            ArbeidsgiverNotifikasjonTilAltinnRessursHendelse(
                 type = HendelseType.AG_VARSEL_ALTINN_RESSURS,
                 ferdigstill = false,
                 data = null,
                 orgnummer = "999888777",
                 ressursId = "nav_syfo_dialogmote",
                 ressursUrl = "https://www.altinn.no",
+                arbeidstakerFnr = "012345678901",
+                kilde = "tjeneste.type",
+                eksternReferanseId = UUID.randomUUID().toString(),
             )
 
         describe("ArbeidsgiverVarselService stub") {

--- a/src/test/kotlin/no/nav/syfo/service/ArbeidsgiverVarselServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/service/ArbeidsgiverVarselServiceTest.kt
@@ -1,0 +1,87 @@
+package no.nav.syfo.service
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import no.nav.syfo.kafka.common.createObjectMapper
+import no.nav.syfo.kafka.consumers.varselbus.domain.ArbeidsgiverHendelse
+import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType
+
+class ArbeidsgiverVarselServiceTest :
+    DescribeSpec({
+        val service = ArbeidsgiverVarselService()
+        val objectMapper = createObjectMapper()
+
+        val grunnHendelse =
+            ArbeidsgiverHendelse(
+                type = HendelseType.AG_VARSEL_ALTINN_RESSURS,
+                ferdigstill = false,
+                data = null,
+                orgnummer = "999888777",
+                ressursId = "nav_syfo_dialogmote",
+                ressursUrl = "https://www.altinn.no",
+            )
+
+        describe("ArbeidsgiverVarselService stub") {
+            it("tåler gyldig varselData uten exception") {
+                val gyldigData =
+                    objectMapper.readTree(
+                        """{"notifikasjonInnhold":{"epostTittel":"Hei","epostBody":"Body","smsTekst":"SMS"}}""",
+                    )
+
+                val result = runCatching { service.sendVarselTilArbeidsgiver(grunnHendelse.copy(data = gyldigData)) }
+
+                result.isSuccess shouldBe true
+            }
+
+            it("håndterer parse-feil i data strengt og kaster exception") {
+                val exception =
+                    shouldThrow<IllegalArgumentException> {
+                        service.sendVarselTilArbeidsgiver(grunnHendelse.copy(data = "ikke-json"))
+                    }
+                exception.message shouldContain "ArbeidsgiverHendelse har ugyldig format i feltet: data"
+            }
+
+            it("kaster exception ved manglende data-felt") {
+                val exception =
+                    shouldThrow<IllegalArgumentException> {
+                        service.sendVarselTilArbeidsgiver(grunnHendelse.copy(data = null))
+                    }
+
+                exception.message shouldContain "ArbeidsgiverHendelse mangler feltet: data"
+            }
+
+            it("kaster exception ved manglende notifikasjonInnhold i varselData") {
+                val manglendeNotifikasjonInnhold =
+                    objectMapper.readTree(
+                        """{}""",
+                    )
+
+                val exception =
+                    shouldThrow<IllegalArgumentException> {
+                        service.sendVarselTilArbeidsgiver(
+                            grunnHendelse.copy(data = manglendeNotifikasjonInnhold),
+                        )
+                    }
+
+                exception.message shouldContain "ArbeidsgiverHendelse mangler feltet: data.notifikasjonInnhold"
+            }
+
+            it("kaster exception ved manglende obligatorisk felt i notifikasjonInnhold") {
+                val manglendeEpostBody =
+                    objectMapper.readTree(
+                        """{"notifikasjonInnhold":{"epostTittel":"Hei","smsTekst":"SMS"}}""",
+                    )
+
+                val exception =
+                    shouldThrow<IllegalArgumentException> {
+                        service.sendVarselTilArbeidsgiver(
+                            grunnHendelse.copy(data = manglendeEpostBody),
+                        )
+                    }
+
+                exception.message shouldContain "ArbeidsgiverHendelse har ugyldig format i feltet: data.notifikasjonInnhold.epostBody"
+            }
+        }
+    })

--- a/src/test/kotlin/no/nav/syfo/service/VarselBusServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/service/VarselBusServiceTest.kt
@@ -5,8 +5,9 @@ import io.mockk.clearAllMocks
 import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.verify
-import no.nav.syfo.kafka.consumers.varselbus.domain.ArbeidsgiverHendelse
+import no.nav.syfo.kafka.consumers.varselbus.domain.ArbeidsgiverNotifikasjonTilAltinnRessursHendelse
 import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType
+import java.util.UUID
 
 class VarselBusServiceTest :
     DescribeSpec({
@@ -43,14 +44,17 @@ class VarselBusServiceTest :
                 kartleggingssporsmalVarselService = kartleggingssporsmalVarselService,
             )
 
-        val arbeidsgiverHendelse =
-            ArbeidsgiverHendelse(
+        val arbeidsgiverNotifikasjonTilAltinnRessursHendelse =
+            ArbeidsgiverNotifikasjonTilAltinnRessursHendelse(
                 type = HendelseType.AG_VARSEL_ALTINN_RESSURS,
                 ferdigstill = false,
                 data = """{"notifikasjonInnhold":{"epostTittel":"Tittel","epostBody":"Body","smsTekst":"SMS"}}""",
                 orgnummer = "999888777",
                 ressursId = "nav_syfo_dialogmote",
                 ressursUrl = "https://www.altinn.no",
+                arbeidstakerFnr = "012345678901",
+                kilde = "tjeneste.type",
+                eksternReferanseId = UUID.randomUUID().toString(),
             )
 
         beforeTest {
@@ -59,14 +63,16 @@ class VarselBusServiceTest :
 
         describe("VarselBusService for arbeidsgiverhendelser") {
             it("ruter AG_VARSEL_ALTINN_RESSURS til ArbeidsgiverVarselService") {
-                varselBusService.processVarselHendelse(arbeidsgiverHendelse)
+                varselBusService.processVarselHendelse(arbeidsgiverNotifikasjonTilAltinnRessursHendelse)
 
-                coVerify(exactly = 1) { arbeidsgiverVarselService.sendVarselTilArbeidsgiver(arbeidsgiverHendelse) }
+                coVerify(
+                    exactly = 1,
+                ) { arbeidsgiverVarselService.sendVarselTilArbeidsgiver(arbeidsgiverNotifikasjonTilAltinnRessursHendelse) }
                 verify(exactly = 0) { mikrofrontendService.updateMikrofrontendForUserByHendelse(any()) }
             }
 
             it("ferdigstiller ikke arbeidsgiverhendelser i arbeidstaker/narmeste-leder-spor") {
-                varselBusService.ferdigstillVarsel(arbeidsgiverHendelse.copy(ferdigstill = true))
+                varselBusService.ferdigstillVarsel(arbeidsgiverNotifikasjonTilAltinnRessursHendelse.copy(ferdigstill = true))
 
                 coVerify(exactly = 0) { senderFacade.ferdigstillArbeidstakerVarsler(any()) }
                 coVerify(exactly = 0) { senderFacade.ferdigstillNarmesteLederVarsler(any()) }

--- a/src/test/kotlin/no/nav/syfo/service/VarselBusServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/service/VarselBusServiceTest.kt
@@ -1,0 +1,75 @@
+package no.nav.syfo.service
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.mockk.clearAllMocks
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.syfo.kafka.consumers.varselbus.domain.ArbeidsgiverHendelse
+import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType
+
+class VarselBusServiceTest :
+    DescribeSpec({
+        val senderFacade = mockk<SenderFacade>(relaxed = true)
+        val arbeidsgiverVarselService = mockk<ArbeidsgiverVarselService>(relaxed = true)
+        val motebehovVarselService = mockk<MotebehovVarselService>(relaxed = true)
+        val oppfolgingsplanVarselService = mockk<OppfolgingsplanVarselService>(relaxed = true)
+        val nyOppfolgingsplanVarselService = mockk<NyOppfolgingsplanVarselService>(relaxed = true)
+        val dialogmoteInnkallingSykmeldtVarselService = mockk<DialogmoteInnkallingSykmeldtVarselService>(relaxed = true)
+        val dialogmoteInnkallingNarmesteLederVarselService = mockk<DialogmoteInnkallingNarmesteLederVarselService>(relaxed = true)
+        val aktivitetspliktForhandsvarselService = mockk<AktivitetspliktForhandsvarselService>(relaxed = true)
+        val arbeidsuforhetForhandsvarselService = mockk<ArbeidsuforhetForhandsvarselService>(relaxed = true)
+        val mikrofrontendService = mockk<no.nav.syfo.service.microfrontend.MikrofrontendService>(relaxed = true)
+        val friskmeldingTilArbeidsformidlingVedtakService = mockk<FriskmeldingTilArbeidsformidlingVedtakService>(relaxed = true)
+        val manglendeMedvirkningVarselService = mockk<ManglendeMedvirkningVarselService>(relaxed = true)
+        val merVeiledningVarselService = mockk<MerVeiledningVarselService>(relaxed = true)
+        val kartleggingssporsmalVarselService = mockk<KartleggingssporsmalVarselService>(relaxed = true)
+
+        val varselBusService =
+            VarselBusService(
+                senderFacade = senderFacade,
+                arbeidsgiverVarselService = arbeidsgiverVarselService,
+                motebehovVarselService = motebehovVarselService,
+                oppfolgingsplanVarselService = oppfolgingsplanVarselService,
+                nyOppfolgingsplanVarselService = nyOppfolgingsplanVarselService,
+                dialogmoteInnkallingSykmeldtVarselService = dialogmoteInnkallingSykmeldtVarselService,
+                dialogmoteInnkallingNarmesteLederVarselService = dialogmoteInnkallingNarmesteLederVarselService,
+                aktivitetspliktForhandsvarselService = aktivitetspliktForhandsvarselService,
+                arbeidsuforhetForhandsvarselService = arbeidsuforhetForhandsvarselService,
+                mikrofrontendService = mikrofrontendService,
+                friskmeldingTilArbeidsformidlingVedtakService = friskmeldingTilArbeidsformidlingVedtakService,
+                manglendeMedvirkningVarselService = manglendeMedvirkningVarselService,
+                merVeiledningVarselService = merVeiledningVarselService,
+                kartleggingssporsmalVarselService = kartleggingssporsmalVarselService,
+            )
+
+        val arbeidsgiverHendelse =
+            ArbeidsgiverHendelse(
+                type = HendelseType.AG_VARSEL_ALTINN_RESSURS,
+                ferdigstill = false,
+                data = """{"notifikasjonInnhold":{"epostTittel":"Tittel","epostBody":"Body","smsTekst":"SMS"}}""",
+                orgnummer = "999888777",
+                ressursId = "nav_syfo_dialogmote",
+                ressursUrl = "https://www.altinn.no",
+            )
+
+        beforeTest {
+            clearAllMocks()
+        }
+
+        describe("VarselBusService for arbeidsgiverhendelser") {
+            it("ruter AG_VARSEL_ALTINN_RESSURS til ArbeidsgiverVarselService") {
+                varselBusService.processVarselHendelse(arbeidsgiverHendelse)
+
+                coVerify(exactly = 1) { arbeidsgiverVarselService.sendVarselTilArbeidsgiver(arbeidsgiverHendelse) }
+                verify(exactly = 0) { mikrofrontendService.updateMikrofrontendForUserByHendelse(any()) }
+            }
+
+            it("ferdigstiller ikke arbeidsgiverhendelser i arbeidstaker/narmeste-leder-spor") {
+                varselBusService.ferdigstillVarsel(arbeidsgiverHendelse.copy(ferdigstill = true))
+
+                coVerify(exactly = 0) { senderFacade.ferdigstillArbeidstakerVarsler(any()) }
+                coVerify(exactly = 0) { senderFacade.ferdigstillNarmesteLederVarsler(any()) }
+            }
+        }
+    })


### PR DESCRIPTION
## Beskrivelse

Legger til støtte for `AG_VARSEL_ALTINN_RESSURS` i esyfovarsel med ny arbeidsgiverhendelse, routing via `VarselBusService` og en stubbet `ArbeidsgiverVarselService`.

Notifikasjonsinnhold er modellert som nested `VarselDataNotifikasjonInnhold` med tydelig validering av ugyldig payload.

## Endringer

- `src/main/kotlin/no/nav/syfo/kafka/consumers/varselbus/domain/EsyfovarselHendelse.kt`: ny `ArbeidsgiverHendelse`, `AG_VARSEL_ALTINN_RESSURS` og nested `notifikasjonInnhold`
- `src/main/kotlin/no/nav/syfo/service/ArbeidsgiverVarselService.kt`: stub for arbeidsgivervarsel med presis feilhåndtering og trygg logging
- `src/main/kotlin/no/nav/syfo/service/VarselBusService.kt`: routing og guard for arbeidsgiverhendelser
- `src/main/kotlin/no/nav/syfo/BootstrapApplication.kt`: wiring av `ArbeidsgiverVarselService`
- `src/test/kotlin/no/nav/syfo/kafka/consumers/varselbus/domain/EsyfovarselHendelseTest.kt`: deserialisering og nested roundtrip-assert
- `src/test/kotlin/no/nav/syfo/service/VarselBusServiceTest.kt`: routing og ferdigstill-guard
- `src/test/kotlin/no/nav/syfo/service/ArbeidsgiverVarselServiceTest.kt`: validering av nested innhold og feilbaner

## Issue

Closes #946

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)