### PR TITLE
feat(arbeidsgivernotifikasjon): støtt Altinn3-ressursmottaker

### DIFF
--- a/src/main/graphql/arbeidsgivernotifikasjon-schema.graphqls
+++ b/src/main/graphql/arbeidsgivernotifikasjon-schema.graphqls
@@ -1,89 +1,97 @@
-directive @Validate on ARGUMENT_DEFINITION
+# Denne dokumentasjonen er skrev i "du/dere"-form, hvor du/dere er produsenter, og "vi" er
+# notifikasjons-plattformen.
 
-directive @MaxLength(max: Int) on INPUT_FIELD_DEFINITION | ARGUMENT_DEFINITION
-
-directive @NonIdentifying on INPUT_FIELD_DEFINITION | ARGUMENT_DEFINITION
-
-directive @ExactlyOneFieldGiven on INPUT_OBJECT
-
-directive @MaxValue(upToIncluding: Int) on ARGUMENT_DEFINITION
-
-directive @NorwegianMobilePhoneNumber on INPUT_FIELD_DEFINITION | ARGUMENT_DEFINITION
-
-# Indicates exactly one field must be supplied and this field must not be `null`.
-directive @oneOf on INPUT_OBJECT
-
-# DateTime med offset etter ISO8601-standaren. F.eks. '2011-12-03T10:15:30+01:00'.
-#
-# Er representert som String.
+"""
+DateTime etter ISO8601-standaren. F.eks. '2011-12-03T10:15:30+01:00'.
+Dersom tidssone/offset ikke er oppgitt, så antar vi at tidspunktet er Oslo-tid ('Europe/Oslo').
+"""
 scalar ISO8601DateTime
 
-# Dato og lokaltid etter ISO8601-standaren. F.eks. '2001-12-24T10:44:01'.
-# Vi tolker tidspunktet som Oslo-tid ('Europe/Oslo').
+"""
+Dato og lokaltid etter ISO8601-standaren. F.eks. '2001-12-24T10:44:01'.
+Vi tolker tidspunktet som Oslo-tid ('Europe/Oslo').
+"""
 scalar ISO8601LocalDateTime
 
-# Duration ISO8601-standaren. F.eks. 'P2DT3H4M'.
-#
-# Er representert som String.
+"""
+Duration ISO8601-standaren. F.eks. 'P2DT3H4M'.
+
+Er representert som String.
+"""
 scalar ISO8601Duration
 
-# Dato etter ISO8601-standaren. F.eks. `2020-01-02`, altså 2. mars 2020.
+"""
+Dato etter ISO8601-standaren. F.eks. `2020-01-02`, altså 2. mars 2020.
+"""
 scalar ISO8601Date
 
-# Tilstanden til en oppgave.
+"""
+Tilstanden til en oppgave.
+"""
 enum OppgaveTilstand {
-    # En oppgave som kan utføres.
+    """
+    En oppgave som kan utføres.
+    """
     NY
 
-    # En oppgave som allerede er utført.
+    """
+    En oppgave som allerede er utført.
+    """
     UTFOERT
 
-    # En oppgave hvor frist har utgått.
+    """
+    En oppgave hvor frist har utgått.
+    """
     UTGAATT
 }
 
-# Dette er roten som alle forespørsler starter fra.
+"""
+Dette er roten som alle forespørsler starter fra.
+"""
 type Query {
-    # Egnet for feilsøking. Forteller hvem du er autentisert som.
+    """
+    Egnet for feilsøking. Forteller hvem du er autentisert som.
+    """
     whoami: String
 
-    # Vi bruker det Connections-patternet for paginering. Se
-    # [Connection-standaren](https://relay.dev/graphql/connections.htm) for mer
-    # informasjon.
-    #
-    # Dere må gjenta paremetere når dere blar gjennom alle notifikasjonen.
-    #
-    # Hvis verken `merkelapp` eller `merkelapper` er gitt, vil notifikasjoner
-    # med alle dine merkelapper være med.
+    """
+    Vi bruker det Connections-patternet for paginering. Se
+    [Connection-standaren](https://relay.dev/graphql/connections.htm) for mer
+    informasjon.
+
+    Dere må gjenta paremetere når dere blar gjennom alle notifikasjonen.
+
+    Hvis verken `merkelapp` eller `merkelapper` er gitt, vil notifikasjoner
+    med alle dine merkelapper være med.
+    """
     mineNotifikasjoner(
-        # antall notifikasjoner du ønsker å hente
+        "antall notifikasjoner du ønsker å hente"
         first: Int
 
-        # Cursor til notifikasjonen du henter fra. Cursor får du fra [NotifikasjonEdge](#notifikasjonedge).
+        """Cursor til notifikasjonen du henter fra. Cursor får du fra [NotifikasjonEdge](#notifikasjonedge)."""
         after: String
 
-        # Filtrer på merkelapp. Kan ikke brukes sammen med `merkelapper`.
+        """Filtrer på merkelapp. Kan ikke brukes sammen med `merkelapper`."""
         merkelapp: String
 
-        # Filtrer på merkelapper. Kan ikke brukes sammen med `merkelapp`.
+        """Filtrer på merkelapper. Kan ikke brukes sammen med `merkelapp`."""
         merkelapper: [String!]
+
         grupperingsid: String
     ): MineNotifikasjonerResultat!
+
     hentNotifikasjon(id: ID!): HentNotifikasjonResultat!
     hentSak(id: ID!): HentSakResultat!
-    hentSakMedGrupperingsid(
-        grupperingsid: String!
-        merkelapp: String!
-    ): HentSakResultat!
+    hentSakMedGrupperingsid(grupperingsid: String!, merkelapp: String!): HentSakResultat!
 }
 
 union MineNotifikasjonerResultat =
-    NotifikasjonConnection
+    | NotifikasjonConnection
     | UgyldigMerkelapp
     | UkjentProdusent
 
 union HentNotifikasjonResultat =
-    HentetNotifikasjon
+    | HentetNotifikasjon
     | UkjentProdusent
     | UgyldigMerkelapp
     | NotifikasjonFinnesIkke
@@ -93,10 +101,11 @@ type HentetNotifikasjon {
 }
 
 union HentSakResultat =
-    HentetSak
+    | HentetSak
     | SakFinnesIkke
     | UgyldigMerkelapp
     | UkjentProdusent
+
 
 type HentetSak {
     sak: Sak!
@@ -159,7 +168,10 @@ type Kalenderavtale {
     eksterneVarsler: [EksterntVarsel!]!
 }
 
-union Mottaker = AltinnMottaker | NaermesteLederMottaker | AltinnRessursMottaker
+union Mottaker =
+    | AltinnMottaker
+    | NaermesteLederMottaker
+    | AltinnRessursMottaker
 
 type AltinnMottaker {
     serviceCode: String!
@@ -181,69 +193,98 @@ type AltinnRessursMottaker {
 type OppgaveData {
     tilstand: OppgaveTilstand
 
-    # Merkelapp for beskjeden. Er typisk navnet på ytelse eller lignende. Den vises til brukeren.
+    """
+    Merkelapp for beskjeden. Er typisk navnet på ytelse eller lignende. Den vises til brukeren.
+    """
     merkelapp: String!
 
-    # Teksten som vises til brukeren.
+    """
+    Teksten som vises til brukeren.
+    """
     tekst: String!
 
-    # Lenken som brukeren føres til hvis de klikker på beskjeden.
+    """
+    Lenken som brukeren føres til hvis de klikker på beskjeden.
+    """
     lenke: String!
 }
 
 type BeskjedData {
-    # Merkelapp for beskjeden. Er typisk navnet på ytelse eller lignende. Den vises til brukeren.
+    """
+    Merkelapp for beskjeden. Er typisk navnet på ytelse eller lignende. Den vises til brukeren.
+    """
     merkelapp: String!
 
-    # Teksten som vises til brukeren.
+    """
+    Teksten som vises til brukeren.
+    """
     tekst: String!
 
-    # Lenken som brukeren føres til hvis de klikker på beskjeden.
+    """
+    Lenken som brukeren føres til hvis de klikker på beskjeden.
+    """
     lenke: String!
 }
 
 type KalenderavtaleData {
-    # Merkelapp for kalenderavtalen. Er typisk navnet på ytelse eller lignende.
+    """
+    Merkelapp for kalenderavtalen. Er typisk navnet på ytelse eller lignende.
+    """
     merkelapp: String!
 
-    # Teksten som vises til brukeren.
+    """
+    Teksten som vises til brukeren.
+    """
     tekst: String!
 
-    # Lenken som brukeren føres til hvis de klikker på kalenderavtalen.
+    """
+    Lenken som brukeren føres til hvis de klikker på kalenderavtalen.
+    """
     lenke: String!
 
-    # Når avtalen starter.
-    startTidspunkt: ISO8601LocalDateTime!
+    """
+    Når avtalen starter.
+    """
+    startTidspunkt: ISO8601DateTime!
 
-    # Når avtalen slutter.
-    sluttTidspunkt: ISO8601LocalDateTime
+    """
+    Når avtalen slutter.
+    """
+    sluttTidspunkt: ISO8601DateTime
 
-    # Her kan dere oppgi en fysisk adresse som brukeren kan møte opp på dersom dere har det.
-    # Denne vil vises til brukeren hvis den er angitt.
+    """
+    Her kan dere oppgi en fysisk adresse som brukeren kan møte opp på dersom dere har det.
+    Denne vil vises til brukeren hvis den er angitt.
+    """
     lokasjon: Lokasjon
 
-    # Ved å sette dette flagget kan dere vise brukeren at det er mulig å møte digitalt.
-    # Det vil vises til brukeren hvis det er satt til true.
+    """
+    Ved å sette dette flagget kan dere vise brukeren at det er mulig å møte digitalt.
+    Det vil vises til brukeren hvis det er satt til true.
+    """
     digitalt: Boolean!
 
-    # Tilstanden til avtalen. Default er `VENTER_SVAR_FRA_ARBEIDSGIVER`.
-    # Denne vises til brukeren.
+    """
+    Tilstanden til avtalen. Default er `VENTER_SVAR_FRA_ARBEIDSGIVER`.
+    Denne vises til brukeren.
+    """
     tilstand: KalenderavtaleTilstand
 }
 
 type Metadata {
     id: ID!
 
-    #
+    """
+    """
     eksternId: String!
 
-    #
+    """
+    """
     opprettetTidspunkt: ISO8601DateTime
 
-    #
+    """
+    """
     grupperingsid: String
-    softDeleted: Boolean!
-    softDeletedAt: ISO8601DateTime
 }
 
 type EksterntVarsel {
@@ -259,7 +300,7 @@ enum EksterntVarselStatus {
 }
 
 union NySakResultat =
-    NySakVellykket
+    | NySakVellykket
     | UgyldigMerkelapp
     | UgyldigMottaker
     | DuplikatGrupperingsid
@@ -272,7 +313,7 @@ type NySakVellykket {
 }
 
 union NyStatusSakResultat =
-    NyStatusSakVellykket
+    | NyStatusSakVellykket
     | SakFinnesIkke
     | Konflikt
     | UgyldigMerkelapp
@@ -281,19 +322,19 @@ union NyStatusSakResultat =
 type NyStatusSakVellykket {
     id: ID!
 
-    # Nyeste statusoppdatering er først i listen.
+    """Nyeste statusoppdatering er først i listen."""
     statuser: [StatusOppdatering!]!
 }
 
 union TilleggsinformasjonSakResultat =
-    TilleggsinformasjonSakVellykket
+    | TilleggsinformasjonSakVellykket
     | SakFinnesIkke
     | Konflikt
     | UgyldigMerkelapp
     | UkjentProdusent
 
 union NesteStegSakResultat =
-    NesteStegSakVellykket
+    | NesteStegSakVellykket
     | SakFinnesIkke
     | Konflikt
     | UgyldigMerkelapp
@@ -307,21 +348,29 @@ type NesteStegSakVellykket {
     id: ID!
 }
 
-# Statusen påvirker bl.a. hvilket ikon som vises og brukes bl.a.
-# for å kunne filtrere saksoversikten på min side arbeidsgiver.
+"""
+Statusen påvirker bl.a. hvilket ikon som vises og brukes bl.a.
+for å kunne filtrere saksoversikten på min side arbeidsgiver.
+"""
 enum SaksStatus {
-    # Naturlig start-tilstand for en sak.
-    #
-    # Default tekst som vises til bruker: "Mottatt"
+    """
+    Naturlig start-tilstand for en sak.
+
+    Default tekst som vises til bruker: "Mottatt"
+    """
     MOTTATT
 
-    # Default tekst som vises til bruker: "Under behandling"
+    """
+    Default tekst som vises til bruker: "Under behandling"
+    """
     UNDER_BEHANDLING
 
-    # Slutt-tilstand for en sak. Når en sak er `FERDIG`, så vil vi
-    # nedprioritere visningen av den på min side arbeidsgivere.
-    #
-    # Default tekst som vises til bruker: "Ferdig".
+    """
+    Slutt-tilstand for en sak. Når en sak er `FERDIG`, så vil vi
+    nedprioritere visningen av den på min side arbeidsgivere.
+
+    Default tekst som vises til bruker: "Ferdig".
+    """
     FERDIG
 }
 
@@ -331,671 +380,904 @@ type StatusOppdatering {
     overstyrStatusTekstMed: String
 }
 
-# Dette er roten som alle endringer ("mutations") starter fra. Endringer inkluderer også
-# å opprette nye ting.
+"""
+Dette er roten som alle endringer ("mutations") starter fra. Endringer inkluderer også
+å opprette nye ting.
+"""
 type Mutation {
     nyKalenderavtale(
-        # Hvilken virksomhet som skal motta kalenderavtalen.
+        """
+        Hvilken virksomhet som skal motta kalenderavtalen.
+        """
         virksomhetsnummer: String!
 
-        # Grupperings-id-en knytter denne kalenderavtalen til en sak med samme grupperings-id og merkelapp.
-        # Det vises ikke til brukere.
-        # Saksnummer er en naturlig grupperings-id.
-        #
-        # Når dere bruker grupperings-id, så er det mulig for oss å presentere en tidslinje
-        # med alle notifikasjonene og status-oppdateringer knyttet til en sak.
+        """
+        Grupperings-id-en knytter denne kalenderavtalen til en sak med samme grupperings-id og merkelapp.
+        Det vises ikke til brukere.
+        Saksnummer er en naturlig grupperings-id.
+
+        Når dere bruker grupperings-id, så er det mulig for oss å presentere en tidslinje
+        med alle notifikasjonene og status-oppdateringer knyttet til en sak.
+        """
         grupperingsid: String!
 
-        # Merkelapp for kalenderavtalen. Er typisk navnet på ytelse eller lignende. Den vises ikke til brukeren,
-        # men brukes i kombinasjon med grupperingsid for å koble kalenderavtalen til sak.
-        #
-        # Hva du kan oppgi som merkelapp er bestemt av produsent-registeret.
+        """
+        Merkelapp for kalenderavtalen. Er typisk navnet på ytelse eller lignende. Den vises ikke til brukeren,
+        men brukes i kombinasjon med grupperingsid for å koble kalenderavtalen til sak.
+
+        Hva du kan oppgi som merkelapp er bestemt av produsent-registeret.
+        """
         merkelapp: String!
 
-        # Den eksterne id-en brukes for å unikt identifisere en notifikasjon. Den må være unik for merkelappen.
-        #
-        # Hvis dere har en enkel, statisk bruk av notifikasjoner, så kan dere utlede eksternId
-        # fra f.eks. et saksnummer, og på den måten kunne referere til notifikasjoner dere har opprettet,
-        # uten at dere må lagre ID-ene vi genererer og returnerer til dere.
+        """
+        Den eksterne id-en brukes for å unikt identifisere en notifikasjon. Den må være unik for merkelappen.
+
+        Hvis dere har en enkel, statisk bruk av notifikasjoner, så kan dere utlede eksternId
+        fra f.eks. et saksnummer, og på den måten kunne referere til notifikasjoner dere har opprettet,
+        uten at dere må lagre ID-ene vi genererer og returnerer til dere.
+        """
         eksternId: String!
 
-        # Teksten som vises til brukeren.
+        """
+        Teksten som vises til brukeren.
+        """
         tekst: String!
 
-        # Lenken som brukeren føres til hvis de klikker på kalenderavtalen. Typisk en side i deres system som viser detaljer om avtalen.
+        """
+        Lenken som brukeren føres til hvis de klikker på kalenderavtalen. Typisk en side i deres system som viser detaljer om avtalen.
+        """
         lenke: String!
 
-        # Her bestemmer dere hvem som skal få se kalenderavtalen.
+        """
+        Her bestemmer dere hvem som skal få se kalenderavtalen.
+        """
         mottakere: [MottakerInput!]!
 
-        # Når avtalen starter.
+        """
+        Når avtalen starter.
+        """
         startTidspunkt: ISO8601DateTime!
 
-        # Når avtalen slutter.
+        """
+        Når avtalen slutter.
+        """
         sluttTidspunkt: ISO8601DateTime
 
-        # Her kan dere oppgi en fysisk adresse som brukeren kan møte opp på dersom dere har det.
-        # Denne vil vises til brukeren hvis den er angitt.
+        """
+        Her kan dere oppgi en fysisk adresse som brukeren kan møte opp på dersom dere har det.
+        Denne vil vises til brukeren hvis den er angitt.
+        """
         lokasjon: LokasjonInput
 
-        # Ved å sette dette flagget kan dere vise brukeren at det er mulig å møte digitalt.
-        # Det vil vises til brukeren hvis det er satt til true.
+        """
+        Ved å sette dette flagget kan dere vise brukeren at det er mulig å møte digitalt.
+        Det vil vises til brukeren hvis det er satt til true.
+        """
         erDigitalt: Boolean
 
-        # Tilstanden til avtalen. Default er `VENTER_SVAR_FRA_ARBEIDSGIVER`.
-        # Denne vises til brukeren.
+        """
+        Tilstanden til avtalen. Default er `VENTER_SVAR_FRA_ARBEIDSGIVER`.
+        Denne vises til brukeren.
+        """
         tilstand: KalenderavtaleTilstand
+
         eksterneVarsler: [EksterntVarselInput!]! = []
 
-        # Her kan du spesifisere en påminnelse for kalenderavtalen.
-        # Brukeren vil bli gjort oppmerksom via bjellen og evt ekstern varsling dersom du oppgir det.
+        """
+        Her kan du spesifisere en påminnelse for kalenderavtalen.
+        Brukeren vil bli gjort oppmerksom via bjellen og evt ekstern varsling dersom du oppgir det.
+        """
         paaminnelse: PaaminnelseInput
 
-        # Oppgi dersom dere ønsker at hard delete skal skeduleres. Vi
-        # tolker relative datoer basert på når vi mottok kallet.
+        """
+        Oppgi dersom dere ønsker at hard delete skal skeduleres. Vi
+        tolker relative datoer basert på når vi mottok kallet.
+        """
         hardDelete: FutureTemporalInput
     ): NyKalenderavtaleResultat!
+
     nySak(
-        # Grupperings-id-en knytter en sak og notifikasjoner sammen.
-        # Den skal være unik for saker innenfor merkelappen.
-        # Et naturlig valg av grupperingsid er f.eks. et saksnummer.
+        """
+        Grupperings-id-en knytter en sak og notifikasjoner sammen.
+        Den skal være unik for saker innenfor merkelappen.
+        Et naturlig valg av grupperingsid er f.eks. et saksnummer.
+        """
         grupperingsid: String!
 
-        # Merkelapp som saken skal assossieres med.
+        """Merkelapp som saken skal assossieres med."""
         merkelapp: String!
 
-        # Virksomhetsnummeret til virksomheten som saken omhandler.
+        """Virksomhetsnummeret til virksomheten som saken omhandler."""
         virksomhetsnummer: String!
 
-        # Hvem som skal få se saken.
-        #
-        # NB. At en bruker har tilgang til en sak påvirker ikke om de har tilgang
-        # til en notifikasjon. De tilgangsstyres hver for seg.
+        """
+        Hvem som skal få se saken.
+
+        NB. At en bruker har tilgang til en sak påvirker ikke om de har tilgang
+        til en notifikasjon. De tilgangsstyres hver for seg.
+        """
         mottakere: [MottakerInput!]!
 
-        # En tittel på saken, som vises til brukeren.
-        # Feltet er begrenset til 140 tegn og kan ikke inneholde fødselsnummer.
+        """
+        En tittel på saken, som vises til brukeren.
+        Feltet er begrenset til 140 tegn og kan ikke inneholde fødselsnummer.
+        """
         tittel: String!
 
-        # Dette feltet er frivillig.
-        # Tilleggssinformasjon som vises under tittelen på en sak.
-        # Feltet er begrenset til 140 tegn og kan ikke inneholde fødselsnummer.
+        """
+        Dette feltet er frivillig.
+        Tilleggssinformasjon som vises under tittelen på en sak.
+        Feltet er begrenset til 140 tegn og kan ikke inneholde fødselsnummer.
+        """
         tilleggsinformasjon: String
 
-        # Her oppgir dere en lenke som brukeren kan klikke på for å komme rett til saken.
-        # Dersom lenken ikke oppgis vil saken lenke til en enkel visning av saken i Min side - Arbeidsgiver.
+        """
+        Her oppgir dere en lenke som brukeren kan klikke på for å komme rett til saken.
+        Dersom lenken ikke oppgis vil saken lenke til en enkel visning av saken i Min side - Arbeidsgiver.
+        """
         lenke: String
 
-        #
+        """
+        """
         initiellStatus: SaksStatus!
 
-        # Dette feltet er frivillig.
-        # Her har dere mulighet til å vise virksomheten hva som er neste steg i saken.
-        # F.eks. "Saksbehandlignstiden er lang. Du kan forvente refusjon utbetalt i januar 2025."
-        # Dette vises i tidslinjen som en fremtidig handling i saken, over siste oppgave, beskjed eller kalenderavtale.
+        """
+        Dette feltet er frivillig.
+        Her har dere mulighet til å vise virksomheten hva som er neste steg i saken.
+        F.eks. "Saksbehandlignstiden er lang. Du kan forvente refusjon utbetalt i januar 2025."
+        Dette vises i tidslinjen som en fremtidig handling i saken, over siste oppgave, beskjed eller kalenderavtale.
+        """
         nesteSteg: String
 
-        # Når endringen skjedde. Det kan godt være i fortiden.
-        # Dette feltet er frivillig. Hvis feltet ikke er oppgitt, bruker vi tidspunktet dere gjør
-        # kallet på.
+        """
+        Når endringen skjedde. Det kan godt være i fortiden.
+        Dette feltet er frivillig. Hvis feltet ikke er oppgitt, bruker vi tidspunktet dere gjør
+        kallet på.
+        """
         tidspunkt: ISO8601DateTime
 
-        # Dette feltet er frivillig. Det lar deg overstyre hvilken tekst vi viser
-        # til brukeren. Se `SaksStatus` for default tekster.
+        """
+        Dette feltet er frivillig. Det lar deg overstyre hvilken tekst vi viser
+        til brukeren. Se `SaksStatus` for default tekster.
+        """
         overstyrStatustekstMed: String
 
-        # Oppgi dersom dere ønsker at hard delete skal skeduleres. Vi
-        # tolker relative datoer basert på `opprettetTidspunkt` (eller
-        # når vi mottok kallet hvis dere ikke har oppgitt `opprettetTidspunkt`).
+        """
+        Oppgi dersom dere ønsker at hard delete skal skeduleres. Vi
+        tolker relative datoer basert på `opprettetTidspunkt` (eller
+        når vi mottok kallet hvis dere ikke har oppgitt `opprettetTidspunkt`).
+        """
         hardDelete: FutureTemporalInput
     ): NySakResultat!
+
     nyStatusSak(
         idempotencyKey: String
         id: ID!
         nyStatus: SaksStatus!
 
-        # Når endringen skjedde. Det kan godt være i fortiden.
-        # Dette feltet er frivillig. Hvis feltet ikke er oppgitt, bruker vi tidspunktet dere gjør
-        # kallet på.
+        """
+        Når endringen skjedde. Det kan godt være i fortiden.
+        Dette feltet er frivillig. Hvis feltet ikke er oppgitt, bruker vi tidspunktet dere gjør
+        kallet på.
+        """
         tidspunkt: ISO8601DateTime
 
-        # Dette feltet er frivillig. Det lar deg overstyre hvilken tekst vi viser
-        # til brukeren. Se `SaksStatus` for default tekster.
+        """
+        Dette feltet er frivillig. Det lar deg overstyre hvilken tekst vi viser
+        til brukeren. Se `SaksStatus` for default tekster.
+        """
         overstyrStatustekstMed: String
 
-        # Se: [HardDeleteUpdateInput typen](#harddeleteupdateinput)
+        """
+        Se: [HardDeleteUpdateInput typen](#harddeleteupdateinput)
+        """
         hardDelete: HardDeleteUpdateInput
 
-        # Her kan dere endre lenken til saken. F.eks hvis saken har gått fra å være en
-        # søknad til en kvittering, så kan det være dere har behov for å endre url som brukeren sendes til.
-        # Dette feltet er frivillig; er det ikke oppgitt (eller er null), så forblir lenken knyttet til saken uendret.
+        """
+        Her kan dere endre lenken til saken. F.eks hvis saken har gått fra å være en
+        søknad til en kvittering, så kan det være dere har behov for å endre url som brukeren sendes til.
+        Dette feltet er frivillig; er det ikke oppgitt (eller er null), så forblir lenken knyttet til saken uendret.
+        """
         nyLenkeTilSak: String
+
     ): NyStatusSakResultat!
+
     nyStatusSakByGrupperingsid(
         idempotencyKey: String
         grupperingsid: String!
         merkelapp: String!
+
         nyStatus: SaksStatus!
 
-        # Når endringen skjedde. Det kan godt være i fortiden.
-        # Dette feltet er frivillig. Hvis feltet ikke er oppgitt, bruker vi tidspunktet dere gjør
-        # kallet på.
+        """
+        Når endringen skjedde. Det kan godt være i fortiden.
+        Dette feltet er frivillig. Hvis feltet ikke er oppgitt, bruker vi tidspunktet dere gjør
+        kallet på.
+        """
         tidspunkt: ISO8601DateTime
 
-        # Dette feltet er frivillig. Det lar deg overstyre hvilken tekst vi viser
-        # til brukeren. Se `SaksStatus` for default tekster.
+        """
+        Dette feltet er frivillig. Det lar deg overstyre hvilken tekst vi viser
+        til brukeren. Se `SaksStatus` for default tekster.
+        """
         overstyrStatustekstMed: String
 
-        # Se: [HardDeleteUpdateInput typen](#harddeleteupdateinput)
+        """
+        Se: [HardDeleteUpdateInput typen](#harddeleteupdateinput)
+        """
         hardDelete: HardDeleteUpdateInput
 
-        # Her kan dere endre lenken til saken. F.eks hvis saken har gått fra å være en
-        # søknad til en kvittering, så kan det være dere har behov for å endre url som brukeren sendes til.
-        # Dette feltet er frivillig; er det ikke oppgitt (eller er null), så forblir lenken knyttet til saken uendret.
+        """
+        Her kan dere endre lenken til saken. F.eks hvis saken har gått fra å være en
+        søknad til en kvittering, så kan det være dere har behov for å endre url som brukeren sendes til.
+        Dette feltet er frivillig; er det ikke oppgitt (eller er null), så forblir lenken knyttet til saken uendret.
+        """
         nyLenkeTilSak: String
     ): NyStatusSakResultat!
+
     tilleggsinformasjonSak(
         idempotencyKey: String
         id: ID!
 
-        # Dette feltet er frivillig.
-        # Her har dere mulighet til å vise virksomheten mer informasjon om saken.
-        # Feltet er begrenset til 140 tegn og kan ikke inneholde fødselsnummer.
+        """
+        Dette feltet er frivillig.
+        Her har dere mulighet til å vise virksomheten mer informasjon om saken.
+        Feltet er begrenset til 140 tegn og kan ikke inneholde fødselsnummer.
+        """
         tilleggsinformasjon: String
     ): TilleggsinformasjonSakResultat!
+
     tilleggsinformasjonSakByGrupperingsid(
         idempotencyKey: String
         grupperingsid: String!
         merkelapp: String!
 
-        # Dette feltet er frivillig.
-        # Her har dere mulighet til å vise virksomheten mer informasjon om saken.
-        # Feltet er begrenset til 140 tegn og kan ikke inneholde fødselsnummer.
+        """
+        Dette feltet er frivillig.
+        Her har dere mulighet til å vise virksomheten mer informasjon om saken.
+        Feltet er begrenset til 140 tegn og kan ikke inneholde fødselsnummer.
+        """
         tilleggsinformasjon: String
     ): TilleggsinformasjonSakResultat!
+
+
     nesteStegSak(
         idempotencyKey: String
         id: ID!
 
-        # Dette feltet er frivillig.
-        # Her har dere mulighet til å vise virksomheten hva som er neste steg i saken.
-        # F.eks. "Saksbehandlignstiden er lang. Du kan forvente refusjon utbetalt i januar 2025."
-        # Dette vises i tidslinjen som en fremtidig handling i saken, over siste oppgave, beskjed eller kalenderavtale.
-        # Her kan dere oppgi verdien null for å fjerne neste steg.
+        """
+        Dette feltet er frivillig.
+        Her har dere mulighet til å vise virksomheten hva som er neste steg i saken.
+        F.eks. "Saksbehandlignstiden er lang. Du kan forvente refusjon utbetalt i januar 2025."
+        Dette vises i tidslinjen som en fremtidig handling i saken, over siste oppgave, beskjed eller kalenderavtale.
+        Her kan dere oppgi verdien null for å fjerne neste steg.
+        """
         nesteSteg: String
     ): NesteStegSakResultat!
+
     nesteStegSakByGrupperingsid(
         idempotencyKey: String
         grupperingsid: String!
         merkelapp: String!
 
-        # Dette feltet er frivillig.
-        # Her har dere mulighet til å vise virksomheten hva som er neste steg i saken.
-        # F.eks. "Saksbehandlignstiden er lang. Du kan forvente refusjon utbetalt i januar 2025."
-        # Dette vises i tidslinjen som en fremtidig handling i saken, over siste oppgave, beskjed eller kalenderavtale.
-        # Her kan dere oppgi verdien null for å fjerne neste steg.
+        """
+        Dette feltet er frivillig.
+        Her har dere mulighet til å vise virksomheten hva som er neste steg i saken.
+        F.eks. "Saksbehandlignstiden er lang. Du kan forvente refusjon utbetalt i januar 2025."
+        Dette vises i tidslinjen som en fremtidig handling i saken, over siste oppgave, beskjed eller kalenderavtale.
+        Her kan dere oppgi verdien null for å fjerne neste steg.
+        """
         nesteSteg: String
     ): NesteStegSakResultat!
 
-    # Opprett en ny beskjed.
+    """
+    Opprett en ny beskjed.
+    """
     nyBeskjed(nyBeskjed: NyBeskjedInput!): NyBeskjedResultat!
 
-    # Opprett en ny oppgave.
+    """
+    Opprett en ny oppgave.
+    """
     nyOppgave(nyOppgave: NyOppgaveInput!): NyOppgaveResultat!
 
-    # Marker en oppgave (identifisert ved id) som utført. Dersom oppgaven har påminnelse, vil denne og eventuelle eksterne varsler på påminnelsen bli kansellert.
+    """
+    Marker en oppgave (identifisert ved id) som utført. Dersom oppgaven har påminnelse, vil denne og eventuelle eksterne varsler på påminnelsen bli kansellert.
+    """
     oppgaveUtfoert(
-        # ID-en som oppgaven har. Den du fikk da du opprettet oppgaven med `nyOppgave`.
+        """
+        ID-en som oppgaven har. Den du fikk da du opprettet oppgaven med `nyOppgave`.
+        """
         id: ID!
 
-        # Se: [HardDeleteUpdateInput typen](#harddeleteupdateinput)
+        """
+        Se: [HardDeleteUpdateInput typen](#harddeleteupdateinput)
+        """
         hardDelete: HardDeleteUpdateInput
 
-        # Ny lenke som oppgaven peker på: overskriver lenken som ble gitt ved
-        # opprettelse av oppgave. F.eks. for å peke på en kvitterings-side.
-        #
-        # Optional: hvis ikke oppgitt/null, så beholdes forrige lenke.
+        """
+        Ny lenke som oppgaven peker på: overskriver lenken som ble gitt ved
+        opprettelse av oppgave. F.eks. for å peke på en kvitterings-side.
+
+        Optional: hvis ikke oppgitt/null, så beholdes forrige lenke.
+        """
         nyLenke: String = null
 
-        # Tidspunkt for når oppgaven ble utført.
-        #
-        # Optional: hvis ikke oppgitt/null, så blir den satt til now().
+        """
+        Tidspunkt for når oppgaven ble utført.
+
+        Optional: hvis ikke oppgitt/null, så blir den satt til now().
+        """
         utfoertTidspunkt: ISO8601DateTime = null
     ): OppgaveUtfoertResultat!
 
-    # Marker en oppgave (identifisert ved ekstern id) som utført. Dersom oppgaven har påminnelse, vil denne og eventuelle eksterne varsler på påminnelsen bli kansellert.
+    """
+    Marker en oppgave (identifisert ved ekstern id) som utført. Dersom oppgaven har påminnelse, vil denne og eventuelle eksterne varsler på påminnelsen bli kansellert.
+    """
     oppgaveUtfoertByEksternId(
-        # Merkelapp som oppgaven er registrert med.
-        merkelapp: String!
+        """
+        Merkelapp som oppgaven er registrert med.
+        """
+        merkelapp: String!,
 
-        # ID-en som *dere ga oss* da dere opprettet oppgaven med `nyOppgave`.
+        """
+        ID-en som *dere ga oss* da dere opprettet oppgaven med `nyOppgave`.
+        """
         eksternId: ID!
 
-        # Se: [HardDeleteUpdateInput typen](#harddeleteupdateinput)
+        """
+        Se: [HardDeleteUpdateInput typen](#harddeleteupdateinput)
+        """
         hardDelete: HardDeleteUpdateInput
     ): OppgaveUtfoertResultat!
-    @deprecated(
-        reason: "Using the type ID for `eksternId` can lead to unexpected behaviour. Use oppgaveUtfoertByEksternId_V2 instead."
+    @deprecated(reason:
+    "Using the type ID for `eksternId` can lead to unexpected behaviour. Use oppgaveUtfoertByEksternId_V2 instead."
     )
 
-    # Marker en oppgave (identifisert ved ekstern id) som utført. Dersom oppgaven har påminnelse, vil denne og eventuelle eksterne varsler på påminnelsen bli kansellert.
+    """
+    Marker en oppgave (identifisert ved ekstern id) som utført. Dersom oppgaven har påminnelse, vil denne og eventuelle eksterne varsler på påminnelsen bli kansellert.
+    """
     oppgaveUtfoertByEksternId_V2(
-        # Merkelapp som oppgaven er registrert med.
-        merkelapp: String!
+        """
+        Merkelapp som oppgaven er registrert med.
+        """
+        merkelapp: String!,
 
-        # ID-en som *dere ga oss* da dere opprettet oppgaven med `nyOppgave`.
+        """
+        ID-en som *dere ga oss* da dere opprettet oppgaven med `nyOppgave`.
+        """
         eksternId: String!
 
-        # Se: [HardDeleteUpdateInput typen](#harddeleteupdateinput)
+        """
+        Se: [HardDeleteUpdateInput typen](#harddeleteupdateinput)
+        """
         hardDelete: HardDeleteUpdateInput
 
-        # Ny lenke som oppgaven peker på: overskriver lenken som ble gitt ved
-        # opprettelse av oppgave. F.eks. for å peke på en kvitterings-side.
-        #
-        # Optional: hvis ikke oppgitt/null, så beholdes forrige lenke.
+        """
+        Ny lenke som oppgaven peker på: overskriver lenken som ble gitt ved
+        opprettelse av oppgave. F.eks. for å peke på en kvitterings-side.
+
+        Optional: hvis ikke oppgitt/null, så beholdes forrige lenke.
+        """
         nyLenke: String = null
 
-        # Tidspunkt for når oppgaven ble utført.
-        #
-        # Optional: hvis ikke oppgitt/null, så blir den satt til now().
+        """
+        Tidspunkt for når oppgaven ble utført.
+
+        Optional: hvis ikke oppgitt/null, så blir den satt til now().
+        """
         utfoertTidspunkt: ISO8601DateTime = null
     ): OppgaveUtfoertResultat!
 
-    # Marker en oppgave (identifisert ved id) som utgått. Dersom oppgaven har påminnelse, vil denne og eventuelle eksterne varsler på påminnelsen bli kansellert.
+    """
+    Marker en oppgave (identifisert ved id) som utgått. Dersom oppgaven har påminnelse, vil denne og eventuelle eksterne varsler på påminnelsen bli kansellert.
+    """
     oppgaveUtgaatt(
-        # ID-en som oppgaven har. Den du fikk da du opprettet oppgaven med `nyOppgave`.
+        """
+        ID-en som oppgaven har. Den du fikk da du opprettet oppgaven med `nyOppgave`.
+        """
         id: ID!
 
-        # Se: [HardDeleteUpdateInput typen](#harddeleteupdateinput)
+        """
+        Se: [HardDeleteUpdateInput typen](#harddeleteupdateinput)
+        """
         hardDelete: HardDeleteUpdateInput
 
-        # Ny lenke som oppgaven peker på: overskriver lenken som ble gitt ved
-        # opprettelse av oppgave. F.eks. for å peke på en kvitterings-side.
-        #
-        # Optional: hvis ikke oppgitt/null, så beholdes forrige lenke.
+        """
+        Ny lenke som oppgaven peker på: overskriver lenken som ble gitt ved
+        opprettelse av oppgave. F.eks. for å peke på en kvitterings-side.
+
+        Optional: hvis ikke oppgitt/null, så beholdes forrige lenke.
+        """
         nyLenke: String = null
 
-        # Tidspunkt for når oppgaven utgikk.
-        #
-        # Optional: hvis ikke oppgitt/null, så blir den satt til now().
+        """
+        Tidspunkt for når oppgaven utgikk.
+
+        Optional: hvis ikke oppgitt/null, så blir den satt til now().
+        """
         utgaattTidspunkt: ISO8601DateTime = null
     ): OppgaveUtgaattResultat!
 
-    # Marker en oppgave (identifisert ved ekstern id) som utgått. Dersom oppgaven har påminnelse, vil denne og eventuelle eksterne varsler på påminnelsen bli kansellert.
+
+    """
+    Marker en oppgave (identifisert ved ekstern id) som utgått. Dersom oppgaven har påminnelse, vil denne og eventuelle eksterne varsler på påminnelsen bli kansellert.
+    """
     oppgaveUtgaattByEksternId(
-        # Merkelapp som oppgaven er registrert med.
-        merkelapp: String!
+        """
+        Merkelapp som oppgaven er registrert med.
+        """
+        merkelapp: String!,
 
-        # ID-en som *dere ga oss* da dere opprettet oppgaven med `nyOppgave`.
+        """
+        ID-en som *dere ga oss* da dere opprettet oppgaven med `nyOppgave`.
+        """
         eksternId: String!
 
-        # Se: [HardDeleteUpdateInput typen](#harddeleteupdateinput)
+        """
+        Se: [HardDeleteUpdateInput typen](#harddeleteupdateinput)
+        """
         hardDelete: HardDeleteUpdateInput
 
-        # Ny lenke som oppgaven peker på: overskriver lenken som ble gitt ved
-        # opprettelse av oppgave. F.eks. for å peke på en kvitterings-side.
-        #
-        # Optional: hvis ikke oppgitt/null, så beholdes forrige lenke.
+        """
+        Ny lenke som oppgaven peker på: overskriver lenken som ble gitt ved
+        opprettelse av oppgave. F.eks. for å peke på en kvitterings-side.
+
+        Optional: hvis ikke oppgitt/null, så beholdes forrige lenke.
+        """
         nyLenke: String = null
 
-        # Tidspunkt for når oppgaven utgikk.
-        #
-        # Optional: hvis ikke oppgitt/null, så blir den satt til now().
+        """
+        Tidspunkt for når oppgaven utgikk.
+
+        Optional: hvis ikke oppgitt/null, så blir den satt til now().
+        """
         utgaattTidspunkt: ISO8601DateTime = null
     ): OppgaveUtgaattResultat!
 
-    # Utsett frist på en oppgave.
-    # Dersom oppgaven allerede er utgått så gjenåpnes den og fristen utsettes.
-    # Dersom fristen ikke var utgått, og det tidligere var angitt en påminnelse så vil den påminnelsen bli slettet.
-    # Dersom dere ønsker at brukeren skal få en påminnelse når fristen nærmer seg må det angis i denne mutasjonen.
+    """
+    Utsett frist på en oppgave.
+    Dersom oppgaven allerede er utgått så gjenåpnes den og fristen utsettes.
+    Dersom fristen ikke var utgått, og det tidligere var angitt en påminnelse så vil den påminnelsen bli slettet.
+    Dersom dere ønsker at brukeren skal få en påminnelse når fristen nærmer seg må det angis i denne mutasjonen.
+    """
     oppgaveUtsettFrist(
-        # ID-en som oppgaven har. Den du fikk da du opprettet oppgaven med `nyOppgave`.
+        """
+        ID-en som oppgaven har. Den du fikk da du opprettet oppgaven med `nyOppgave`.
+        """
         id: ID!
 
-        # Her angir du den nye fristen for når oppgaven skal utføres av bruker.
-        #
-        # Fristen vises til bruker i grensesnittet.
-        # Oppgaven blir automatisk markert som `UTGAAT` når fristen er forbi.
-        # Dere kan kun oppgi frist med dato, og ikke klokkelsett.
-        # Fristen regnes som utløpt når dagen er omme (midnatt, norsk tidssone).
+        """
+        Her angir du den nye fristen for når oppgaven skal utføres av bruker.
+
+        Fristen vises til bruker i grensesnittet.
+        Oppgaven blir automatisk markert som `UTGAAT` når fristen er forbi.
+        Dere kan kun oppgi frist med dato, og ikke klokkelsett.
+        Fristen regnes som utløpt når dagen er omme (midnatt, norsk tidssone).
+        """
         nyFrist: ISO8601Date!
 
-        # Her kan du spesifisere en påminnelse for oppgaven.
-        # Brukeren vil bli gjort oppmerksom via bjellen og evt ekstern varsling dersom du oppgir det.
+        """
+        Her kan du spesifisere en påminnelse for oppgaven.
+        Brukeren vil bli gjort oppmerksom via bjellen og evt ekstern varsling dersom du oppgir det.
+        """
         paaminnelse: PaaminnelseInput
     ): OppgaveUtsettFristResultat!
 
-    # Utsett frist på en oppgave (identifisert ved ekstern id).
-    # Dersom oppgaven allerede er utgått så gjenåpnes den og fristen utsettes.
-    # Dersom fristen ikke var utgått, og det tidligere var angitt en påminnelse så vil den påminnelsen bli slettet.
-    # Dersom dere ønsker at brukeren skal få en påminnelse når fristen nærmer seg må det angis i denne mutasjonen.
+
+    """
+    Utsett frist på en oppgave (identifisert ved ekstern id).
+    Dersom oppgaven allerede er utgått så gjenåpnes den og fristen utsettes.
+    Dersom fristen ikke var utgått, og det tidligere var angitt en påminnelse så vil den påminnelsen bli slettet.
+    Dersom dere ønsker at brukeren skal få en påminnelse når fristen nærmer seg må det angis i denne mutasjonen.
+    """
     oppgaveUtsettFristByEksternId(
-        # Merkelapp som oppgaven er registrert med.
-        merkelapp: String!
+        """
+        Merkelapp som oppgaven er registrert med.
+        """
+        merkelapp: String!,
 
-        # ID-en som *dere ga oss* da dere opprettet oppgaven med `nyOppgave`.
+        """
+        ID-en som *dere ga oss* da dere opprettet oppgaven med `nyOppgave`.
+        """
         eksternId: String!
 
-        # Her angir du den nye fristen for når oppgaven skal utføres av bruker.
-        #
-        # Fristen vises til bruker i grensesnittet.
-        # Oppgaven blir automatisk markert som `UTGAAT` når fristen er forbi.
-        # Dere kan kun oppgi frist med dato, og ikke klokkelsett.
-        # Fristen regnes som utløpt når dagen er omme (midnatt, norsk tidssone).
+        """
+        Her angir du den nye fristen for når oppgaven skal utføres av bruker.
+
+        Fristen vises til bruker i grensesnittet.
+        Oppgaven blir automatisk markert som `UTGAAT` når fristen er forbi.
+        Dere kan kun oppgi frist med dato, og ikke klokkelsett.
+        Fristen regnes som utløpt når dagen er omme (midnatt, norsk tidssone).
+        """
         nyFrist: ISO8601Date!
 
-        # Her kan du spesifisere en påminnelse for oppgaven.
-        # Brukeren vil bli gjort oppmerksom via bjellen og evt ekstern varsling dersom du oppgir det.
+        """
+        Her kan du spesifisere en påminnelse for oppgaven.
+        Brukeren vil bli gjort oppmerksom via bjellen og evt ekstern varsling dersom du oppgir det.
+        """
         paaminnelse: PaaminnelseInput
     ): OppgaveUtsettFristResultat!
 
-    # Endre påminnelsen for en oppgave.
-    # Dersom oppgaven har en eksisterende påminnelse, vil denne bli overskrevet. Eksterne varsler blir også overskrevet
-    # For fjerning av påminnelse, kan man send inn null
+    """
+    Endre påminnelsen for en oppgave.
+    Dersom oppgaven har en eksisterende påminnelse, vil denne bli overskrevet. Eksterne varsler blir også overskrevet
+    For fjerning av påminnelse, kan man send inn null
+    """
     oppgaveEndrePaaminnelse(
-        # ID-en som oppgaven har. Den du fikk da du opprettet oppgaven med `nyOppgave`.
+        """
+        ID-en som oppgaven har. Den du fikk da du opprettet oppgaven med `nyOppgave`.
+        """
         id: ID!
 
-        # Dersom dere angir idempotenceKey så vil konsekvente kall med samme idempotenceKey gi samme resultat.
-        # Dette kan f.eks være nyttig hvis dere har retry mekanismer i deres system.
+        """
+        Dersom dere angir idempotenceKey så vil konsekvente kall med samme idempotenceKey gi samme resultat.
+        Dette kan f.eks være nyttig hvis dere har retry mekanismer i deres system.
+        """
         idempotencyKey: String
 
-        # Her kan du spesifisere en påminnelse for oppgaven.
-        # Dersom eksisterende påminnelse skal fjernes, spesifiser null
-        # Brukeren vil bli gjort oppmerksom via bjellen og evt ekstern varsling dersom du oppgir det.
+        """
+        Her kan du spesifisere en påminnelse for oppgaven.
+        Dersom eksisterende påminnelse skal fjernes, spesifiser null
+        Brukeren vil bli gjort oppmerksom via bjellen og evt ekstern varsling dersom du oppgir det.
+        """
         paaminnelse: PaaminnelseInput
-    ): OppgaveEndrePaaminnelseResultat!
+    ) : OppgaveEndrePaaminnelseResultat!
 
-    # Endre påminnelsen for en oppgave (identifisert ved ekstern id)
-    # Dersom oppgaven har en eksisterende påminnelse, vil denne bli overskrevet. Eksterne varsler blir også overskrevet
-    # For fjerning av påminnelse, kan man send inn null
+    """
+    Endre påminnelsen for en oppgave (identifisert ved ekstern id)
+    Dersom oppgaven har en eksisterende påminnelse, vil denne bli overskrevet. Eksterne varsler blir også overskrevet
+    For fjerning av påminnelse, kan man send inn null
+    """
     oppgaveEndrePaaminnelseByEksternId(
-        # Merkelapp som oppgaven er registrert med.
-        merkelapp: String!
+        """
+        Merkelapp som oppgaven er registrert med.
+        """
+        merkelapp: String!,
 
-        # ID-en som *dere ga oss* da dere opprettet oppgaven med `nyOppgave`.
+        """
+        ID-en som *dere ga oss* da dere opprettet oppgaven med `nyOppgave`.
+        """
         eksternId: String!
 
-        # Dersom dere angir idempotenceKey så vil konsekvente kall med samme idempotenceKey gi samme resultat.
-        # Dette kan f.eks være nyttig hvis dere har retry mekanismer i deres system.
+        """
+        Dersom dere angir idempotenceKey så vil konsekvente kall med samme idempotenceKey gi samme resultat.
+        Dette kan f.eks være nyttig hvis dere har retry mekanismer i deres system.
+        """
         idempotencyKey: String
 
-        # Her kan du spesifisere en påminnelse for oppgaven.
-        # Dersom eksisterende påminnelse skal fjernes, spesifiser null
-        # Brukeren vil bli gjort oppmerksom via bjellen og evt ekstern varsling dersom du oppgir det.
+        """
+        Her kan du spesifisere en påminnelse for oppgaven.
+        Dersom eksisterende påminnelse skal fjernes, spesifiser null
+        Brukeren vil bli gjort oppmerksom via bjellen og evt ekstern varsling dersom du oppgir det.
+        """
         paaminnelse: PaaminnelseInput
-    ): OppgaveEndrePaaminnelseResultat!
+    ) : OppgaveEndrePaaminnelseResultat!
 
-    # Oppdater tilstand på en kalenderavtale.
-    # Det er ingen regler tilknyttet endring av tilstand. Dere bestemmer her hvilken tilstand avtalen skal ha.
-    # Den nye tilstanden vises til brukeren. Dette kallet er ment for å oppdatere tilstand samt gi brukeren mer utfyllende informasjon når det blir kjent.
-    # Dette kallet vil anses som vellyket uavhengig av om dataen faktisk er endret. Dvs hvis dere sender inn samme tilstand som allerede er satt, så vil kallet anses som vellykket.
-    # Dette gjelder også hvis dere gjør kallet uten å oppgi noen nye verdier.
+
+    """
+    Oppdater tilstand på en kalenderavtale.
+    Det er ingen regler tilknyttet endring av tilstand. Dere bestemmer her hvilken tilstand avtalen skal ha.
+    Den nye tilstanden vises til brukeren. Dette kallet er ment for å oppdatere tilstand samt gi brukeren mer utfyllende informasjon når det blir kjent.
+    Dette kallet vil anses som vellyket uavhengig av om dataen faktisk er endret. Dvs hvis dere sender inn samme tilstand som allerede er satt, så vil kallet anses som vellykket.
+    Dette gjelder også hvis dere gjør kallet uten å oppgi noen nye verdier.
+    """
     oppdaterKalenderavtale(
-        # ID-en som kalenderavtalen har. Den du fikk da du opprettet kalenderavtalen med `nyKalenderavtale`.
+        """
+        ID-en som kalenderavtalen har. Den du fikk da du opprettet kalenderavtalen med `nyKalenderavtale`.
+        """
         id: ID!
 
-        # Ny tilstand for kalenderavtalen.
-        # Dersom ny tilstand settes til `AVLYST` vil vi stoppe eksterne varslinger som ikke allerede er sendt,
-        # og kansellere registrerte påminnelser.
+        """
+        Ny tilstand for kalenderavtalen.
+        Dersom ny tilstand settes til `AVLYST` vil vi stoppe eksterne varslinger som ikke allerede er sendt,
+        og kansellere registrerte påminnelser.
+        """
         nyTilstand: KalenderavtaleTilstand
 
-        # Teksten som vises til brukeren.
+        """
+        Teksten som vises til brukeren.
+        """
         nyTekst: String
 
-        # Lenken som brukeren føres til hvis de klikker på kalenderavtalen. Typisk en side i deres system som viser detaljer om avtalen.
+        """
+        Lenken som brukeren føres til hvis de klikker på kalenderavtalen. Typisk en side i deres system som viser detaljer om avtalen.
+        """
         nyLenke: String
 
-        # Her kan dere oppgi en fysisk adresse som brukeren kan møte opp på dersom dere har det.
-        # Denne vil vises til brukeren hvis den er angitt.
+        """
+        Her kan dere oppgi en fysisk adresse som brukeren kan møte opp på dersom dere har det.
+        Denne vil vises til brukeren hvis den er angitt.
+        """
         nyLokasjon: LokasjonInput
 
-        # Ved å sette dette flagget kan dere vise brukeren at det er mulig å møte digitalt.
-        # Det vil vises til brukeren hvis det er satt til true.
+        """
+        Ved å sette dette flagget kan dere vise brukeren at det er mulig å møte digitalt.
+        Det vil vises til brukeren hvis det er satt til true.
+        """
         nyErDigitalt: Boolean
 
-        # Se: [HardDeleteUpdateInput typen](#harddeleteupdateinput)
+        """
+        Se: [HardDeleteUpdateInput typen](#harddeleteupdateinput)
+        """
         hardDelete: HardDeleteUpdateInput
 
-        # Dersom dere angir idempotenceKey så vil konsekvente kall med samme idempotenceKey gi samme resultat.
-        # Dette kan f.eks være nyttig hvis dere har retry mekanismer i deres system.
+        """
+        Dersom dere angir idempotenceKey så vil konsekvente kall med samme idempotenceKey gi samme resultat.
+        Dette kan f.eks være nyttig hvis dere har retry mekanismer i deres system.
+        """
         idempotencyKey: String
 
-        # Her kan dere oppgi eksterne varsler som skal sendes i forbindelse med oppdateringen.
-        # Disse varslene vil erstatte tidligere bestilte varsler som ikke er sendt enda.
-        # Vi anbefaler dere å bruke denne i kombinasjon med idempotencyKey for å unngå å sende samme varsel flere ganger.
+        """
+        Her kan dere oppgi eksterne varsler som skal sendes i forbindelse med oppdateringen.
+        Disse varslene vil erstatte tidligere bestilte varsler som ikke er sendt enda.
+        Vi anbefaler dere å bruke denne i kombinasjon med idempotencyKey for å unngå å sende samme varsel flere ganger.
+        """
         eksterneVarsler: [EksterntVarselInput!]! = []
 
-        # Her kan du spesifisere en påminnelse for kalenderavtalen.
-        # Brukeren vil bli gjort oppmerksom via bjellen og evt ekstern varsling dersom du oppgir det.
-        # Dersom dere senere oppdaterer kalenderavtalen og setter den til AVLYST, vil vi kansellere registrerte påminnelser.
-        # Vi anbefaler dere å bruke denne i kombinasjon med idempotencyKey.
+        """
+        Her kan du spesifisere en påminnelse for kalenderavtalen.
+        Brukeren vil bli gjort oppmerksom via bjellen og evt ekstern varsling dersom du oppgir det.
+        Dersom dere senere oppdaterer kalenderavtalen og setter den til AVLYST, vil vi kansellere registrerte påminnelser.
+        Vi anbefaler dere å bruke denne i kombinasjon med idempotencyKey.
+        """
         paaminnelse: PaaminnelseInput
     ): OppdaterKalenderavtaleResultat!
 
-    # Oppdater tilstand på en kalenderavtale (identifisert ved ekstern id).
-    # Det er ingen regler tilknyttet endring av tilstand. Dere bestemmer her hvilken tilstand avtalen skal ha.
-    # Den nye tilstanden vises til brukeren. Dette kallet er ment for å oppdatere tilstand samt gi brukeren mer utfyllende informasjon når det blir kjent.
-    # Dette kallet vil anses som vellyket uavhengig av om dataen faktisk er endret. Dvs hvis dere sender inn samme tilstand som allerede er satt, så vil kallet anses som vellykket.
-    # Dette gjelder også hvis dere gjør kallet uten å oppgi noen nye verdier.
+
+    """
+    Oppdater tilstand på en kalenderavtale (identifisert ved ekstern id).
+    Det er ingen regler tilknyttet endring av tilstand. Dere bestemmer her hvilken tilstand avtalen skal ha.
+    Den nye tilstanden vises til brukeren. Dette kallet er ment for å oppdatere tilstand samt gi brukeren mer utfyllende informasjon når det blir kjent.
+    Dette kallet vil anses som vellyket uavhengig av om dataen faktisk er endret. Dvs hvis dere sender inn samme tilstand som allerede er satt, så vil kallet anses som vellykket.
+    Dette gjelder også hvis dere gjør kallet uten å oppgi noen nye verdier.
+    """
     oppdaterKalenderavtaleByEksternId(
-        # Merkelapp som kalenderavtalen er registrert med.
-        merkelapp: String!
+        """
+        Merkelapp som kalenderavtalen er registrert med.
+        """
+        merkelapp: String!,
 
-        # ID-en som *dere ga oss* da dere opprettet kalenderavtalen med `nyKalenderavtale`.
+        """
+        ID-en som *dere ga oss* da dere opprettet kalenderavtalen med `nyKalenderavtale`.
+        """
         eksternId: String!
 
-        # Ny tilstand for kalenderavtalen.
-        # Dersom ny tilstand settes til `AVLYST` vil vi stoppe eksterne varslinger som ikke allerede er sendt,
-        # og kansellere registrerte påminnelser.
+        """
+        Ny tilstand for kalenderavtalen.
+        Dersom ny tilstand settes til `AVLYST` vil vi stoppe eksterne varslinger som ikke allerede er sendt,
+        og kansellere registrerte påminnelser.
+        """
         nyTilstand: KalenderavtaleTilstand
 
-        # Teksten som vises til brukeren.
+        """
+        Teksten som vises til brukeren.
+        """
         nyTekst: String
 
-        # Lenken som brukeren føres til hvis de klikker på kalenderavtalen. Typisk en side i deres system som viser detaljer om avtalen.
+        """
+        Lenken som brukeren føres til hvis de klikker på kalenderavtalen. Typisk en side i deres system som viser detaljer om avtalen.
+        """
         nyLenke: String
 
-        # Her kan dere oppgi en fysisk adresse som brukeren kan møte opp på dersom dere har det.
-        # Denne vil vises til brukeren hvis den er angitt.
+        """
+        Her kan dere oppgi en fysisk adresse som brukeren kan møte opp på dersom dere har det.
+        Denne vil vises til brukeren hvis den er angitt.
+        """
         nyLokasjon: LokasjonInput
 
-        # Ved å sette dette flagget kan dere vise brukeren at det er mulig å møte digitalt.
-        # Det vil vises til brukeren hvis det er satt til true.
+        """
+        Ved å sette dette flagget kan dere vise brukeren at det er mulig å møte digitalt.
+        Det vil vises til brukeren hvis det er satt til true.
+        """
         nyErDigitalt: Boolean
 
-        # Se: [HardDeleteUpdateInput typen](#harddeleteupdateinput)
+        """
+        Se: [HardDeleteUpdateInput typen](#harddeleteupdateinput)
+        """
         hardDelete: HardDeleteUpdateInput
 
-        # Dersom dere angir idempotenceKey så vil konsekvente kall med samme idempotenceKey gi samme resultat.
-        # Dette kan f.eks være nyttig hvis dere har retry mekanismer i deres system.
+        """
+        Dersom dere angir idempotenceKey så vil konsekvente kall med samme idempotenceKey gi samme resultat.
+        Dette kan f.eks være nyttig hvis dere har retry mekanismer i deres system.
+        """
         idempotencyKey: String
 
-        # Her kan dere oppgi eksterne varsler som skal sendes i forbindelse med oppdateringen.
-        # Disse varslene vil erstatte tidligere bestilte varsler som ikke er sendt enda.
-        # Vi anbefaler dere å bruke denn i kombinasjon med idempoencyKey for å unngå å sende samme varsel flere ganger.
+        """
+        Her kan dere oppgi eksterne varsler som skal sendes i forbindelse med oppdateringen.
+        Disse varslene vil erstatte tidligere bestilte varsler som ikke er sendt enda.
+        Vi anbefaler dere å bruke denn i kombinasjon med idempoencyKey for å unngå å sende samme varsel flere ganger.
+        """
         eksterneVarsler: [EksterntVarselInput!]! = []
 
-        # Her kan du spesifisere en påminnelse for kalenderavtalen.
-        # Brukeren vil bli gjort oppmerksom via bjellen og evt ekstern varsling dersom du oppgir det.
-        # Dersom dere senere oppdaterer kalenderavtalen og setter den til AVLYST, vil vi kansellere registrerte påminnelser.
-        # Vi anbefaler dere å bruke denne i kombinasjon med idempotencyKey.
+        """
+        Her kan du spesifisere en påminnelse for kalenderavtalen.
+        Brukeren vil bli gjort oppmerksom via bjellen og evt ekstern varsling dersom du oppgir det.
+        Dersom dere senere oppdaterer kalenderavtalen og setter den til AVLYST, vil vi kansellere registrerte påminnelser.
+        Vi anbefaler dere å bruke denne i kombinasjon med idempotencyKey.
+        """
         paaminnelse: PaaminnelseInput
     ): OppdaterKalenderavtaleResultat!
 
-    # Markerer en notifikasjon som slettet (soft delete).
-    #
-    # Notifikasjonen vil forsvinne helt for mottakeren: de vil ikke kunne se den på
-    # noen som helst måte — som om notifikasjonen aldri eksisterte.
-    #
-    # For dere (produsenter), så kan dere fortsatt se notifikasjonen i listen over deres notifikasjoner.
-    #
-    # Eventuelle eksterne varsler (SMS, e-post) knyttet til notifikasjonen vil bli fortsatt bli sendt.
-    #
-    # Advarsel: det er ikke mulig å angre på denne operasjonen.
     softDeleteNotifikasjon(id: ID!): SoftDeleteNotifikasjonResultat!
+    @deprecated(reason:
+    "All sletting er endret til å medføre hard delete. Denne mutation blir snart fjernet. bruk hardDeleteNotifikasjon(id) i stedet."
+    )
 
-    # Se dokumentasjon for `softDeleteNotifikasjon(id)`.
     softDeleteNotifikasjonByEksternId(
-        # Merkelappen som dere ga oss da dere opprettet notifikasjonen.
-        merkelapp: String!
-
-        # ID-en som dere ga oss da dere opprettet notifikasjonen.
+        merkelapp: String!,
         eksternId: ID!
     ): SoftDeleteNotifikasjonResultat!
-    @deprecated(
-        reason: "Using the type ID for `eksternId` can lead to unexpected behaviour. Use softDeleteNotifikasjonByEksternId_V2 instead."
+    @deprecated(reason:
+    "All sletting er endret til å medføre hard delete. Denne mutation blir snart fjernet. bruk hardDeleteNotifikasjonByEksternId_V2(merkelapp, eksternId) i stedet."
     )
 
-    # Se dokumentasjon for `softDeleteNotifikasjon(id)`.
     softDeleteNotifikasjonByEksternId_V2(
-        # Merkelappen som dere ga oss da dere opprettet notifikasjonen.
-        merkelapp: String!
-
-        # ID-en som dere ga oss da dere opprettet notifikasjonen.
+        merkelapp: String!,
         eksternId: String!
     ): SoftDeleteNotifikasjonResultat!
-
-    # Sletter en notifikasjon og tilhørende data helt fra databasen og kafka.
-    # Formålet er å støtte juridiske krav om sletting i henhold til personvern.
-    #
-    # Eventuelle eksterne varsler (SMS, e-post) knyttet til notifikasjonen vil bli fortsatt bli sendt.
-    #
-    # Advarsel: det er ikke mulig å angre på denne operasjonen. All data blir borte for godt.
-    hardDeleteNotifikasjon(
-        # ID-en som notifikasjolnen har. Den du fikk da du opprettet notifikasjonen.
-        id: ID!
-    ): HardDeleteNotifikasjonResultat!
-
-    # Se dokumentasjon for `hardDeleteNotifikasjon(id)`.
-    hardDeleteNotifikasjonByEksternId(
-        # Merkelappen som dere ga oss da dere opprettet notifikasjonen.
-        merkelapp: String!
-
-        # ID-en som dere ga oss da dere opprettet notifikasjonen.
-        eksternId: ID!
-    ): HardDeleteNotifikasjonResultat!
-    @deprecated(
-        reason: "Using the type ID for `eksternId` can lead to unexpected behaviour. Use hardDeleteNotifikasjonByEksternId_V2 instead."
+    @deprecated(reason:
+    "All sletting er endret til å medføre hard delete. Denne mutation blir snart fjernet. bruk hardDeleteNotifikasjonByEksternId_V2(merkelapp, eksternId) i stedet."
     )
 
-    # Se dokumentasjon for `hardDeleteNotifikasjon(id)`.
-    hardDeleteNotifikasjonByEksternId_V2(
-        # Merkelappen som dere ga oss da dere opprettet notifikasjonen.
+    hardDeleteNotifikasjonByEksternId(
         merkelapp: String!
-
-        # ID-en som dere ga oss da dere opprettet notifikasjonen.
-        eksternId: String!
+        eksternId: ID!
     ): HardDeleteNotifikasjonResultat!
+    @deprecated(reason:
+    "Using the type ID for `eksternId` can lead to unexpected behaviour. Use hardDeleteNotifikasjonByEksternId_V2 instead."
+    )
 
-    # Markerer en sak som slettet (soft delete).
-    #
-    # Sak vil forsvinne helt for mottakeren: de vil ikke kunne se den på
-    # noen som helst måte — som om saken aldri eksisterte.
-    #
-    # Advarsel: det er ikke mulig å angre på denne operasjonen.
-    # Advarsel: ingen notifikasjoner blir slettet, selv om de har samme grupperingsid.
     softDeleteSak(
-        # ID-en som notifikasjolnen har. Den du fikk da du opprettet notifikasjonen.
         id: ID!
     ): SoftDeleteSakResultat!
+    @deprecated(reason:
+    "All sletting er endret til å medføre hard delete. Denne mutation blir snart fjernet. bruk hardDeleteSak(id) i stedet."
+    )
 
-    # Se dokumentasjon for `softDeleteSak(id)`.
     softDeleteSakByGrupperingsid(
-        # Merkelappen som dere ga oss da dere opprettet saken.
         merkelapp: String!
-
-        # ID-en som dere ga oss da dere opprettet saken.
         grupperingsid: String!
     ): SoftDeleteSakResultat!
+    @deprecated(reason:
+    "All sletting er endret til å medføre hard delete. Denne mutation blir snart fjernet. bruk hardDeleteSakByGrupperingsid(merkelapp, grupperingsid) i stedet."
+    )
 
-    # Sletter en sak og tilhørende data helt fra databasen og kafka.
-    # Formålet er å støtte juridiske krav om sletting i henhold til personvern.
-    #
-    # Advarsel: det er ikke mulig å angre på denne operasjonen. All data blir borte for godt.
-    # Advarsel: notifikasjoner med samme merkelapp og grupperingsid blir slettet.
-    # Advarsel: Det vil ikke være mulig å lage en ny sak med samme merkelapp og grupperingsid.
-    hardDeleteSak(id: ID!): HardDeleteSakResultat!
+    """
+    Sletter en notifikasjon og tilhørende data helt fra databasen og kafka.
+    Formålet er å støtte juridiske krav om sletting i henhold til personvern.
 
-    # Se dokumentasjon for `hardDeleteSak(id)`.
-    hardDeleteSakByGrupperingsid(
-        # Merkelappen som dere ga oss da dere opprettet saken.
+    Eventuelle eksterne varsler (SMS, e-post) knyttet til notifikasjonen vil bli fortsatt bli sendt.
+
+    Advarsel: det er ikke mulig å angre på denne operasjonen. All data blir borte for godt.
+    """
+    hardDeleteNotifikasjon(
+        """
+        ID-en som notifikasjolnen har. Den du fikk da du opprettet notifikasjonen.
+        """
+        id: ID!
+    ): HardDeleteNotifikasjonResultat!
+
+    """
+    Se dokumentasjon for `hardDeleteNotifikasjon(id)`.
+    """
+    hardDeleteNotifikasjonByEksternId_V2(
+        """
+        Merkelappen som dere ga oss da dere opprettet notifikasjonen.
+        """
         merkelapp: String!
 
-        # ID-en som dere ga oss da dere opprettet saken.
+        """
+        ID-en som dere ga oss da dere opprettet notifikasjonen.
+        """
+        eksternId: String!
+    ): HardDeleteNotifikasjonResultat!
+
+    """
+    Sletter en sak og tilhørende data helt fra databasen og kafka.
+    Formålet er å støtte juridiske krav om sletting i henhold til personvern.
+
+    Advarsel: det er ikke mulig å angre på denne operasjonen. All data blir borte for godt.
+    Advarsel: notifikasjoner med samme merkelapp og grupperingsid blir slettet.
+    Advarsel: Det vil ikke være mulig å lage en ny sak med samme merkelapp og grupperingsid.
+    """
+    hardDeleteSak(id: ID!): HardDeleteSakResultat!
+
+    """
+    Se dokumentasjon for `hardDeleteSak(id)`.
+    """
+    hardDeleteSakByGrupperingsid(
+        """
+        Merkelappen som dere ga oss da dere opprettet saken.
+        """
+        merkelapp: String!
+
+        """
+        ID-en som dere ga oss da dere opprettet saken.
+        """
         grupperingsid: String!
     ): HardDeleteSakResultat!
 }
 
 union SoftDeleteNotifikasjonResultat =
-    SoftDeleteNotifikasjonVellykket
+    | SoftDeleteNotifikasjonVellykket
     | UgyldigMerkelapp
     | NotifikasjonFinnesIkke
     | UkjentProdusent
 
 type SoftDeleteNotifikasjonVellykket {
-    # ID-en til oppgaven du "soft-delete"-et.
+    """
+    ID-en til oppgaven du "soft-delete"-et.
+    """
     id: ID!
 }
 
 union HardDeleteNotifikasjonResultat =
-    HardDeleteNotifikasjonVellykket
+    | HardDeleteNotifikasjonVellykket
     | UgyldigMerkelapp
     | NotifikasjonFinnesIkke
     | UkjentProdusent
 
 type HardDeleteNotifikasjonVellykket {
-    # ID-en til oppgaven du "hard-delete"-et.
+    """
+    ID-en til oppgaven du "hard-delete"-et.
+    """
     id: ID!
 }
 
 union SoftDeleteSakResultat =
-    SoftDeleteSakVellykket
+    | SoftDeleteSakVellykket
     | UgyldigMerkelapp
     | SakFinnesIkke
     | UkjentProdusent
 
 type SoftDeleteSakVellykket {
-    # ID-en til saken du "soft-delete"-et.
+    """
+    ID-en til saken du "soft-delete"-et.
+    """
     id: ID!
 }
 
 union HardDeleteSakResultat =
-    HardDeleteSakVellykket
+    | HardDeleteSakVellykket
     | UgyldigMerkelapp
     | SakFinnesIkke
     | UkjentProdusent
 
 type HardDeleteSakVellykket {
-    # ID-en til saken du "hard-delete"-et.
+    """
+    ID-en til saken du "hard-delete"-et.
+    """
     id: ID!
 }
-
 union OppgaveUtgaattResultat =
-    OppgaveUtgaattVellykket
+    | OppgaveUtgaattVellykket
     | UgyldigMerkelapp
     | OppgavenErAlleredeUtfoert
     | NotifikasjonFinnesIkke
     | UkjentProdusent
 
 type OppgaveUtgaattVellykket {
-    # ID-en til oppgaven du oppdaterte.
+    """
+    ID-en til oppgaven du oppdaterte.
+    """
     id: ID!
 }
 
 union OppgaveUtfoertResultat =
-    OppgaveUtfoertVellykket
+    | OppgaveUtfoertVellykket
     | UgyldigMerkelapp
     | NotifikasjonFinnesIkke
     | UkjentProdusent
 
 type OppgaveUtfoertVellykket {
-    # ID-en til oppgaven du oppdaterte.
+    """
+    ID-en til oppgaven du oppdaterte.
+    """
     id: ID!
 }
 
 union OppgaveUtsettFristResultat =
-    OppgaveUtsettFristVellykket
+    | OppgaveUtsettFristVellykket
     | UgyldigMerkelapp
     | Konflikt
     | UgyldigPaaminnelseTidspunkt
@@ -1003,17 +1285,21 @@ union OppgaveUtsettFristResultat =
     | UkjentProdusent
 
 type OppgaveUtsettFristVellykket {
-    # ID-en til oppgaven du oppdaterte.
+    """
+    ID-en til oppgaven du oppdaterte.
+    """
     id: ID!
 }
 
 type OppgaveEndrePaaminnelseVellykket {
-    # ID-en til oppgaven du oppdaterte.
+    """
+    ID-en til oppgaven du oppdaterte.
+    """
     id: ID!
 }
 
 union OppgaveEndrePaaminnelseResultat =
-    OppgaveEndrePaaminnelseVellykket
+    | OppgaveEndrePaaminnelseVellykket
     | UgyldigMerkelapp
     | UgyldigPaaminnelseTidspunkt
     | OppgavenErAlleredeUtfoert
@@ -1021,7 +1307,7 @@ union OppgaveEndrePaaminnelseResultat =
     | UkjentProdusent
 
 union OppdaterKalenderavtaleResultat =
-    OppdaterKalenderavtaleVellykket
+    | OppdaterKalenderavtaleVellykket
     | UgyldigKalenderavtale
     | UgyldigMerkelapp
     | Konflikt
@@ -1029,82 +1315,106 @@ union OppdaterKalenderavtaleResultat =
     | UkjentProdusent
 
 type OppdaterKalenderavtaleVellykket {
-    # ID-en til kalenderavtalen du oppdaterte.
+    """
+    ID-en til kalenderavtalen du oppdaterte.
+    """
     id: ID!
 }
 
 input NyBeskjedInput {
-    # Se dokumentasjonen til `mottakere`-feltet.
+    """
+    Se dokumentasjonen til `mottakere`-feltet.
+    """
     mottaker: MottakerInput
 
-    # Her bestemmer dere hvem som skal få se notifikasjonen.
-    #
-    # Hvis dere oppgir en mottaker i `mottaker`-feltet, så tolker vi det som om det var et element
-    # i denne listen over mottakere.
-    #
-    # Dere må gi oss minst 1 mottaker.
+    """
+    Her bestemmer dere hvem som skal få se notifikasjonen.
+
+    Hvis dere oppgir en mottaker i `mottaker`-feltet, så tolker vi det som om det var et element
+    i denne listen over mottakere.
+
+    Dere må gi oss minst 1 mottaker.
+    """
     mottakere: [MottakerInput!]! = []
+
     notifikasjon: NotifikasjonInput!
     metadata: MetadataInput!
     eksterneVarsler: [EksterntVarselInput!]! = []
 }
 
 input NyOppgaveInput {
-    # Se dokumentasjonen til `mottakere`-feltet.
+    """
+    Se dokumentasjonen til `mottakere`-feltet.
+    """
     mottaker: MottakerInput
 
-    # Her bestemmer dere hvem som skal få se notifikasjonen.
-    #
-    # Hvis dere oppgir en mottaker i `mottaker`-feltet, så tolker vi det som om det var et element
-    # i denne listen over mottakere.
-    #
-    # Dere må gi oss minst 1 mottaker.
+    """
+    Her bestemmer dere hvem som skal få se notifikasjonen.
+
+    Hvis dere oppgir en mottaker i `mottaker`-feltet, så tolker vi det som om det var et element
+    i denne listen over mottakere.
+
+    Dere må gi oss minst 1 mottaker.
+    """
     mottakere: [MottakerInput!]! = []
     notifikasjon: NotifikasjonInput!
 
-    # Her kan du spesifisere frist for når oppgaven skal utføres av bruker.
-    # Ideen er at etter fristen, så har ikke bruker lov, eller dere sperret for,
-    # å gjøre oppgaven.
-    #
-    # Fristen vises til bruker i grensesnittet.
-    # Oppgaven blir automatisk markert som `UTGAAT` når fristen er forbi.
-    # Dere kan kun oppgi frist med dato, og ikke klokkelsett.
-    # Fristen regnes som utløpt når dagen er omme (midnatt, norsk tidssone).
-    #
-    # Hvis dere ikke sender med frist, så viser vi ingen frist for bruker,
-    # og oppgaven anses som NY frem til dere markerer oppgaven som `UTFOERT` eller
-    # `UTGAATT`.
+    """
+    Her kan du spesifisere frist for når oppgaven skal utføres av bruker.
+    Ideen er at etter fristen, så har ikke bruker lov, eller dere sperret for,
+    å gjøre oppgaven.
+
+    Fristen vises til bruker i grensesnittet.
+    Oppgaven blir automatisk markert som `UTGAAT` når fristen er forbi.
+    Dere kan kun oppgi frist med dato, og ikke klokkelsett.
+    Fristen regnes som utløpt når dagen er omme (midnatt, norsk tidssone).
+
+    Hvis dere ikke sender med frist, så viser vi ingen frist for bruker,
+    og oppgaven anses som NY frem til dere markerer oppgaven som `UTFOERT` eller
+    `UTGAATT`.
+    """
     frist: ISO8601Date
     metadata: MetadataInput!
     eksterneVarsler: [EksterntVarselInput!]! = []
 
-    # Her kan du spesifisere en påminnelse for en oppgave.
-    # Brukeren vil bli gjort oppmerksom via bjellen og evt ekstern varsling dersom du oppgir det.
+    """
+    Her kan du spesifisere en påminnelse for en oppgave.
+    Brukeren vil bli gjort oppmerksom via bjellen og evt ekstern varsling dersom du oppgir det.
+    """
     paaminnelse: PaaminnelseInput
 }
 
 input PaaminnelseInput {
-    # Tidspunktet for når påminnelsen skal aktiveres.
-    # Dersom det er angitt frist må påminnelsen være før dette.
-    #
-    # Hvis du sender `eksterneVarsler`, så vil vi sjekke at vi har
-    # mulighet for å sende dem før fristen, ellers får du feil ved
-    # opprettelse av oppgaven/kalenderavtalen.
+    """
+    Tidspunktet for når påminnelsen skal aktiveres.
+    Dersom det er angitt frist må påminnelsen være før dette.
+
+    Hvis du sender `eksterneVarsler`, så vil vi sjekke at vi har
+    mulighet for å sende dem før fristen, ellers får du feil ved
+    opprettelse av oppgaven/kalenderavtalen.
+    """
     tidspunkt: PaaminnelseTidspunktInput!
     eksterneVarsler: [PaaminnelseEksterntVarselInput!]! = []
 }
 
 input PaaminnelseTidspunktInput {
-    # Konkret tidspunkt
+    """
+    Konkret tidspunkt
+    """
     konkret: ISO8601LocalDateTime
-
-    # Relativ til når oppgaven/kalenderavtalen er angitt som opprettet. Altså X duration etter opprettelse.
+    """
+    Relativ til når oppgaven/kalenderavtalen er angitt som opprettet. Altså X duration etter opprettelse.
+    """
     etterOpprettelse: ISO8601Duration
 
-    # Relativ til oppgavens frist, altså X duration før frist. Anses som ugyldig dersom det ikke er en oppgave med frist.
+    """
+    Relativ til oppgavens frist, altså X duration før frist. Anses som ugyldig dersom det ikke er en oppgave med frist.
+    """
     foerFrist: ISO8601Duration
 
-    # Relativ til kalenderavtalens startTidspunkt, altså X duration før startTidspunkt. Anses som ugyldig dersom det ikke er en kalenderavtale.
+    """
+    Relativ til kalenderavtalens startTidspunkt, altså X duration før startTidspunkt. Anses som ugyldig dersom det ikke er en kalenderavtale.
+    """
     foerStartTidspunkt: ISO8601Duration
 }
 
@@ -1112,142 +1422,238 @@ input PaaminnelseEksterntVarselInput {
     sms: PaaminnelseEksterntVarselSmsInput
     epost: PaaminnelseEksterntVarselEpostInput
     altinntjeneste: PaaminnelseEksterntVarselAltinntjenesteInput
+    altinnressurs: PaaminnelseEksterntVarselAltinnressursInput
 }
 
 input PaaminnelseEksterntVarselSmsInput {
     mottaker: SmsMottakerInput!
-
-    # Teksten som sendes i SMS-en.
-    # OBS: Det er ikke lov med personopplysninger i teksten. SMS er ikke en sikker kanal.
+    """
+    Teksten som sendes i SMS-en.
+    OBS: Det er ikke lov med personopplysninger i teksten. SMS er ikke en sikker kanal.
+    """
     smsTekst: String!
 
-    # Vi sender SMS-en med utgangspunkt i påminnelsestidspunktet, men tar hensyn
-    # til sendingsvinduet. Hvis påminnelsestidspunktet er utenfor vinduet, sender vi
-    # det ved første mulighet.
+    """
+    Vi sender SMS-en med utgangspunkt i påminnelsestidspunktet, men tar hensyn
+    til sendingsvinduet. Hvis påminnelsestidspunktet er utenfor vinduet, sender vi
+    det ved første mulighet.
+    """
     sendevindu: Sendevindu!
 }
 
 input PaaminnelseEksterntVarselEpostInput {
     mottaker: EpostMottakerInput!
-
-    # Subject/emne til e-posten.
-    # OBS: Det er ikke lov med personopplysninger i teksten. E-post er ikke en sikker kanal.
+    """
+    Subject/emne til e-posten.
+    OBS: Det er ikke lov med personopplysninger i teksten. E-post er ikke en sikker kanal.
+    """
     epostTittel: String!
-
-    # Kroppen til e-posten. Tolkes som HTML.
-    # OBS: Det er ikke lov med personopplysninger i teksten. E-post er ikke en sikker kanal.
+    """
+    Kroppen til e-posten. Tolkes som HTML.
+    OBS: Det er ikke lov med personopplysninger i teksten. E-post er ikke en sikker kanal.
+    """
     epostHtmlBody: String!
 
-    # Vi sender eposten med utgangspunkt i påminnelsestidspunktet, men tar hensyn
-    # til sendingsvinduet. Hvis påminnelsestidspunktet er utenfor vinduet, sender vi
-    # det ved første mulighet.
+    """
+    Vi sender eposten med utgangspunkt i påminnelsestidspunktet, men tar hensyn
+    til sendingsvinduet. Hvis påminnelsestidspunktet er utenfor vinduet, sender vi
+    det ved første mulighet.
+    """
     sendevindu: Sendevindu!
 }
 
 input PaaminnelseEksterntVarselAltinntjenesteInput {
     mottaker: AltinntjenesteMottakerInput!
-
-    # Subject/emne til e-posten, eller tekst i sms
-    # OBS: Det er ikke lov med personopplysninger i teksten.
+    """
+    Subject/emne til e-posten, eller tekst i sms
+    OBS: Det er ikke lov med personopplysninger i teksten.
+    """
     tittel: String!
-
-    # Kroppen til e-posten. Dersom det sendes SMS blir dette feltet lagt til i kroppen på sms etter tittel
-    # OBS: Det er ikke lov med personopplysninger i teksten.
+    """
+    Kroppen til e-posten. Dersom det sendes SMS blir dette feltet lagt til i kroppen på sms etter tittel
+    OBS: Det er ikke lov med personopplysninger i teksten.
+    """
     innhold: String!
 
-    # Vi sender eposten med utgangspunkt i påminnelsestidspunktet, men tar hensyn
-    # til sendingsvinduet. Hvis påminnelsestidspunktet er utenfor vinduet, sender vi
-    # det ved første mulighet.
+    """
+    Vi sender eposten med utgangspunkt i påminnelsestidspunktet, men tar hensyn
+    til sendingsvinduet. Hvis påminnelsestidspunktet er utenfor vinduet, sender vi
+    det ved første mulighet.
+    """
     sendevindu: Sendevindu!
 }
 
+input PaaminnelseEksterntVarselAltinnressursInput {
+    mottaker: AltinnRessursMottakerInput!
+    """
+    Subject/emne til e-posten
+    OBS: Det er ikke lov med personopplysninger i teksten.
+    """
+    epostTittel: String!
+    """
+    Kroppen til e-posten. Kan inneholde HTML.
+    OBS: Det er ikke lov med personopplysninger i teksten.
+    """
+    epostHtmlBody: String!
+    """
+    Teksten som sendes i SMS-en.
+    OBS: Det er ikke lov med personopplysninger i teksten.
+    """
+    smsTekst: String!
+    """
+    Vi sender eposten med utgangspunkt i påminnelsestidspunktet, men tar hensyn
+    til sendingsvinduet. Hvis påminnelsestidspunktet er utenfor vinduet, sender vi
+    det ved første mulighet.
+    """
+    sendevindu: Sendevindu!
+}
+
+"""
+Input som definerer hvordan et eksternt varsel skal sendes.
+Kun ett av feltene i inputen kan være satt.
+"""
 input EksterntVarselInput {
     sms: EksterntVarselSmsInput
     epost: EksterntVarselEpostInput
     altinntjeneste: EksterntVarselAltinntjenesteInput
+    altinnressurs: EksterntVarselAltinnressursInput
 }
 
-# For SMS, så vil
-# [Altinns varslingsvindu](https://altinn.github.io/docs/utviklingsguider/varsling/#varslingsvindu-for-sms)
-# også gjelde. Dette burde kun påvirke `LOEPENDE`.
+"""
+For SMS, så vil
+[Altinns varslingsvindu](https://altinn.github.io/docs/utviklingsguider/varsling/#varslingsvindu-for-sms)
+også gjelde. Dette burde kun påvirke `LOEPENDE`.
+"""
 enum Sendevindu {
-    # Vi sender varselet slik at mottaker skal ha mulighet for å
-    # kontakte NAVs kontaktsenter (NKS) når de mottar varselet. Varsler
-    # blir sendt litt før NKS åpner, og vi slutter å sende litt før
-    # NKS stenger.
-    #
-    # Vi tar foreløpig ikke hensyn til røde dager eller produksjonshendelser som fører til
-    # at NKS er utilgjengelig.
+    """
+    Vi sender varselet slik at mottaker skal ha mulighet for å
+    kontakte NAVs kontaktsenter (NKS) når de mottar varselet. Varsler
+    blir sendt litt før NKS åpner, og vi slutter å sende litt før
+    NKS stenger.
+
+    Vi tar foreløpig ikke hensyn til røde dager eller produksjonshendelser som fører til
+    at NKS er utilgjengelig.
+    """
     NKS_AAPNINGSTID
 
-    # Vi sender varselet på dagtid, mandag til lørdag.
-    # Altså sender vi ikke om kvelden og om natten, og ikke i det hele tatt på søndager.
-    #
-    # Vi tar ikke hensyn til røde dager.
+
+    """
+    Vi sender varselet på dagtid, mandag til lørdag.
+    Altså sender vi ikke om kvelden og om natten, og ikke i det hele tatt på søndager.
+
+    Vi tar ikke hensyn til røde dager.
+    """
     DAGTID_IKKE_SOENDAG
 
-    # Vi sender varslet så fort vi kan.
+    """
+    Vi sender varslet så fort vi kan.
+    """
     LOEPENDE
 }
 
-# Med denne typen velger du når du ønsker at det eksterne varselet blir sendt.
-# Du skal velge en (og kun en) av feltene, ellers blir forespørselen din avvist
-# med en feil.
+"""
+Med denne typen velger du når du ønsker at det eksterne varselet blir sendt.
+Du skal velge en (og kun en) av feltene, ellers blir forespørselen din avvist
+med en feil.
+"""
 input SendetidspunktInput {
-    # Hvis du spesifiserer et tidspunkt på formen "YYYY-MM-DDThh:mm", så sender
-    # vi notifikasjonen på det tidspunktet. Oppgir du et tidspunkt i fortiden,
-    # så sender vi varselet øyeblikkelig.
-    #
-    # Tidspunktet tolker vi som lokal, norsk tid (veggklokke-tid).
+    """
+    Hvis du spesifiserer et tidspunkt på formen "YYYY-MM-DDThh:mm", så sender
+    vi notifikasjonen på det tidspunktet. Oppgir du et tidspunkt i fortiden,
+    så sender vi varselet øyeblikkelig.
+
+    Tidspunktet tolker vi som lokal, norsk tid (veggklokke-tid).
+    """
     tidspunkt: ISO8601LocalDateTime
+
     sendevindu: Sendevindu
 }
 
+
 input EksterntVarselSmsInput {
     mottaker: SmsMottakerInput!
-
-    # Teksten som sendes i SMS-en.
-    # OBS: Det er ikke lov med personopplysninger i teksten. SMS er ikke en sikker kanal.
+    """
+    Teksten som sendes i SMS-en.
+    OBS: Det er ikke lov med personopplysninger i teksten. SMS er ikke en sikker kanal.
+    """
     smsTekst: String!
     sendetidspunkt: SendetidspunktInput!
 }
 
 input EksterntVarselEpostInput {
     mottaker: EpostMottakerInput!
-
-    # Subject/emne til e-posten.
-    # OBS: Det er ikke lov med personopplysninger i teksten. E-post er ikke en sikker kanal.
+    """
+    Subject/emne til e-posten.
+    OBS: Det er ikke lov med personopplysninger i teksten. E-post er ikke en sikker kanal.
+    """
     epostTittel: String!
-
-    # Kroppen til e-posten. Tolkes som HTML.
-    # OBS: Det er ikke lov med personopplysninger i teksten. E-post er ikke en sikker kanal.
+    """
+    Kroppen til e-posten. Tolkes som HTML.
+    OBS: Det er ikke lov med personopplysninger i teksten. E-post er ikke en sikker kanal.
+    """
     epostHtmlBody: String!
     sendetidspunkt: SendetidspunktInput!
 }
 
-# Med denne typen vil varsel sendes til virksomheten vha tjenesten i Altinn.
-# Dette vil bli sendt med EMAIL_PREFERRED, som betyr at det mest sannsynlig blir sendt som epost, men i enkelte tilfeller
-# vil bli sendt sms.
-#
-# De som har registrert sin kontaktadresse på underenheten (enten uten filter eller hvor filteret stemmer med tjenestekoden som oppgis) vil bli varslet.
-# Den offisielle kontaktinformasjonen til overenheten vil bli varslet.
-#
-# Malen som benyttes er TokenTextOnly og den ser slik ut:
-# <pre>
-# type   | subject  | notificationText
-# SMS    |          | {tittel}{innhold}
-# EMAIL  | {tittel} | {innhold}
-# </pre>
+"""
+Med denne typen vil varsel sendes til virksomheten vha tjenesten i Altinn 2.
+APIet i Altinn 2 som brukes er <a href="https://altinn.github.io/docs/api/tjenesteeiere/soap/endepunkt-liste/#notificationagencyexternal">NotificationAgencyExternal.SendStandaloneNotiuficationBasic</a>
+
+Dette vil bli sendt med EMAIL_PREFERRED, som betyr at det mest sannsynlig blir sendt som epost, men i enkelte tilfeller
+vil bli sendt sms.
+
+De som har registrert sin kontaktadresse på underenheten (enten uten filter eller hvor filteret stemmer med tjenestekoden som oppgis) vil bli varslet.
+Den offisielle kontaktinformasjonen til overenheten vil bli varslet.
+
+Malen som benyttes er TokenTextOnly og den ser slik ut:
+<pre>
+type   | subject  | notificationText
+SMS    |          | {tittel}{innhold}
+EMAIL  | {tittel} | {innhold}
+</pre>
+"""
 input EksterntVarselAltinntjenesteInput {
     mottaker: AltinntjenesteMottakerInput!
-
-    # Subject/emne til e-posten, eller tekst i sms
-    # OBS: Det er ikke lov med personopplysninger i teksten.
+    """
+    Subject/emne til e-posten, eller tekst i sms
+    OBS: Det er ikke lov med personopplysninger i teksten.
+    """
     tittel: String!
-
-    # Kroppen til e-posten. Dersom det sendes SMS blir dette feltet lagt til i kroppen på sms etter tittel
-    # OBS: Det er ikke lov med personopplysninger i teksten.
+    """
+    Kroppen til e-posten. Dersom det sendes SMS blir dette feltet lagt til i kroppen på sms etter tittel
+    OBS: Det er ikke lov med personopplysninger i teksten.
+    """
     innhold: String!
+    sendetidspunkt: SendetidspunktInput!
+}
+
+"""
+Med denne typen vil varsel sendes til virksomheten vha ressursen i Altinn 3.
+APIet i Altinn 3 som brukes er <a href="https://docs.altinn.studio/notifications/reference/api/">Altinn Notifications API</a>
+
+Dette vil bli sendt med EMAIL_PREFERRED, som betyr at det mest sannsynlig blir sendt som epost, men i enkelte tilfeller
+vil bli sendt sms.
+
+De som har registrert sin kontaktadresse på underenheten (enten uten filter eller hvor filteret stemmer med ressursen som oppgis) vil bli varslet.
+Den offisielle kontaktinformasjonen til overenheten vil bli varslet.
+"""
+input EksterntVarselAltinnressursInput {
+    mottaker: AltinnRessursMottakerInput!
+    """
+    Subject/emne til e-posten
+    OBS: Det er ikke lov med personopplysninger i teksten.
+    """
+    epostTittel: String!
+    """
+    Kroppen til e-posten. Kan inneholde HTML.
+    OBS: Det er ikke lov med personopplysninger i teksten.
+    """
+    epostHtmlBody: String!
+    """
+    Teksten som sendes i SMS-en.
+    OBS: Det er ikke lov med personopplysninger i teksten.
+    """
+    smsTekst: String!
     sendetidspunkt: SendetidspunktInput!
 }
 
@@ -1256,12 +1662,13 @@ input SmsMottakerInput {
 }
 
 input SmsKontaktInfoInput {
-    # deprecated. value is ignored.
+    """deprecated. value is ignored. """
     fnr: String
-
-    # Må være et gyldig norsk mobilnummer. Kan inneholde landkode på format +47 eller 0047.
-    # Nummeret må være gyldig iht norske mobilnummer-regler (40000000-49999999, 90000000-99999999)
-    # se https://nkom.no/telefoni-og-telefonnummer/telefonnummer-og-den-norske-nummerplan/alle-nummerserier-for-norske-telefonnumre
+    """
+    Må være et gyldig norsk mobilnummer. Kan inneholde landkode på format +47 eller 0047.
+    Nummeret må være gyldig iht norske mobilnummer-regler (40000000-49999999, 90000000-99999999)
+    se https://nkom.no/telefoni-og-telefonnummer/telefonnummer-og-den-norske-nummerplan/alle-nummerserier-for-norske-telefonnumre
+    """
     tlf: String!
 }
 
@@ -1270,133 +1677,180 @@ input EpostMottakerInput {
 }
 
 input EpostKontaktInfoInput {
-    # deprecated. value is ignored.
+    """deprecated. value is ignored. """
     fnr: String
     epostadresse: String!
 }
 
+"""
+Ekstern varsling på Altinn 2 tjeneste.
+Ekstern varsling på Altinn 3 ressurs er ikke implementert, men er i backloggen.
+Ta kontakt derssom dere ønsker at vi prioriterer dette.
+"""
 input AltinntjenesteMottakerInput {
     serviceCode: String!
     serviceEdition: String!
 }
 
-# Hvem som skal se notifikasjonen.
-#
-# Du kan spesifisere mottaker av notifikasjoner på forskjellige måter. Du skal bruke nøyaktig ett av feltene.
-#
-# Vi har implementert det på denne måten fordi GraphQL ikke støtter union-typer som input.
+"""
+Hvem som skal se notifikasjonen.
+
+Du kan spesifisere mottaker av notifikasjoner på forskjellige måter. Du skal bruke nøyaktig ett av feltene.
+
+Vi har implementert det på denne måten fordi GraphQL ikke støtter union-typer som input.
+"""
 input MottakerInput {
     altinn: AltinnMottakerInput
     altinnRessurs: AltinnRessursMottakerInput
     naermesteLeder: NaermesteLederMottakerInput
 }
 
-# Spesifiser mottaker ved hjelp av tilganger i Altinn 2. Enhver som har den gitte tilgangen vil
-# kunne se notifikasjone.
-#
-# Tilgangssjekken utføres hver gang en bruker ser på notifikasjoner. Det betyr at hvis en
-# bruker mister en Altinn 2-tilgang, så vil de hverken se historiske eller nye notifikasjone knyttet til den Altinn 2-tilgangen.
-# Og motsatt, hvis en bruker får en Altinn 2-tilgang, vil de se tidligere notifikasjoner for den Altinn2-tilgangen.
-#
-# Altinn 2 skal avvikles innen juni 2026, og denne mottakeren vil da også forsvinne. Vi anbefaler å migrere til Altinn 3, og ta i bruk
-# AltinnRessursMottakerInput. Når dere migrerer til Altinn3 kan vi sørge for at brukere fortsatt får tilgang til gamle saker og notifikasjoner, så lenge vi blir informert
-# om hvilke Altinn 3 ressurser som tilsvarer hvilke Altinn 2 tjenester. Ta gjerne kontakt med oss og gi beskjed.
+"""
+Spesifiser mottaker ved hjelp av tilganger i Altinn 2. Enhver som har den gitte tilgangen vil
+kunne se notifikasjone.
+
+Tilgangssjekken utføres hver gang en bruker ser på notifikasjoner. Det betyr at hvis en
+bruker mister en Altinn 2-tilgang, så vil de hverken se historiske eller nye notifikasjone knyttet til den Altinn 2-tilgangen.
+Og motsatt, hvis en bruker får en Altinn 2-tilgang, vil de se tidligere notifikasjoner for den Altinn2-tilgangen.
+
+Altinn 2 skal avvikles innen juni 2026, og denne mottakeren vil da også forsvinne. Vi anbefaler å migrere til Altinn 3, og ta i bruk
+AltinnRessursMottakerInput. Når dere migrerer til Altinn3 kan vi sørge for at brukere fortsatt får tilgang til gamle saker og notifikasjoner, så lenge vi blir informert
+om hvilke Altinn 3 ressurser som tilsvarer hvilke Altinn 2 tjenester. Ta gjerne kontakt med oss og gi beskjed.
+"""
 input AltinnMottakerInput {
     serviceCode: String!
     serviceEdition: String!
 }
 
-# Spesifiser mottaker ved hjelp av tilganger i Altinn 3. Enhver som har den gitte tilgangen vil
-# kunne se notifikasjone.
-#
-# Tilgangssjekken utføres hver gang en bruker ser på notifikasjoner. Det betyr at hvis en
-# bruker mister en Altinn 3-tilgang, så vil de hverken se historiske eller nye notifikasjone knyttet til den Altinn 3-tilgangen.
-# Og motsatt, hvis en bruker får en Altinn 3-tilgang, vil de se tidligere notifikasjoner for den Altinn2-tilgangen.
+"""
+Spesifiser mottaker ved hjelp av tilganger i Altinn 3. Enhver som har den gitte tilgangen vil
+kunne se notifikasjone.
+
+Tilgangssjekken utføres hver gang en bruker ser på notifikasjoner. Det betyr at hvis en
+bruker mister en Altinn 3-tilgang, så vil de hverken se historiske eller nye notifikasjone knyttet til den Altinn 3-tilgangen.
+Og motsatt, hvis en bruker får en Altinn 3-tilgang, vil de se tidligere notifikasjoner for den Altinn2-tilgangen.
+"""
 input AltinnRessursMottakerInput {
     ressursId: String!
 }
 
-# Spesifiser mottaker ved hjelp av fødselsnummer. Fødselsnummeret er det til nærmeste leder. Det er kun denne personen
-# som potensielt kan se notifikasjonen. Det er videre en sjekk for å se om denne personen fortsatt er nærmeste leder
-# for den ansatte notifikasjonen gjelder.
-#
-# Tilgangssjekken utføres hver gang en bruker ønsker se notifikasjonen.
+"""
+Spesifiser mottaker ved hjelp av fødselsnummer. Fødselsnummeret er det til nærmeste leder. Det er kun denne personen
+som potensielt kan se notifikasjonen. Det er videre en sjekk for å se om denne personen fortsatt er nærmeste leder
+for den ansatte notifikasjonen gjelder.
+
+Tilgangssjekken utføres hver gang en bruker ønsker se notifikasjonen.
+"""
 input NaermesteLederMottakerInput {
     naermesteLederFnr: String!
     ansattFnr: String!
 }
 
-#
+
+"""
+"""
 input NotifikasjonInput {
-    # Merkelapp for beskjeden. Er typisk navnet på ytelse eller lignende. Den vises til brukeren.
-    #
-    # Hva du kan oppgi som merkelapp er bestemt av produsent-registeret.
+    """
+    Merkelapp for beskjeden. Er typisk navnet på ytelse eller lignende. Den vises til brukeren.
+
+    Hva du kan oppgi som merkelapp er bestemt av produsent-registeret.
+    """
     merkelapp: String!
 
-    # Teksten som vises til brukeren. Feltet er begrenset til 300 tegn og kan ikke inneholde fødselsnummer.
+    """
+    Teksten som vises til brukeren. Feltet er begrenset til 300 tegn og kan ikke inneholde fødselsnummer.
+    """
     tekst: String!
 
-    # Lenken som brukeren føres til hvis de klikker på beskjeden.
+    """
+    Lenken som brukeren føres til hvis de klikker på beskjeden.
+    """
     lenke: String!
 }
 
 input MetadataInput {
-    # Hvilken virksomhet som skal motta notifikasjonen.
+    """
+    Hvilken virksomhet som skal motta notifikasjonen.
+    """
     virksomhetsnummer: String!
 
-    # Den eksterne id-en brukes for å unikt identifisere en notifikasjon. Den må være unik for merkelappen.
-    #
-    # Hvis dere har en enkel, statisk bruk av notifikasjoner, så kan dere utlede eksternId
-    # fra f.eks. et saksnummer, og på den måten kunne referere til notifikasjoner dere har opprettet,
-    # uten at dere må lagre ID-ene vi genererer og returnerer til dere.
+    """
+    Den eksterne id-en brukes for å unikt identifisere en notifikasjon. Den må være unik for merkelappen.
+
+    Hvis dere har en enkel, statisk bruk av notifikasjoner, så kan dere utlede eksternId
+    fra f.eks. et saksnummer, og på den måten kunne referere til notifikasjoner dere har opprettet,
+    uten at dere må lagre ID-ene vi genererer og returnerer til dere.
+    """
     eksternId: String!
 
-    # Hvilken dato vi viser til brukeren. Dersom dere ikke oppgir noen dato, så
-    # bruker vi tidspuktet dere gjør kallet på.
+    """
+    Hvilken dato vi viser til brukeren. Dersom dere ikke oppgir noen dato, så
+    bruker vi tidspuktet dere gjør kallet på.
+    """
     opprettetTidspunkt: ISO8601DateTime
 
-    # Grupperings-id-en gjør det mulig å knytte sammen forskjellige oppgaver, beskjed og saker.
-    # Det vises ikke til brukere.
-    # Saksnummer er en naturlig grupperings-id.
-    #
-    # Når dere bruker grupperings-id, så er det mulig for oss å presentere en tidslinje
-    # med alle notifikasjonene og status-oppdateringer knyttet til en sak.
+    """
+    Grupperings-id-en gjør det mulig å knytte sammen forskjellige oppgaver, beskjed og saker.
+    Det vises ikke til brukere.
+    Saksnummer er en naturlig grupperings-id.
+
+    Når dere bruker grupperings-id, så er det mulig for oss å presentere en tidslinje
+    med alle notifikasjonene og status-oppdateringer knyttet til en sak.
+    """
     grupperingsid: String
 
-    # Oppgi dersom dere ønsker at hard delete skal skeduleres. Vi
-    # tolker relative datoer basert på `opprettetTidspunkt` (eller
-    # når vi mottok kallet hvis dere ikke har oppgitt `opprettetTidspunkt`).
+    """
+    Oppgi dersom dere ønsker at hard delete skal skeduleres. Vi
+    tolker relative datoer basert på `opprettetTidspunkt` (eller
+    når vi mottok kallet hvis dere ikke har oppgitt `opprettetTidspunkt`).
+    """
     hardDelete: FutureTemporalInput
 }
 
-# Med denne kan dere spesifiserer et konkret tidspunkt.
+"""
+Med denne kan dere spesifiserer et konkret tidspunkt.
+"""
 input FutureTemporalInput {
-    # En konkret dato. I Europe/Oslo-tidssone.
+    """
+    En konkret dato. I Europe/Oslo-tidssone.
+    """
     den: ISO8601LocalDateTime
 
-    # Som duration-offset relativt til implisitt dato.  Dere må se
-    # på dokumentasjonen til feltet hvor denne datatypen er brukt for
-    # å vite hva vi bruker som implisitt dato.
+    """
+    Som duration-offset relativt til implisitt dato.  Dere må se
+    på dokumentasjonen til feltet hvor denne datatypen er brukt for
+    å vite hva vi bruker som implisitt dato.
+    """
     om: ISO8601Duration
 }
 
-# Dersom dere vet at saken/notifikasjonen senere skal slettes helt kan det angis her.
+"""
+Dersom dere vet at saken/notifikasjonen senere skal slettes helt kan det angis her.
+"""
 input HardDeleteUpdateInput {
-    # Oppgi dersom dere ønsker at hard delete skal skeduleres. Vi
-    # tolker relative datoer basert på tidspunkt angitt i kallet eller
-    # når vi mottok kallet, hvis dere ikke har oppgitt det eller det
-    # ikke er mulig å oppgi.
+    """
+    Oppgi dersom dere ønsker at hard delete skal skeduleres. Vi
+    tolker relative datoer basert på tidspunkt angitt i kallet eller
+    når vi mottok kallet, hvis dere ikke har oppgitt det eller det
+    ikke er mulig å oppgi.
+    """
     nyTid: FutureTemporalInput!
 
-    # hvis det finnes fremtidig sletting hvordan skal vi håndtere dette
+    """
+    hvis det finnes fremtidig sletting hvordan skal vi håndtere dette
+    """
     strategi: NyTidStrategi!
 }
 
 enum NyTidStrategi {
-    # Vi bruker den tiden som er lengst i fremtiden.
+    """
+    Vi bruker den tiden som er lengst i fremtiden.
+    """
     FORLENG
 
-    # Vi bruker den nye tiden uansett.
+    """
+    Vi bruker den nye tiden uansett.
+    """
     OVERSKRIV
 }
 
@@ -1406,30 +1860,39 @@ input LokasjonInput {
     poststed: String!
 }
 
-# Tilstanden til en kalenderavtale. Disse tilstandene er laget basert på eksisterende behov.
-# Har dere behov for flere tilstander, så ta kontakt med oss.
+"""
+Tilstanden til en kalenderavtale. Disse tilstandene er laget basert på eksisterende behov.
+Har dere behov for flere tilstander, så ta kontakt med oss.
+"""
 enum KalenderavtaleTilstand {
-    # Avtalen venter på at brukeren skal svare. Dette er standardtilstanden.
+    """
+    Avtalen venter på at brukeren skal svare. Dette er standardtilstanden.
+    """
     VENTER_SVAR_FRA_ARBEIDSGIVER
-
-    # Arbeidsgiver har svart at de ønsker å avlyse
+    """
+    Arbeidsgiver har svart at de ønsker å avlyse
+    """
     ARBEIDSGIVER_VIL_AVLYSE
-
-    # Arbeidsgiver har svart at de ønsker å endre tid eller sted
+    """
+    Arbeidsgiver har svart at de ønsker å endre tid eller sted
+    """
     ARBEIDSGIVER_VIL_ENDRE_TID_ELLER_STED
-
-    # Arbeidsgiver har godtatt avtalen
+    """
+    Arbeidsgiver har godtatt avtalen
+    """
     ARBEIDSGIVER_HAR_GODTATT
-
-    # Avtalen er avlyst
+    """
+    Avtalen er avlyst
+    """
     AVLYST
-
-    # Møtet er avholdt
+    """
+    Avtalen er avholdt, dette skjer automatisk når starttidspunkt har passert, men kan også settes manuelt
+    """
     AVHOLDT
 }
 
 union NyOppgaveResultat =
-    NyOppgaveVellykket
+    | NyOppgaveVellykket
     | UgyldigMerkelapp
     | UgyldigMottaker
     | DuplikatEksternIdOgMerkelapp
@@ -1438,7 +1901,7 @@ union NyOppgaveResultat =
     | UgyldigPaaminnelseTidspunkt
 
 union NyBeskjedResultat =
-    NyBeskjedVellykket
+    | NyBeskjedVellykket
     | UgyldigMerkelapp
     | UgyldigMottaker
     | DuplikatEksternIdOgMerkelapp
@@ -1446,7 +1909,7 @@ union NyBeskjedResultat =
     | UkjentRolle
 
 union NyKalenderavtaleResultat =
-    NyKalenderavtaleVellykket
+    | NyKalenderavtaleVellykket
     | UgyldigKalenderavtale
     | UgyldigMerkelapp
     | UgyldigMottaker
@@ -1485,31 +1948,41 @@ type Lokasjon {
     poststed: String!
 }
 
-# Denne feilen returneres dersom en produsent forsøker å benytte en merkelapp som den ikke har tilgang til.
+"""
+Denne feilen returneres dersom en produsent forsøker å benytte en merkelapp som den ikke har tilgang til.
+"""
 type UgyldigMerkelapp implements Error {
     feilmelding: String!
 }
 
-# Denne feilen returneres dersom en produsent forsøker å benytte en mottaker som den ikke har tilgang til.
+"""
+Denne feilen returneres dersom en produsent forsøker å benytte en mottaker som den ikke har tilgang til.
+"""
 type UgyldigMottaker implements Error {
     feilmelding: String!
 }
 
-# Denne feilen returneres dersom vi ikke greier å finne dere i produsent-registeret vårt.
+"""
+Denne feilen returneres dersom vi ikke greier å finne dere i produsent-registeret vårt.
+"""
 type UkjentProdusent implements Error {
     feilmelding: String!
 }
 
-# Denne feilen returneres dersom du forsøker å gå fra utført til utgått.
+"""
+Denne feilen returneres dersom du forsøker å gå fra utført til utgått.
+"""
 type OppgavenErAlleredeUtfoert implements Error {
     feilmelding: String!
 }
 
-# Denne feilen returneres dersom du prøver å referere til en notifikasjon
-# som ikke eksisterer.
-#
-# Utover at dere kan ha oppgitt feil informasjon, så kan det potensielt være på grunn
-# av "eventual consistency" i systemet vårt.
+"""
+Denne feilen returneres dersom du prøver å referere til en notifikasjon
+som ikke eksisterer.
+
+Utover at dere kan ha oppgitt feil informasjon, så kan det potensielt være på grunn
+av "eventual consistency" i systemet vårt.
+"""
 type NotifikasjonFinnesIkke implements Error {
     feilmelding: String!
 }
@@ -1518,21 +1991,27 @@ type SakFinnesIkke implements Error {
     feilmelding: String!
 }
 
-# Denne feilen returneres dersom du prøver å opprette en notifikasjon med en eksternId og merkelapp som allerede finnes
+"""
+Denne feilen returneres dersom du prøver å opprette en notifikasjon med en eksternId og merkelapp som allerede finnes
+"""
 type DuplikatEksternIdOgMerkelapp implements Error {
     feilmelding: String!
     idTilEksisterende: ID!
 }
 
-# Denne feilen returneres hvis det allerede eksisterer en sak med denne grupperingsid-en under
-# merkelappen.
+"""
+Denne feilen returneres hvis det allerede eksisterer en sak med denne grupperingsid-en under
+merkelappen.
+"""
 type DuplikatGrupperingsid implements Error {
     feilmelding: String!
     idTilEksisterende: ID!
 }
 
-# Denne feilen returneres hvis det tidligere eksisterte en sak med denne grupperingsid-en under
-# merkelappen, som har blitt slettet.
+"""
+Denne feilen returneres hvis det tidligere eksisterte en sak med denne grupperingsid-en under
+merkelappen, som har blitt slettet.
+"""
 type DuplikatGrupperingsidEtterDelete implements Error {
     feilmelding: String!
 }
@@ -1541,17 +2020,23 @@ type UkjentRolle implements Error {
     feilmelding: String!
 }
 
-# Tidpunkt for påminnelse er ugyldig iht grenseverdier. F.eks før opprettelse eller etter frist, eller i fortid.
+"""
+Tidpunkt for påminnelse er ugyldig iht grenseverdier. F.eks før opprettelse eller etter frist, eller i fortid.
+"""
 type UgyldigPaaminnelseTidspunkt implements Error {
     feilmelding: String!
 }
 
-# Oppgitt informasjon samsvarer ikke med tidligere informasjon som er oppgitt.
+"""
+Oppgitt informasjon samsvarer ikke med tidligere informasjon som er oppgitt.
+"""
 type Konflikt implements Error {
     feilmelding: String!
 }
 
-# Kalenderavtalen er ugyldig. Det kan f.eks være at startTidspunkt er etter sluttTidspunkt. Detaljer kommer i feilmelding.
+"""
+Kalenderavtalen er ugyldig. Det kan f.eks være at startTidspunkt er etter sluttTidspunkt. Detaljer kommer i feilmelding.
+"""
 type UgyldigKalenderavtale implements Error {
     feilmelding: String!
 }

--- a/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonProdusent.kt
+++ b/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonProdusent.kt
@@ -29,8 +29,6 @@ import no.nav.syfo.UrlEnv
 import no.nav.syfo.auth.AzureAdTokenConsumer
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.ArbeidsgiverDeleteNotifikasjon
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.ArbeidsgiverNotifikasjon
-import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.ArbeidsgiverNotifikasjonAltinnRessurs
-import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.ArbeidsgiverNotifikasjonNarmesteLeder
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NyKalenderInput
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NySakInput
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NyStatusSakInput

--- a/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonProdusent.kt
+++ b/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonProdusent.kt
@@ -29,6 +29,7 @@ import no.nav.syfo.UrlEnv
 import no.nav.syfo.auth.AzureAdTokenConsumer
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.ArbeidsgiverDeleteNotifikasjon
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.ArbeidsgiverNotifikasjon
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.ArbeidsgiverNotifikasjonAltinnRessurs
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.ArbeidsgiverNotifikasjonNarmesteLeder
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NyKalenderInput
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NySakInput
@@ -58,7 +59,7 @@ open class ArbeidsgiverNotifikasjonProdusent(
             .addInterceptor(BearerTokenInterceptor { azureAdTokenConsumer.getToken(scope) })
             .build()
 
-    suspend fun createNewOppgaveForArbeidsgiver(arbeidsgiverNotifikasjon: ArbeidsgiverNotifikasjonNarmesteLeder): String? {
+    suspend fun createNewOppgaveForArbeidsgiver(arbeidsgiverNotifikasjon: ArbeidsgiverNotifikasjon): String? {
         log.info(
             "About to send new task with uuid ${arbeidsgiverNotifikasjon.varselId} to ag-notifikasjon-produsent-api",
         )
@@ -262,23 +263,6 @@ open class ArbeidsgiverNotifikasjonProdusent(
             return null
         }
     }
-
-    private fun ArbeidsgiverNotifikasjonNarmesteLeder.createVariables() =
-        VariablesCreate(
-            varselId,
-            virksomhetsnummer,
-            url,
-            narmesteLederFnr,
-            ansattFnr,
-            merkelapp,
-            messageText,
-            narmesteLederEpostadresse,
-            emailTitle,
-            emailBody,
-            EpostSendevinduTypes.LOEPENDE,
-            hardDeleteDate.formatAsISO8601DateTime(),
-            grupperingsid,
-        )
 
     suspend fun deleteNotifikasjonForArbeidsgiver(arbeidsgiverDeleteNotifikasjon: ArbeidsgiverDeleteNotifikasjon) {
         log.info(

--- a/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonProdusent.kt
+++ b/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonProdusent.kt
@@ -29,16 +29,15 @@ import no.nav.syfo.UrlEnv
 import no.nav.syfo.auth.AzureAdTokenConsumer
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.ArbeidsgiverDeleteNotifikasjon
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.ArbeidsgiverNotifikasjon
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.ArbeidsgiverNotifikasjonNarmesteLeder
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NyKalenderInput
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NySakInput
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NyStatusSakInput
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.OppdaterKalenderInput
-import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.toNyBeskjedMutation
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.toNyKalenderavtaleMutation
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.toNySakMutation
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.toNyStatusSakByGrupperingsidMutation
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.toOppdaterKalenderavtaleMutation
-import no.nav.syfo.producer.arbeidsgivernotifikasjon.response.nyoppgave.NyOppgaveErrorResponse
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.response.nyoppgave.NyOppgaveResponse
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.response.nyoppgave.NyoppgaveMutationStatus.NY_OPPGAVE_VELLYKKET
 import no.nav.syfo.utils.httpClientWithRetry
@@ -59,7 +58,7 @@ open class ArbeidsgiverNotifikasjonProdusent(
             .addInterceptor(BearerTokenInterceptor { azureAdTokenConsumer.getToken(scope) })
             .build()
 
-    suspend fun createNewOppgaveForArbeidsgiver(arbeidsgiverNotifikasjon: ArbeidsgiverNotifikasjon): String? {
+    suspend fun createNewOppgaveForArbeidsgiver(arbeidsgiverNotifikasjon: ArbeidsgiverNotifikasjonNarmesteLeder): String? {
         log.info(
             "About to send new task with uuid ${arbeidsgiverNotifikasjon.varselId} to ag-notifikasjon-produsent-api",
         )
@@ -68,7 +67,8 @@ open class ArbeidsgiverNotifikasjonProdusent(
                 CREATE_TASK_AG_MUTATION,
                 arbeidsgiverNotifikasjon.createVariables(),
             )
-        val nyOppgave = response.body<NyOppgaveResponse>().data?.nyOppgave
+        val nyOppgaveResponse = response.body<NyOppgaveResponse>()
+        val nyOppgave = nyOppgaveResponse.data?.nyOppgave
         val resultat = nyOppgave?.__typename
         if (resultat == NY_OPPGAVE_VELLYKKET.status) {
             log.info(
@@ -79,9 +79,8 @@ open class ArbeidsgiverNotifikasjonProdusent(
             if (resultat != null) {
                 throw RuntimeException(nyOppgave.feilmelding)
             }
-            val errors = response.body<NyOppgaveErrorResponse>().errors
             throw RuntimeException(
-                "Could not send task to arbeidsgiver. because of error: ${errors[0].message}, data was null",
+                "Could not send task to arbeidsgiver. because of error: ${nyOppgaveResponse.errors?.firstOrNull()?.message ?: "unknown error"}, data was null",
             )
         }
     }
@@ -264,7 +263,7 @@ open class ArbeidsgiverNotifikasjonProdusent(
         }
     }
 
-    private fun ArbeidsgiverNotifikasjon.createVariables() =
+    private fun ArbeidsgiverNotifikasjonNarmesteLeder.createVariables() =
         VariablesCreate(
             varselId,
             virksomhetsnummer,
@@ -277,7 +276,7 @@ open class ArbeidsgiverNotifikasjonProdusent(
             emailTitle,
             emailBody,
             EpostSendevinduTypes.LOEPENDE,
-            hardDeleteDate.toString(),
+            hardDeleteDate.formatAsISO8601DateTime(),
             grupperingsid,
         )
 

--- a/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonProdusent.kt
+++ b/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonProdusent.kt
@@ -79,7 +79,7 @@ open class ArbeidsgiverNotifikasjonProdusent(
                 throw RuntimeException(nyOppgave.feilmelding)
             }
             throw RuntimeException(
-                "Could not send task to arbeidsgiver. because of error: ${nyOppgaveResponse.errors?.firstOrNull()?.message ?: "unknown error"}, data was null",
+                "Could not send task to arbeidsgiver: httpStatus=${response.status.value}, errorsEmpty=${nyOppgaveResponse.errors.isNullOrEmpty()}, firstError=${nyOppgaveResponse.errors?.firstOrNull()?.message ?: "unknown error"}, dataWasNull=${nyOppgaveResponse.data == null}",
             )
         }
     }

--- a/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/CreateNewNotificationAgRequest.kt
+++ b/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/CreateNewNotificationAgRequest.kt
@@ -11,7 +11,7 @@ enum class EpostSendevinduTypes {
 
 sealed interface Variables
 
-data class VariablesCreate(
+data class NarmestelederVariablesCreate(
     val eksternId: String,
     val virksomhetsnummer: String,
     val lenke: String,
@@ -25,6 +25,20 @@ data class VariablesCreate(
     val sendevindu: EpostSendevinduTypes,
     val hardDeleteDate: String,
     val grupperingsid: String,
+) : Variables
+
+data class AltinnRessursVariablesCreate(
+    val eksternId: String,
+    val virksomhetsnummer: String,
+    val lenke: String,
+    val merkelapp: String,
+    val tekst: String,
+    val epostTittel: String,
+    val epostHtmlBody: String,
+    val sendevindu: EpostSendevinduTypes,
+    val hardDeleteDate: String,
+    val grupperingsid: String,
+    val ressursId: String,
 ) : Variables
 
 data class VariablesDelete(

--- a/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/CreateNewNotificationAgRequest.kt
+++ b/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/CreateNewNotificationAgRequest.kt
@@ -23,7 +23,7 @@ data class NarmestelederVariablesCreate(
     val epostTittel: String,
     val epostHtmlBody: String,
     val sendevindu: EpostSendevinduTypes,
-    val hardDeleteDate: String,
+    val hardDeleteDate: String?,
     val grupperingsid: String,
 ) : Variables
 
@@ -36,7 +36,7 @@ data class AltinnRessursVariablesCreate(
     val epostTittel: String,
     val epostHtmlBody: String,
     val sendevindu: EpostSendevinduTypes,
-    val hardDeleteDate: String,
+    val hardDeleteDate: String?,
     val grupperingsid: String,
     val ressursId: String,
 ) : Variables

--- a/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/domain/ArbeidsgiverNotifikasjon.kt
+++ b/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/domain/ArbeidsgiverNotifikasjon.kt
@@ -1,6 +1,8 @@
 package no.nav.syfo.producer.arbeidsgivernotifikasjon.domain
 
 import com.apollo.graphql.NyBeskjedMutation
+import com.apollo.graphql.type.AltinnRessursMottakerInput
+import com.apollo.graphql.type.EksterntVarselAltinnressursInput
 import com.apollo.graphql.type.EksterntVarselEpostInput
 import com.apollo.graphql.type.EksterntVarselInput
 import com.apollo.graphql.type.EpostKontaktInfoInput
@@ -17,95 +19,155 @@ import com.apollographql.apollo.api.Optional
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.formatAsISO8601DateTime
 import java.time.LocalDateTime
 
-data class ArbeidsgiverNotifikasjon(
-    val varselId: String,
-    val virksomhetsnummer: String,
-    val url: String,
+sealed class ArbeidsgiverNotifikasjon {
+    abstract val varselId: String
+    abstract val virksomhetsnummer: String
+    abstract val url: String
+    abstract val messageText: String
+    abstract val merkelapp: String
+    abstract val emailTitle: String
+    abstract val emailBody: String
+    abstract val hardDeleteDate: LocalDateTime
+    abstract val grupperingsid: String
+
+    fun toNyBeskjedMutation(): NyBeskjedMutation =
+        NyBeskjedMutation(
+            nyBeskjed =
+                NyBeskjedInput(
+                    mottakere = Optional.present(createMottakere()),
+                    notifikasjon = createNotifikasjon(),
+                    metadata = createMetadata(),
+                    eksterneVarsler = Optional.present(createEksterneVarsler()),
+                ),
+        )
+
+    protected abstract fun createMottakere(): List<MottakerInput>
+
+    protected abstract fun createEksterneVarsler(): List<EksterntVarselInput>
+
+    protected fun createSendetidspunkt(): SendetidspunktInput =
+        SendetidspunktInput(
+            tidspunkt = Optional.Absent,
+            sendevindu = Optional.present(Sendevindu.NKS_AAPNINGSTID),
+        )
+
+    private fun createNotifikasjon(): NotifikasjonInput =
+        NotifikasjonInput(
+            merkelapp = merkelapp,
+            tekst = messageText,
+            lenke = url,
+        )
+
+    private fun createMetadata(): MetadataInput =
+        MetadataInput(
+            virksomhetsnummer = virksomhetsnummer,
+            eksternId = varselId,
+            grupperingsid = Optional.present(grupperingsid),
+            hardDelete =
+                Optional.present(
+                    FutureTemporalInput(
+                        den = Optional.present(hardDeleteDate.formatAsISO8601DateTime()),
+                    ),
+                ),
+        )
+}
+
+data class ArbeidsgiverNotifikasjonNarmesteLeder(
+    override val varselId: String,
+    override val virksomhetsnummer: String,
+    override val url: String,
     val narmesteLederFnr: String,
     val ansattFnr: String,
-    val messageText: String,
+    override val messageText: String,
     val narmesteLederEpostadresse: String,
-    val merkelapp: String,
-    val emailTitle: String,
-    val emailBody: String,
-    val hardDeleteDate: LocalDateTime?,
-    val grupperingsid: String,
-)
+    override val merkelapp: String,
+    override val emailTitle: String,
+    override val emailBody: String,
+    override val hardDeleteDate: LocalDateTime,
+    override val grupperingsid: String,
+) : ArbeidsgiverNotifikasjon() {
+    override fun createMottakere(): List<MottakerInput> =
+        listOf(
+            MottakerInput(
+                naermesteLeder =
+                    Optional.present(
+                        NaermesteLederMottakerInput(
+                            naermesteLederFnr = narmesteLederFnr,
+                            ansattFnr = ansattFnr,
+                        ),
+                    ),
+            ),
+        )
+
+    override fun createEksterneVarsler(): List<EksterntVarselInput> =
+        listOf(
+            EksterntVarselInput(
+                epost =
+                    Optional.present(
+                        EksterntVarselEpostInput(
+                            mottaker =
+                                EpostMottakerInput(
+                                    kontaktinfo =
+                                        Optional.present(
+                                            EpostKontaktInfoInput(
+                                                epostadresse = narmesteLederEpostadresse,
+                                            ),
+                                        ),
+                                ),
+                            epostTittel = emailTitle,
+                            epostHtmlBody = emailBody,
+                            sendetidspunkt = createSendetidspunkt(),
+                        ),
+                    ),
+            ),
+        )
+}
+
+data class ArbeidsgiverNotifikasjonAltinnRessurs(
+    override val varselId: String,
+    override val virksomhetsnummer: String,
+    override val url: String,
+    override val messageText: String,
+    override val merkelapp: String,
+    override val emailTitle: String,
+    override val emailBody: String,
+    override val hardDeleteDate: LocalDateTime,
+    override val grupperingsid: String,
+    val ressursId: String,
+) : ArbeidsgiverNotifikasjon() {
+    override fun createMottakere(): List<MottakerInput> =
+        listOf(
+            MottakerInput(
+                altinnRessurs =
+                    Optional.present(
+                        AltinnRessursMottakerInput(
+                            ressursId = ressursId,
+                        ),
+                    ),
+            ),
+        )
+
+    override fun createEksterneVarsler(): List<EksterntVarselInput> =
+        listOf(
+            EksterntVarselInput(
+                altinnressurs =
+                    Optional.present(
+                        EksterntVarselAltinnressursInput(
+                            mottaker =
+                                AltinnRessursMottakerInput(
+                                    ressursId = ressursId,
+                                ),
+                            epostTittel = emailTitle,
+                            epostHtmlBody = emailBody,
+                            smsTekst = messageText,
+                            sendetidspunkt = createSendetidspunkt(),
+                        ),
+                    ),
+            ),
+        )
+}
 
 data class ArbeidsgiverDeleteNotifikasjon(
     val merkelapp: String,
     val eksternReferanse: String,
 )
-
-fun ArbeidsgiverNotifikasjon.toNyBeskjedMutation(): NyBeskjedMutation =
-    NyBeskjedMutation(
-        nyBeskjed =
-            NyBeskjedInput(
-                mottakere = Optional.present(createMottakere()),
-                notifikasjon = createNotifikasjon(),
-                metadata = createMetadata(),
-                eksterneVarsler = Optional.present(createEksterneVarsler()),
-            ),
-    )
-
-private fun ArbeidsgiverNotifikasjon.createMottakere(): List<MottakerInput> =
-    listOf(
-        MottakerInput(
-            naermesteLeder =
-                Optional.present(
-                    NaermesteLederMottakerInput(
-                        naermesteLederFnr = narmesteLederFnr,
-                        ansattFnr = ansattFnr,
-                    ),
-                ),
-        ),
-    )
-
-private fun ArbeidsgiverNotifikasjon.createNotifikasjon(): NotifikasjonInput =
-    NotifikasjonInput(
-        merkelapp = merkelapp,
-        tekst = messageText,
-        lenke = url,
-    )
-
-private fun ArbeidsgiverNotifikasjon.createMetadata(): MetadataInput =
-    MetadataInput(
-        virksomhetsnummer = virksomhetsnummer,
-        eksternId = varselId,
-        grupperingsid = Optional.present(grupperingsid),
-        hardDelete =
-            hardDeleteDate?.let {
-                Optional.present(
-                    FutureTemporalInput(
-                        den = Optional.present(it.formatAsISO8601DateTime()),
-                    ),
-                )
-            } ?: Optional.Absent,
-    )
-
-private fun ArbeidsgiverNotifikasjon.createEksterneVarsler(): List<EksterntVarselInput> =
-    listOf(
-        EksterntVarselInput(
-            epost =
-                Optional.presentIfNotNull(
-                    EksterntVarselEpostInput(
-                        mottaker =
-                            EpostMottakerInput(
-                                kontaktinfo =
-                                    Optional.present(
-                                        EpostKontaktInfoInput(
-                                            epostadresse = narmesteLederEpostadresse,
-                                        ),
-                                    ),
-                            ),
-                        epostTittel = emailTitle,
-                        epostHtmlBody = emailBody,
-                        sendetidspunkt =
-                            SendetidspunktInput(
-                                tidspunkt = Optional.Absent,
-                                sendevindu = Optional.present(Sendevindu.NKS_AAPNINGSTID),
-                            ),
-                    ),
-                ),
-        ),
-    )

--- a/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/domain/ArbeidsgiverNotifikasjon.kt
+++ b/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/domain/ArbeidsgiverNotifikasjon.kt
@@ -18,6 +18,10 @@ import com.apollo.graphql.type.Sendevindu
 import com.apollographql.apollo.api.Optional
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.formatAsISO8601DateTime
 import java.time.LocalDateTime
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.AltinnRessursVariablesCreate
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.EpostSendevinduTypes
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.NarmestelederVariablesCreate
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.Variables
 
 sealed class ArbeidsgiverNotifikasjon {
     abstract val varselId: String
@@ -29,7 +33,7 @@ sealed class ArbeidsgiverNotifikasjon {
     abstract val emailBody: String
     abstract val hardDeleteDate: LocalDateTime
     abstract val grupperingsid: String
-
+    abstract fun createVariables(): Variables
     fun toNyBeskjedMutation(): NyBeskjedMutation =
         NyBeskjedMutation(
             nyBeskjed =
@@ -121,6 +125,23 @@ data class ArbeidsgiverNotifikasjonNarmesteLeder(
                     ),
             ),
         )
+
+    override fun createVariables() =
+        NarmestelederVariablesCreate(
+            varselId,
+            virksomhetsnummer,
+            url,
+            narmesteLederFnr,
+            ansattFnr,
+            merkelapp,
+            messageText,
+            narmesteLederEpostadresse,
+            emailTitle,
+            emailBody,
+            EpostSendevinduTypes.LOEPENDE,
+            hardDeleteDate.formatAsISO8601DateTime(),
+            grupperingsid,
+        )
 }
 
 data class ArbeidsgiverNotifikasjonAltinnRessurs(
@@ -164,6 +185,21 @@ data class ArbeidsgiverNotifikasjonAltinnRessurs(
                         ),
                     ),
             ),
+        )
+
+    override fun createVariables() =
+        AltinnRessursVariablesCreate(
+            eksternId = varselId,
+            virksomhetsnummer = virksomhetsnummer,
+            lenke = url,
+            merkelapp = merkelapp,
+            tekst = messageText,
+            epostTittel = emailTitle,
+            epostHtmlBody = emailBody,
+            sendevindu = EpostSendevinduTypes.LOEPENDE,
+            hardDeleteDate = hardDeleteDate.formatAsISO8601DateTime(),
+            grupperingsid = grupperingsid,
+            ressursId = ressursId
         )
 }
 

--- a/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/domain/ArbeidsgiverNotifikasjon.kt
+++ b/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/domain/ArbeidsgiverNotifikasjon.kt
@@ -16,12 +16,12 @@ import com.apollo.graphql.type.NyBeskjedInput
 import com.apollo.graphql.type.SendetidspunktInput
 import com.apollo.graphql.type.Sendevindu
 import com.apollographql.apollo.api.Optional
-import no.nav.syfo.producer.arbeidsgivernotifikasjon.formatAsISO8601DateTime
-import java.time.LocalDateTime
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.AltinnRessursVariablesCreate
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.EpostSendevinduTypes
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.NarmestelederVariablesCreate
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.Variables
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.formatAsISO8601DateTime
+import java.time.LocalDateTime
 
 sealed class ArbeidsgiverNotifikasjon {
     abstract val varselId: String
@@ -33,7 +33,9 @@ sealed class ArbeidsgiverNotifikasjon {
     abstract val emailBody: String
     abstract val hardDeleteDate: LocalDateTime
     abstract val grupperingsid: String
+
     abstract fun createVariables(): Variables
+
     fun toNyBeskjedMutation(): NyBeskjedMutation =
         NyBeskjedMutation(
             nyBeskjed =
@@ -199,7 +201,7 @@ data class ArbeidsgiverNotifikasjonAltinnRessurs(
             sendevindu = EpostSendevinduTypes.LOEPENDE,
             hardDeleteDate = hardDeleteDate.formatAsISO8601DateTime(),
             grupperingsid = grupperingsid,
-            ressursId = ressursId
+            ressursId = ressursId,
         )
 }
 

--- a/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/domain/ArbeidsgiverNotifikasjon.kt
+++ b/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/domain/ArbeidsgiverNotifikasjon.kt
@@ -31,7 +31,7 @@ sealed class ArbeidsgiverNotifikasjon {
     abstract val merkelapp: String
     abstract val emailTitle: String
     abstract val emailBody: String
-    abstract val hardDeleteDate: LocalDateTime
+    abstract val hardDeleteDate: LocalDateTime?
     abstract val grupperingsid: String
 
     abstract fun createVariables(): Variables
@@ -72,7 +72,7 @@ sealed class ArbeidsgiverNotifikasjon {
             hardDelete =
                 Optional.present(
                     FutureTemporalInput(
-                        den = Optional.present(hardDeleteDate.formatAsISO8601DateTime()),
+                        den = Optional.present(hardDeleteDate?.formatAsISO8601DateTime()),
                     ),
                 ),
         )
@@ -89,7 +89,7 @@ data class ArbeidsgiverNotifikasjonNarmesteLeder(
     override val merkelapp: String,
     override val emailTitle: String,
     override val emailBody: String,
-    override val hardDeleteDate: LocalDateTime,
+    override val hardDeleteDate: LocalDateTime?,
     override val grupperingsid: String,
 ) : ArbeidsgiverNotifikasjon() {
     override fun createMottakere(): List<MottakerInput> =
@@ -141,7 +141,7 @@ data class ArbeidsgiverNotifikasjonNarmesteLeder(
             emailTitle,
             emailBody,
             EpostSendevinduTypes.LOEPENDE,
-            hardDeleteDate.formatAsISO8601DateTime(),
+            hardDeleteDate?.formatAsISO8601DateTime(),
             grupperingsid,
         )
 }
@@ -154,7 +154,7 @@ data class ArbeidsgiverNotifikasjonAltinnRessurs(
     override val merkelapp: String,
     override val emailTitle: String,
     override val emailBody: String,
-    override val hardDeleteDate: LocalDateTime,
+    override val hardDeleteDate: LocalDateTime?,
     override val grupperingsid: String,
     val ressursId: String,
 ) : ArbeidsgiverNotifikasjon() {
@@ -199,7 +199,7 @@ data class ArbeidsgiverNotifikasjonAltinnRessurs(
             epostTittel = emailTitle,
             epostHtmlBody = emailBody,
             sendevindu = EpostSendevinduTypes.LOEPENDE,
-            hardDeleteDate = hardDeleteDate.formatAsISO8601DateTime(),
+            hardDeleteDate = hardDeleteDate?.formatAsISO8601DateTime(),
             grupperingsid = grupperingsid,
             ressursId = ressursId,
         )

--- a/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/response/nyoppgave/NyOppgaveResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/response/nyoppgave/NyOppgaveResponse.kt
@@ -4,6 +4,7 @@ import java.io.Serializable
 
 data class NyOppgaveResponse(
     val data: Data?,
+    val errors: List<Error>? = null,
 )
 
 data class NyOppgave(

--- a/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverNotifikasjonInput.kt
+++ b/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverNotifikasjonInput.kt
@@ -1,0 +1,48 @@
+package no.nav.syfo.service
+
+import no.nav.syfo.service.Meldingstype.BESKJED
+import java.time.LocalDateTime
+import java.util.UUID
+
+sealed class IArbeidsgiverNotifikasjonInput {
+    abstract val uuid: UUID
+    abstract val virksomhetsnummer: String
+    abstract val merkelapp: String
+    abstract val messageText: String
+    abstract val epostTittel: String
+    abstract val epostHtmlBody: String
+    abstract val hardDeleteDate: LocalDateTime
+    abstract val meldingstype: Meldingstype
+    abstract val grupperingsid: String
+    abstract val link: String?
+}
+
+data class ArbeidsgiverNotifikasjonInput(
+    override val uuid: UUID,
+    override val virksomhetsnummer: String,
+    val narmesteLederFnr: String?,
+    val ansattFnr: String,
+    override val merkelapp: String,
+    override val messageText: String,
+    override val epostTittel: String,
+    override val epostHtmlBody: String,
+    override val hardDeleteDate: LocalDateTime,
+    override val meldingstype: Meldingstype = BESKJED,
+    override val grupperingsid: String,
+    override val link: String? = null,
+) : IArbeidsgiverNotifikasjonInput()
+
+data class ArbeidsgiverNotifikasjonAltinnRessursInput(
+    override val uuid: UUID,
+    override val virksomhetsnummer: String,
+    override val merkelapp: String,
+    override val messageText: String,
+    override val epostTittel: String,
+    override val epostHtmlBody: String,
+    override val hardDeleteDate: LocalDateTime,
+    override val meldingstype: Meldingstype = BESKJED,
+    override val grupperingsid: String,
+    override val link: String? = null,
+    val ressursId: String,
+    val ressursUrl: String,
+) : IArbeidsgiverNotifikasjonInput()

--- a/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverNotifikasjonNarmestelederInput.kt
+++ b/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverNotifikasjonNarmestelederInput.kt
@@ -4,7 +4,7 @@ import no.nav.syfo.service.Meldingstype.BESKJED
 import java.time.LocalDateTime
 import java.util.UUID
 
-sealed class IArbeidsgiverNotifikasjonInput {
+sealed class ArbeidsgiverNotifikasjonInput {
     abstract val uuid: UUID
     abstract val virksomhetsnummer: String
     abstract val merkelapp: String
@@ -30,7 +30,7 @@ data class ArbeidsgiverNotifikasjonNarmestelederInput(
     override val meldingstype: Meldingstype = BESKJED,
     override val grupperingsid: String,
     override val link: String? = null,
-) : IArbeidsgiverNotifikasjonInput()
+) : ArbeidsgiverNotifikasjonInput()
 
 data class ArbeidsgiverNotifikasjonAltinnRessursInput(
     override val uuid: UUID,
@@ -45,4 +45,4 @@ data class ArbeidsgiverNotifikasjonAltinnRessursInput(
     override val link: String? = null,
     val ressursId: String,
     val ressursUrl: String,
-) : IArbeidsgiverNotifikasjonInput()
+) : ArbeidsgiverNotifikasjonInput()

--- a/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverNotifikasjonNarmestelederInput.kt
+++ b/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverNotifikasjonNarmestelederInput.kt
@@ -17,7 +17,7 @@ sealed class IArbeidsgiverNotifikasjonInput {
     abstract val link: String?
 }
 
-data class ArbeidsgiverNotifikasjonInput(
+data class ArbeidsgiverNotifikasjonNarmestelederInput(
     override val uuid: UUID,
     override val virksomhetsnummer: String,
     val narmesteLederFnr: String?,

--- a/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverNotifikasjonNarmestelederInput.kt
+++ b/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverNotifikasjonNarmestelederInput.kt
@@ -11,7 +11,7 @@ sealed class ArbeidsgiverNotifikasjonInput {
     abstract val messageText: String
     abstract val epostTittel: String
     abstract val epostHtmlBody: String
-    abstract val hardDeleteDate: LocalDateTime
+    abstract val hardDeleteDate: LocalDateTime?
     abstract val meldingstype: Meldingstype
     abstract val grupperingsid: String
     abstract val link: String?
@@ -26,7 +26,7 @@ data class ArbeidsgiverNotifikasjonNarmestelederInput(
     override val messageText: String,
     override val epostTittel: String,
     override val epostHtmlBody: String,
-    override val hardDeleteDate: LocalDateTime,
+    override val hardDeleteDate: LocalDateTime?,
     override val meldingstype: Meldingstype = BESKJED,
     override val grupperingsid: String,
     override val link: String? = null,
@@ -39,7 +39,7 @@ data class ArbeidsgiverNotifikasjonAltinnRessursInput(
     override val messageText: String,
     override val epostTittel: String,
     override val epostHtmlBody: String,
-    override val hardDeleteDate: LocalDateTime,
+    override val hardDeleteDate: LocalDateTime?,
     override val meldingstype: Meldingstype = BESKJED,
     override val grupperingsid: String,
     override val link: String? = null,

--- a/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverNotifikasjonService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverNotifikasjonService.kt
@@ -3,6 +3,7 @@ package no.nav.syfo.service
 import no.nav.syfo.consumer.narmesteLeder.NarmesteLederService
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.ArbeidsgiverNotifikasjonProdusent
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.ArbeidsgiverDeleteNotifikasjon
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.ArbeidsgiverNotifikasjonAltinnRessurs
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.ArbeidsgiverNotifikasjonNarmesteLeder
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NyKalenderInput
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NySakInput
@@ -12,8 +13,6 @@ import no.nav.syfo.service.Meldingstype.BESKJED
 import no.nav.syfo.service.Meldingstype.OPPGAVE
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.time.LocalDateTime
-import java.util.UUID
 
 class ArbeidsgiverNotifikasjonService(
     private val arbeidsgiverNotifikasjonProdusent: ArbeidsgiverNotifikasjonProdusent,
@@ -62,8 +61,42 @@ class ArbeidsgiverNotifikasjonService(
             )
 
         when (arbeidsgiverNotifikasjon.meldingstype) {
-            BESKJED -> arbeidsgiverNotifikasjonProdusent.createNewBeskjedForArbeidsgiver(arbeidsgiverNotifikasjonNarmesteLeder)
-            OPPGAVE -> arbeidsgiverNotifikasjonProdusent.createNewOppgaveForArbeidsgiver(arbeidsgiverNotifikasjonNarmesteLeder)
+            BESKJED ->
+                arbeidsgiverNotifikasjonProdusent.createNewBeskjedForArbeidsgiver(
+                    arbeidsgiverNotifikasjonNarmesteLeder,
+                )
+
+            OPPGAVE ->
+                arbeidsgiverNotifikasjonProdusent.createNewOppgaveForArbeidsgiver(
+                    arbeidsgiverNotifikasjonNarmesteLeder,
+                )
+        }
+    }
+
+    suspend fun sendNotifikasjon(arbeidsgiverNotifikasjon: ArbeidsgiverNotifikasjonAltinnRessursInput) {
+        val arbeidsgiverNotifikasjonAltinnRessurs =
+            ArbeidsgiverNotifikasjonAltinnRessurs(
+                varselId = arbeidsgiverNotifikasjon.uuid.toString(),
+                virksomhetsnummer = arbeidsgiverNotifikasjon.virksomhetsnummer,
+                url = arbeidsgiverNotifikasjon.ressursUrl,
+                messageText = arbeidsgiverNotifikasjon.messageText,
+                merkelapp = arbeidsgiverNotifikasjon.merkelapp,
+                emailTitle = arbeidsgiverNotifikasjon.epostTittel,
+                emailBody = arbeidsgiverNotifikasjon.epostHtmlBody,
+                hardDeleteDate = arbeidsgiverNotifikasjon.hardDeleteDate,
+                grupperingsid = arbeidsgiverNotifikasjon.grupperingsid,
+                ressursId = arbeidsgiverNotifikasjon.ressursId,
+            )
+        when (arbeidsgiverNotifikasjon.meldingstype) {
+            BESKJED ->
+                arbeidsgiverNotifikasjonProdusent.createNewBeskjedForArbeidsgiver(
+                    arbeidsgiverNotifikasjonAltinnRessurs,
+                )
+
+            OPPGAVE ->
+                arbeidsgiverNotifikasjonProdusent.createNewOppgaveForArbeidsgiver(
+                    arbeidsgiverNotifikasjonAltinnRessurs,
+                )
         }
     }
 
@@ -91,21 +124,6 @@ class ArbeidsgiverNotifikasjonService(
     suspend fun updateKalenderavtale(oppdaterKalenderInput: OppdaterKalenderInput): String? =
         arbeidsgiverNotifikasjonProdusent.updateKalenderavtale(oppdaterKalenderInput)
 }
-
-data class ArbeidsgiverNotifikasjonInput(
-    val uuid: UUID,
-    val virksomhetsnummer: String,
-    val narmesteLederFnr: String?,
-    val ansattFnr: String,
-    val merkelapp: String,
-    val messageText: String,
-    val epostTittel: String,
-    val epostHtmlBody: String,
-    val hardDeleteDate: LocalDateTime,
-    val meldingstype: Meldingstype = BESKJED,
-    val grupperingsid: String,
-    val link: String? = null,
-)
 
 enum class Meldingstype {
     OPPGAVE,

--- a/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverNotifikasjonService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverNotifikasjonService.kt
@@ -3,7 +3,7 @@ package no.nav.syfo.service
 import no.nav.syfo.consumer.narmesteLeder.NarmesteLederService
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.ArbeidsgiverNotifikasjonProdusent
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.ArbeidsgiverDeleteNotifikasjon
-import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.ArbeidsgiverNotifikasjon
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.ArbeidsgiverNotifikasjonNarmesteLeder
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NyKalenderInput
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NySakInput
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NyStatusSakInput
@@ -45,8 +45,8 @@ class ArbeidsgiverNotifikasjonService(
 
         val url = arbeidsgiverNotifikasjon.link ?: "$dineSykmeldteUrl/${narmesteLederRelasjon.narmesteLederId}"
 
-        val arbeidsgiverNotifikasjonen =
-            ArbeidsgiverNotifikasjon(
+        val arbeidsgiverNotifikasjonNarmesteLeder =
+            ArbeidsgiverNotifikasjonNarmesteLeder(
                 varselId = arbeidsgiverNotifikasjon.uuid.toString(),
                 virksomhetsnummer = arbeidsgiverNotifikasjon.virksomhetsnummer,
                 url = url,
@@ -62,8 +62,8 @@ class ArbeidsgiverNotifikasjonService(
             )
 
         when (arbeidsgiverNotifikasjon.meldingstype) {
-            BESKJED -> arbeidsgiverNotifikasjonProdusent.createNewBeskjedForArbeidsgiver(arbeidsgiverNotifikasjonen)
-            OPPGAVE -> arbeidsgiverNotifikasjonProdusent.createNewOppgaveForArbeidsgiver(arbeidsgiverNotifikasjonen)
+            BESKJED -> arbeidsgiverNotifikasjonProdusent.createNewBeskjedForArbeidsgiver(arbeidsgiverNotifikasjonNarmesteLeder)
+            OPPGAVE -> arbeidsgiverNotifikasjonProdusent.createNewOppgaveForArbeidsgiver(arbeidsgiverNotifikasjonNarmesteLeder)
         }
     }
 
@@ -101,7 +101,7 @@ data class ArbeidsgiverNotifikasjonInput(
     val messageText: String,
     val epostTittel: String,
     val epostHtmlBody: String,
-    val hardDeleteDate: LocalDateTime? = null,
+    val hardDeleteDate: LocalDateTime,
     val meldingstype: Meldingstype = BESKJED,
     val grupperingsid: String,
     val link: String? = null,

--- a/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverNotifikasjonService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverNotifikasjonService.kt
@@ -21,7 +21,7 @@ class ArbeidsgiverNotifikasjonService(
 ) {
     private val log: Logger = LoggerFactory.getLogger(ArbeidsgiverNotifikasjonService::class.qualifiedName)
 
-    suspend fun sendNotifikasjon(arbeidsgiverNotifikasjon: ArbeidsgiverNotifikasjonInput) {
+    suspend fun sendNotifikasjon(arbeidsgiverNotifikasjon: ArbeidsgiverNotifikasjonNarmestelederInput) {
         val narmesteLederRelasjon =
             narmesteLederService.getNarmesteLederRelasjon(
                 arbeidsgiverNotifikasjon.ansattFnr,

--- a/src/main/kotlin/no/nav/syfo/service/DialogmoteInnkallingNarmesteLederVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/DialogmoteInnkallingNarmesteLederVarselService.kt
@@ -279,7 +279,7 @@ class DialogmoteInnkallingNarmesteLederVarselService(
             nyTekst = personData?.let { "Dialogmøte med ${it.firstName()} er avholdt" } ?: "Dialogmøtet er avholdt",
         )
         val input =
-            ArbeidsgiverNotifikasjonInput(
+            ArbeidsgiverNotifikasjonNarmestelederInput(
                 uuid = UUID.randomUUID(),
                 virksomhetsnummer = varselHendelse.orgnummer,
                 narmesteLederFnr = varselHendelse.narmesteLederFnr,

--- a/src/main/kotlin/no/nav/syfo/service/DialogmoteInnkallingNarmesteLederVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/DialogmoteInnkallingNarmesteLederVarselService.kt
@@ -265,6 +265,11 @@ class DialogmoteInnkallingNarmesteLederVarselService(
             oldVarselService.sendVarselTilNarmesteLeder(varselHendelse)
             return
         }
+        val varselData = varselHendelse.data?.toVarselData()
+        require(varselData != null) { "DialogmoteReferat mangler varselData" }
+        val motetidspunkt =
+            varselData.motetidspunkt?.tidspunkt
+                ?: throw IllegalArgumentException("DialogmoteReferat mangler motetidspunkt")
         val texts = varselHendelse.dialogmoteNarmesteLederTexts()
         updateSakStatus(sakId = sak.id, grupperingsId = sak.grupperingsid, nyStatus = SakStatus.FERDIG)
         senderFacade.updateKalenderavtale(
@@ -283,10 +288,22 @@ class DialogmoteInnkallingNarmesteLederVarselService(
                 messageText = texts.messageText,
                 epostTittel = texts.epostTittel,
                 epostHtmlBody = texts.emailBody,
+                hardDeleteDate = getReferatHardDeleteDate(motetidspunkt),
                 meldingstype = Meldingstype.BESKJED,
                 grupperingsid = sak.grupperingsid,
             )
         senderFacade.sendTilArbeidsgiverNotifikasjon(varselHendelse, input)
+    }
+
+    private fun getReferatHardDeleteDate(motetidspunkt: LocalDateTime): LocalDateTime {
+        val now = LocalDateTime.now()
+        val hardDeleteDate = motetidspunkt.plusWeeks(WEEKS_BEFORE_DELETE)
+
+        return if (hardDeleteDate.isAfter(now)) {
+            hardDeleteDate
+        } else {
+            now.plusWeeks(WEEKS_BEFORE_DELETE)
+        }
     }
 
     private suspend fun createNewSak(

--- a/src/main/kotlin/no/nav/syfo/service/DialogmoteInnkallingNarmesteLederVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/DialogmoteInnkallingNarmesteLederVarselService.kt
@@ -288,22 +288,11 @@ class DialogmoteInnkallingNarmesteLederVarselService(
                 messageText = texts.messageText,
                 epostTittel = texts.epostTittel,
                 epostHtmlBody = texts.emailBody,
-                hardDeleteDate = getReferatHardDeleteDate(motetidspunkt),
+                hardDeleteDate = null,
                 meldingstype = Meldingstype.BESKJED,
                 grupperingsid = sak.grupperingsid,
             )
         senderFacade.sendTilArbeidsgiverNotifikasjon(varselHendelse, input)
-    }
-
-    private fun getReferatHardDeleteDate(motetidspunkt: LocalDateTime): LocalDateTime {
-        val now = LocalDateTime.now()
-        val hardDeleteDate = motetidspunkt.plusWeeks(WEEKS_BEFORE_DELETE)
-
-        return if (hardDeleteDate.isAfter(now)) {
-            hardDeleteDate
-        } else {
-            now.plusWeeks(WEEKS_BEFORE_DELETE)
-        }
     }
 
     private suspend fun createNewSak(

--- a/src/main/kotlin/no/nav/syfo/service/DialogmoteInnkallingNarmestelederVarselServiceOLD.kt
+++ b/src/main/kotlin/no/nav/syfo/service/DialogmoteInnkallingNarmestelederVarselServiceOLD.kt
@@ -54,7 +54,7 @@ class DialogmoteInnkallingNarmestelederVarselServiceOLD(
 
         if (!sms.isNullOrBlank() && !emailTitle.isNullOrBlank() && !emailBody.isNullOrBlank()) {
             val input =
-                ArbeidsgiverNotifikasjonInput(
+                ArbeidsgiverNotifikasjonNarmestelederInput(
                     uuid = UUID.randomUUID(),
                     virksomhetsnummer = varselHendelse.orgnummer,
                     narmesteLederFnr = varselHendelse.narmesteLederFnr,

--- a/src/main/kotlin/no/nav/syfo/service/MotebehovVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/MotebehovVarselService.kt
@@ -75,7 +75,7 @@ class MotebehovVarselService(
     private suspend fun sendVarselTilArbeidsgiverNotifikasjon(varselHendelse: NarmesteLederHendelse) {
         senderFacade.sendTilArbeidsgiverNotifikasjon(
             varselHendelse,
-            ArbeidsgiverNotifikasjonInput(
+            ArbeidsgiverNotifikasjonNarmestelederInput(
                 UUID.randomUUID(),
                 varselHendelse.orgnummer,
                 varselHendelse.narmesteLederFnr,
@@ -147,7 +147,7 @@ class MotebehovVarselService(
             return false
         }
         val notifikasjon =
-            ArbeidsgiverNotifikasjonInput(
+            ArbeidsgiverNotifikasjonNarmestelederInput(
                 UUID.randomUUID(),
                 utsendtvarselFeilet.orgnummer,
                 utsendtvarselFeilet.narmesteLederFnr,
@@ -213,7 +213,7 @@ class MotebehovVarselService(
         val data = dataToVarselDataMotebehovTilbakemelding(varselHendelse.data)
         senderFacade.sendTilArbeidsgiverNotifikasjon(
             varselHendelse,
-            ArbeidsgiverNotifikasjonInput(
+            ArbeidsgiverNotifikasjonNarmestelederInput(
                 uuid = UUID.randomUUID(),
                 virksomhetsnummer = varselHendelse.orgnummer,
                 narmesteLederFnr = varselHendelse.narmesteLederFnr,

--- a/src/main/kotlin/no/nav/syfo/service/OppfolgingsplanVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/OppfolgingsplanVarselService.kt
@@ -62,7 +62,7 @@ class OppfolgingsplanVarselService(
         )
         senderFacade.sendTilArbeidsgiverNotifikasjon(
             varselHendelse,
-            ArbeidsgiverNotifikasjonInput(
+            ArbeidsgiverNotifikasjonNarmestelederInput(
                 UUID.randomUUID(),
                 varselHendelse.orgnummer,
                 varselHendelse.narmesteLederFnr,
@@ -117,7 +117,7 @@ class OppfolgingsplanVarselService(
         senderFacade.createNewSak(sakInput)
         senderFacade.sendTilArbeidsgiverNotifikasjon(
             varselHendelse,
-            ArbeidsgiverNotifikasjonInput(
+            ArbeidsgiverNotifikasjonNarmestelederInput(
                 UUID.randomUUID(),
                 varselHendelse.orgnummer,
                 varselHendelse.narmesteLederFnr,

--- a/src/main/kotlin/no/nav/syfo/service/SenderFacade.kt
+++ b/src/main/kotlin/no/nav/syfo/service/SenderFacade.kt
@@ -160,7 +160,7 @@ class SenderFacade(
 
     suspend fun sendTilArbeidsgiverNotifikasjon(
         varselHendelse: NarmesteLederHendelse,
-        notifikasjon: ArbeidsgiverNotifikasjonInput,
+        notifikasjon: ArbeidsgiverNotifikasjonNarmestelederInput,
     ) {
         try {
             arbeidsgiverNotifikasjonService.sendNotifikasjon(notifikasjon)
@@ -184,7 +184,7 @@ class SenderFacade(
 
     suspend fun sendTilArbeidsgiverNotifikasjon(
         varselFeilet: PUtsendtVarselFeilet,
-        notifikasjon: ArbeidsgiverNotifikasjonInput,
+        notifikasjon: ArbeidsgiverNotifikasjonNarmestelederInput,
     ) {
         try {
             arbeidsgiverNotifikasjonService.sendNotifikasjon(notifikasjon)

--- a/src/test/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonProdusentSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonProdusentSpek.kt
@@ -64,7 +64,7 @@ class ArbeidsgiverNotifikasjonProdusentSpek :
                     }
 
                 exception.message shouldBe
-                    "Could not send task to arbeidsgiver. because of error: Simulert feil fra arbeidsgiver notifikasjon API, data was null"
+                    "Could not send task to arbeidsgiver: httpStatus=200, errorsEmpty=false, firstError=Simulert feil fra arbeidsgiver notifikasjon API, dataWasNull=true"
             }
 
             it("Should send beskjed") {

--- a/src/test/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonProdusentSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonProdusentSpek.kt
@@ -1,9 +1,12 @@
 package no.nav.syfo.producer.arbeidsgivernotifikasjon
 
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
 import no.nav.syfo.auth.AzureAdTokenConsumer
 import no.nav.syfo.getTestEnv
-import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.ArbeidsgiverNotifikasjon
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.ArbeidsgiverNotifikasjonNarmesteLeder
 import no.nav.syfo.testutil.mocks.FNR_1
 import no.nav.syfo.testutil.mocks.FNR_2
 import no.nav.syfo.testutil.mocks.MockServers
@@ -21,20 +24,21 @@ class ArbeidsgiverNotifikasjonProdusentSpek :
         val arbeidsgiverNotifikasjonProdusent = ArbeidsgiverNotifikasjonProdusent(testEnv.urlEnv, azureAdConsumer)
 
         val arbeidsgiverNotifikasjon =
-            ArbeidsgiverNotifikasjon(
-                UUID.randomUUID().toString(),
-                ORGNUMMER,
-                "",
-                FNR_1,
-                FNR_2,
-                "hei",
-                "test@test.no",
-                "Oppfølging",
-                "Hei du",
-                "Body",
-                LocalDateTime.now().plusDays(1),
-                UUID.randomUUID().toString(),
+            ArbeidsgiverNotifikasjonNarmesteLeder(
+                varselId = UUID.randomUUID().toString(),
+                virksomhetsnummer = ORGNUMMER,
+                url = "",
+                narmesteLederFnr = FNR_1,
+                ansattFnr = FNR_2,
+                messageText = "hei",
+                narmesteLederEpostadresse = "test@test.no",
+                merkelapp = "Oppfølging",
+                emailTitle = "Hei du",
+                emailBody = "Body",
+                hardDeleteDate = LocalDateTime.now().plusDays(1),
+                grupperingsid = UUID.randomUUID().toString(),
             )
+        val expectedId = "d69f8c4f-8d34-47b0-9539-d3c2e54115da"
 
         beforeSpec {
             azureAdMockServer.start()
@@ -48,13 +52,47 @@ class ArbeidsgiverNotifikasjonProdusentSpek :
 
         describe("ArbeidsgiverNotifikasjonProdusentSpek") {
             it("Should send oppgave") {
-                arbeidsgiverNotifikasjonProdusent.createNewOppgaveForArbeidsgiver(arbeidsgiverNotifikasjon)
+                arbeidsgiverNotifikasjonProdusent.createNewOppgaveForArbeidsgiver(arbeidsgiverNotifikasjon) shouldBe expectedId
+            }
+
+            it("Should keep API error message when oppgave response has data null and errors") {
+                val exception =
+                    shouldThrow<RuntimeException> {
+                        arbeidsgiverNotifikasjonProdusent.createNewOppgaveForArbeidsgiver(
+                            arbeidsgiverNotifikasjon.copy(messageText = "force-error"),
+                        )
+                    }
+
+                exception.message shouldBe
+                    "Could not send task to arbeidsgiver. because of error: Simulert feil fra arbeidsgiver notifikasjon API, data was null"
             }
 
             it("Should send beskjed") {
-                arbeidsgiverNotifikasjonProdusent.createNewBeskjedForArbeidsgiver(
-                    arbeidsgiverNotifikasjon,
-                )
+                arbeidsgiverNotifikasjonProdusent.createNewBeskjedForArbeidsgiver(arbeidsgiverNotifikasjon) shouldBe expectedId
+            }
+
+            it("Should serialize hardDeleteDate as required ISO-8601 string") {
+                val hardDeleteDate = LocalDateTime.of(2024, 1, 2, 3, 4, 5)
+                val requestBody =
+                    jacksonObjectMapper().writeValueAsString(
+                        VariablesCreate(
+                            eksternId = UUID.randomUUID().toString(),
+                            virksomhetsnummer = ORGNUMMER,
+                            lenke = "",
+                            naermesteLederFnr = FNR_1,
+                            ansattFnr = FNR_2,
+                            merkelapp = "Oppfølging",
+                            tekst = "hei",
+                            epostadresse = "test@test.no",
+                            epostTittel = "Hei du",
+                            epostHtmlBody = "Body",
+                            sendevindu = EpostSendevinduTypes.LOEPENDE,
+                            hardDeleteDate = hardDeleteDate.formatAsISO8601DateTime(),
+                            grupperingsid = UUID.randomUUID().toString(),
+                        ),
+                    )
+
+                requestBody.contains("\"hardDeleteDate\":\"2024-01-02T03:04:05\"") shouldBe true
             }
         }
     })

--- a/src/test/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonProdusentSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonProdusentSpek.kt
@@ -75,7 +75,7 @@ class ArbeidsgiverNotifikasjonProdusentSpek :
                 val hardDeleteDate = LocalDateTime.of(2024, 1, 2, 3, 4, 5)
                 val requestBody =
                     jacksonObjectMapper().writeValueAsString(
-                        VariablesCreate(
+                        NarmestelederVariablesCreate(
                             eksternId = UUID.randomUUID().toString(),
                             virksomhetsnummer = ORGNUMMER,
                             lenke = "",

--- a/src/test/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/domain/ArbeidsgiverNotifikasjonSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/domain/ArbeidsgiverNotifikasjonSpek.kt
@@ -1,0 +1,116 @@
+package no.nav.syfo.producer.arbeidsgivernotifikasjon.domain
+
+import com.apollographql.apollo.api.Optional
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.formatAsISO8601DateTime
+import no.nav.syfo.testutil.mocks.FNR_1
+import no.nav.syfo.testutil.mocks.FNR_2
+import no.nav.syfo.testutil.mocks.ORGNUMMER
+import java.time.LocalDateTime
+import java.util.UUID
+
+class ArbeidsgiverNotifikasjonSpek :
+    DescribeSpec({
+        val varselId = UUID.randomUUID().toString()
+        val grupperingsid = UUID.randomUUID().toString()
+        val messageText = "Dette er en tekst"
+        val emailTitle = "Oppfølging"
+        val emailBody = "Dette er e-postinnhold"
+        val hardDeleteDate = LocalDateTime.now().plusDays(1)
+
+        describe("toNyBeskjedMutation") {
+            it("mapper naermeste leder til Apollo-input for dagens flyt") {
+                val notifikasjon =
+                    ArbeidsgiverNotifikasjonNarmesteLeder(
+                        varselId = varselId,
+                        virksomhetsnummer = ORGNUMMER,
+                        url = "https://arbeidsgiver.nav.no",
+                        narmesteLederFnr = FNR_1,
+                        ansattFnr = FNR_2,
+                        messageText = messageText,
+                        narmesteLederEpostadresse = "leder@nav.no",
+                        merkelapp = "Oppfølging",
+                        emailTitle = emailTitle,
+                        emailBody = emailBody,
+                        hardDeleteDate = hardDeleteDate,
+                        grupperingsid = grupperingsid,
+                    )
+
+                val mutation = notifikasjon.toNyBeskjedMutation()
+                val mottaker =
+                    mutation.nyBeskjed
+                        .mottakere
+                        .getOrThrow()
+                        .single()
+                val eksterntVarsel =
+                    mutation.nyBeskjed
+                        .eksterneVarsler
+                        .getOrThrow()
+                        .single()
+                val naermesteLeder = requireNotNull(mottaker.naermesteLeder.getOrThrow())
+                val epost = requireNotNull(eksterntVarsel.epost.getOrThrow())
+                val kontaktinfo = requireNotNull(epost.mottaker.kontaktinfo.getOrThrow())
+                val hardDelete =
+                    requireNotNull(
+                        mutation.nyBeskjed.metadata
+                            .hardDelete
+                            .getOrThrow(),
+                    )
+
+                mottaker.altinnRessurs shouldBe Optional.Absent
+                naermesteLeder.naermesteLederFnr shouldBe FNR_1
+                naermesteLeder.ansattFnr shouldBe FNR_2
+                eksterntVarsel.altinnressurs shouldBe Optional.Absent
+                kontaktinfo.epostadresse shouldBe "leder@nav.no"
+                mutation.nyBeskjed.notifikasjon.tekst shouldBe messageText
+                hardDelete.den
+                    .getOrThrow() shouldBe hardDeleteDate.formatAsISO8601DateTime()
+            }
+
+            it("mapper altinnressurs til Apollo-input") {
+                val ressursId = "nav_permittering-og-nedbemanning"
+                val notifikasjon =
+                    ArbeidsgiverNotifikasjonAltinnRessurs(
+                        varselId = varselId,
+                        virksomhetsnummer = ORGNUMMER,
+                        url = "https://arbeidsgiver.nav.no",
+                        messageText = messageText,
+                        merkelapp = "Oppfølging",
+                        emailTitle = emailTitle,
+                        emailBody = emailBody,
+                        hardDeleteDate = hardDeleteDate,
+                        grupperingsid = grupperingsid,
+                        ressursId = ressursId,
+                    )
+
+                val mutation = notifikasjon.toNyBeskjedMutation()
+                val mottaker =
+                    mutation.nyBeskjed
+                        .mottakere
+                        .getOrThrow()
+                        .single()
+                val eksterntVarsel =
+                    mutation.nyBeskjed
+                        .eksterneVarsler
+                        .getOrThrow()
+                        .single()
+                val altinnRessurs = requireNotNull(mottaker.altinnRessurs.getOrThrow())
+                val altinnressursVarsel = requireNotNull(eksterntVarsel.altinnressurs.getOrThrow())
+                val hardDelete =
+                    requireNotNull(
+                        mutation.nyBeskjed.metadata
+                            .hardDelete
+                            .getOrThrow(),
+                    )
+
+                mottaker.naermesteLeder shouldBe Optional.Absent
+                altinnRessurs.ressursId shouldBe ressursId
+                eksterntVarsel.epost shouldBe Optional.Absent
+                altinnressursVarsel.mottaker.ressursId shouldBe ressursId
+                altinnressursVarsel.smsTekst shouldBe messageText
+                hardDelete.den
+                    .getOrThrow() shouldBe hardDeleteDate.formatAsISO8601DateTime()
+            }
+        }
+    })

--- a/src/test/kotlin/no/nav/syfo/service/DialogmoteInnkallingNarmesteLederVarselServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/service/DialogmoteInnkallingNarmesteLederVarselServiceSpek.kt
@@ -31,7 +31,6 @@ import no.nav.syfo.testutil.mocks.ORGNUMMER
 import org.amshove.kluent.shouldBeEqualTo
 import java.time.LocalDateTime
 import java.util.UUID
-import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.ArbeidsgiverNotifikasjonNarmesteLeder
 
 class DialogmoteInnkallingNarmesteLederVarselServiceSpek :
     DescribeSpec({
@@ -96,7 +95,7 @@ class DialogmoteInnkallingNarmesteLederVarselServiceSpek :
                     arbeidsgiverNotifikasjonService.createNewKalenderavtale(any())
                 }
                 coVerify(exactly = 0) {
-                    arbeidsgiverNotifikasjonService.sendNotifikasjon(any<ArbeidsgiverNotifikasjonInput>())
+                    arbeidsgiverNotifikasjonService.sendNotifikasjon(any<ArbeidsgiverNotifikasjonNarmestelederInput>())
                 }
             }
 
@@ -114,7 +113,7 @@ class DialogmoteInnkallingNarmesteLederVarselServiceSpek :
 
                 coVerify(exactly = 1) {
                     arbeidsgiverNotifikasjonService.sendNotifikasjon(
-                        withArg { input: ArbeidsgiverNotifikasjonInput ->
+                        withArg { input: ArbeidsgiverNotifikasjonNarmestelederInput ->
                             input.hardDeleteDate shouldBeEqualTo historiskMotetidspunkt.plusWeeks(4)
                         },
                     )
@@ -137,7 +136,7 @@ class DialogmoteInnkallingNarmesteLederVarselServiceSpek :
 
                 coVerify(exactly = 1) {
                     arbeidsgiverNotifikasjonService.sendNotifikasjon(
-                        withArg { input: ArbeidsgiverNotifikasjonInput ->
+                        withArg { input: ArbeidsgiverNotifikasjonNarmestelederInput ->
                             input.hardDeleteDate.isBefore(expectedLowerBound) shouldBeEqualTo false
                             input.hardDeleteDate.isAfter(expectedUpperBound) shouldBeEqualTo false
                         },
@@ -199,7 +198,7 @@ class DialogmoteInnkallingNarmesteLederVarselServiceSpek :
                     arbeidsgiverNotifikasjonService.updateKalenderavtale(any())
                 }
                 coVerify(exactly = 0) {
-                    arbeidsgiverNotifikasjonService.sendNotifikasjon(any<ArbeidsgiverNotifikasjonInput>())
+                    arbeidsgiverNotifikasjonService.sendNotifikasjon(any<ArbeidsgiverNotifikasjonNarmestelederInput>())
                 }
             }
 
@@ -210,7 +209,7 @@ class DialogmoteInnkallingNarmesteLederVarselServiceSpek :
                 dialogmoteInnkallingNarmesteLederVarselService.sendVarselTilNarmesteLeder(varselHendelseInnkalling)
 
                 coVerify(exactly = 1) {
-                    arbeidsgiverNotifikasjonService.sendNotifikasjon(any<ArbeidsgiverNotifikasjonInput>())
+                    arbeidsgiverNotifikasjonService.sendNotifikasjon(any<ArbeidsgiverNotifikasjonNarmestelederInput>())
                 }
                 coVerify(exactly = 0) {
                     arbeidsgiverNotifikasjonService.createNewKalenderavtale(any())

--- a/src/test/kotlin/no/nav/syfo/service/DialogmoteInnkallingNarmesteLederVarselServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/service/DialogmoteInnkallingNarmesteLederVarselServiceSpek.kt
@@ -99,15 +99,48 @@ class DialogmoteInnkallingNarmesteLederVarselServiceSpek :
                 }
             }
 
-            it("Referat should send notifikasjon") {
+            it("Referat should send notifikasjon with motetidspunkt-based hardDeleteDate for historical motetidspunkt within 4 weeks") {
                 val varselHendelseInnkalling = createHendelse(type = HendelseType.NL_DIALOGMOTE_INNKALT)
                 dialogmoteInnkallingNarmesteLederVarselService.sendVarselTilNarmesteLeder(varselHendelseInnkalling)
 
-                val varselHendelseReferat = createHendelse(type = HendelseType.NL_DIALOGMOTE_REFERAT)
+                val historiskMotetidspunkt = LocalDateTime.now().minusWeeks(1)
+                val varselHendelseReferat =
+                    createHendelse(
+                        type = HendelseType.NL_DIALOGMOTE_REFERAT,
+                        motetidspunkt = historiskMotetidspunkt,
+                    )
                 dialogmoteInnkallingNarmesteLederVarselService.sendVarselTilNarmesteLeder(varselHendelseReferat)
 
                 coVerify(exactly = 1) {
-                    arbeidsgiverNotifikasjonService.sendNotifikasjon(any())
+                    arbeidsgiverNotifikasjonService.sendNotifikasjon(
+                        withArg { input ->
+                            input.hardDeleteDate shouldBeEqualTo historiskMotetidspunkt.plusWeeks(4)
+                        },
+                    )
+                }
+            }
+
+            it("Referat should send notifikasjon with future hardDeleteDate for motetidspunkt older than 4 weeks") {
+                val varselHendelseInnkalling = createHendelse(type = HendelseType.NL_DIALOGMOTE_INNKALT)
+                dialogmoteInnkallingNarmesteLederVarselService.sendVarselTilNarmesteLeder(varselHendelseInnkalling)
+
+                val historiskMotetidspunkt = LocalDateTime.now().minusWeeks(5)
+                val expectedLowerBound = LocalDateTime.now().plusWeeks(4)
+                val varselHendelseReferat =
+                    createHendelse(
+                        type = HendelseType.NL_DIALOGMOTE_REFERAT,
+                        motetidspunkt = historiskMotetidspunkt,
+                    )
+                dialogmoteInnkallingNarmesteLederVarselService.sendVarselTilNarmesteLeder(varselHendelseReferat)
+                val expectedUpperBound = LocalDateTime.now().plusWeeks(4)
+
+                coVerify(exactly = 1) {
+                    arbeidsgiverNotifikasjonService.sendNotifikasjon(
+                        withArg { input ->
+                            input.hardDeleteDate.isBefore(expectedLowerBound) shouldBeEqualTo false
+                            input.hardDeleteDate.isAfter(expectedUpperBound) shouldBeEqualTo false
+                        },
+                    )
                 }
             }
 
@@ -185,7 +218,10 @@ class DialogmoteInnkallingNarmesteLederVarselServiceSpek :
         }
     })
 
-fun createHendelse(type: HendelseType): NarmesteLederHendelse =
+fun createHendelse(
+    type: HendelseType,
+    motetidspunkt: LocalDateTime = LocalDateTime.now().plusWeeks(1),
+): NarmesteLederHendelse =
     NarmesteLederHendelse(
         type = type,
         ferdigstill = false,
@@ -193,7 +229,7 @@ fun createHendelse(type: HendelseType): NarmesteLederHendelse =
             createObjectMapper().writeValueAsString(
                 VarselData(
                     narmesteLeder = VarselDataNarmesteLeder(navn = "Test Testesen"),
-                    motetidspunkt = VarselDataMotetidspunkt(tidspunkt = LocalDateTime.now().plusWeeks(1)),
+                    motetidspunkt = VarselDataMotetidspunkt(tidspunkt = motetidspunkt),
                 ),
             ),
         narmesteLederFnr = ARBEIDSTAKER_AKTOR_ID_1,

--- a/src/test/kotlin/no/nav/syfo/service/DialogmoteInnkallingNarmesteLederVarselServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/service/DialogmoteInnkallingNarmesteLederVarselServiceSpek.kt
@@ -31,6 +31,7 @@ import no.nav.syfo.testutil.mocks.ORGNUMMER
 import org.amshove.kluent.shouldBeEqualTo
 import java.time.LocalDateTime
 import java.util.UUID
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.ArbeidsgiverNotifikasjonNarmesteLeder
 
 class DialogmoteInnkallingNarmesteLederVarselServiceSpek :
     DescribeSpec({
@@ -95,7 +96,7 @@ class DialogmoteInnkallingNarmesteLederVarselServiceSpek :
                     arbeidsgiverNotifikasjonService.createNewKalenderavtale(any())
                 }
                 coVerify(exactly = 0) {
-                    arbeidsgiverNotifikasjonService.sendNotifikasjon(any())
+                    arbeidsgiverNotifikasjonService.sendNotifikasjon(any<ArbeidsgiverNotifikasjonInput>())
                 }
             }
 
@@ -113,7 +114,7 @@ class DialogmoteInnkallingNarmesteLederVarselServiceSpek :
 
                 coVerify(exactly = 1) {
                     arbeidsgiverNotifikasjonService.sendNotifikasjon(
-                        withArg { input ->
+                        withArg { input: ArbeidsgiverNotifikasjonInput ->
                             input.hardDeleteDate shouldBeEqualTo historiskMotetidspunkt.plusWeeks(4)
                         },
                     )
@@ -136,7 +137,7 @@ class DialogmoteInnkallingNarmesteLederVarselServiceSpek :
 
                 coVerify(exactly = 1) {
                     arbeidsgiverNotifikasjonService.sendNotifikasjon(
-                        withArg { input ->
+                        withArg { input: ArbeidsgiverNotifikasjonInput ->
                             input.hardDeleteDate.isBefore(expectedLowerBound) shouldBeEqualTo false
                             input.hardDeleteDate.isAfter(expectedUpperBound) shouldBeEqualTo false
                         },
@@ -198,7 +199,7 @@ class DialogmoteInnkallingNarmesteLederVarselServiceSpek :
                     arbeidsgiverNotifikasjonService.updateKalenderavtale(any())
                 }
                 coVerify(exactly = 0) {
-                    arbeidsgiverNotifikasjonService.sendNotifikasjon(any())
+                    arbeidsgiverNotifikasjonService.sendNotifikasjon(any<ArbeidsgiverNotifikasjonInput>())
                 }
             }
 
@@ -209,7 +210,7 @@ class DialogmoteInnkallingNarmesteLederVarselServiceSpek :
                 dialogmoteInnkallingNarmesteLederVarselService.sendVarselTilNarmesteLeder(varselHendelseInnkalling)
 
                 coVerify(exactly = 1) {
-                    arbeidsgiverNotifikasjonService.sendNotifikasjon(any())
+                    arbeidsgiverNotifikasjonService.sendNotifikasjon(any<ArbeidsgiverNotifikasjonInput>())
                 }
                 coVerify(exactly = 0) {
                     arbeidsgiverNotifikasjonService.createNewKalenderavtale(any())

--- a/src/test/kotlin/no/nav/syfo/service/DialogmoteInnkallingNarmesteLederVarselServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/service/DialogmoteInnkallingNarmesteLederVarselServiceSpek.kt
@@ -1,6 +1,7 @@
 package no.nav.syfo.service
 
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -99,7 +100,7 @@ class DialogmoteInnkallingNarmesteLederVarselServiceSpek :
                 }
             }
 
-            it("Referat should send notifikasjon with motetidspunkt-based hardDeleteDate for historical motetidspunkt within 4 weeks") {
+            it("Referat should send notifikasjon with referat with hardDeleteDate as null") {
                 val varselHendelseInnkalling = createHendelse(type = HendelseType.NL_DIALOGMOTE_INNKALT)
                 dialogmoteInnkallingNarmesteLederVarselService.sendVarselTilNarmesteLeder(varselHendelseInnkalling)
 
@@ -114,31 +115,7 @@ class DialogmoteInnkallingNarmesteLederVarselServiceSpek :
                 coVerify(exactly = 1) {
                     arbeidsgiverNotifikasjonService.sendNotifikasjon(
                         withArg { input: ArbeidsgiverNotifikasjonNarmestelederInput ->
-                            input.hardDeleteDate shouldBeEqualTo historiskMotetidspunkt.plusWeeks(4)
-                        },
-                    )
-                }
-            }
-
-            it("Referat should send notifikasjon with future hardDeleteDate for motetidspunkt older than 4 weeks") {
-                val varselHendelseInnkalling = createHendelse(type = HendelseType.NL_DIALOGMOTE_INNKALT)
-                dialogmoteInnkallingNarmesteLederVarselService.sendVarselTilNarmesteLeder(varselHendelseInnkalling)
-
-                val historiskMotetidspunkt = LocalDateTime.now().minusWeeks(5)
-                val expectedLowerBound = LocalDateTime.now().plusWeeks(4)
-                val varselHendelseReferat =
-                    createHendelse(
-                        type = HendelseType.NL_DIALOGMOTE_REFERAT,
-                        motetidspunkt = historiskMotetidspunkt,
-                    )
-                dialogmoteInnkallingNarmesteLederVarselService.sendVarselTilNarmesteLeder(varselHendelseReferat)
-                val expectedUpperBound = LocalDateTime.now().plusWeeks(4)
-
-                coVerify(exactly = 1) {
-                    arbeidsgiverNotifikasjonService.sendNotifikasjon(
-                        withArg { input: ArbeidsgiverNotifikasjonNarmestelederInput ->
-                            input.hardDeleteDate.isBefore(expectedLowerBound) shouldBeEqualTo false
-                            input.hardDeleteDate.isAfter(expectedUpperBound) shouldBeEqualTo false
+                            input.hardDeleteDate shouldBe null
                         },
                     )
                 }

--- a/src/test/kotlin/no/nav/syfo/service/OppfolgingsplanVarselServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/service/OppfolgingsplanVarselServiceSpek.kt
@@ -124,7 +124,7 @@ class OppfolgingsplanVarselServiceSpek :
             it("Oppfolgingsplan foresporsel should use dinesykmeldte url for arbeidsgivernotifikasjon and sak") {
                 val narmesteLederId = "1234"
                 val expectedUrl = "$fakeDinesykmeldteUrl/$narmesteLederId"
-                val notifikasjonInputSlot = slot<ArbeidsgiverNotifikasjonInput>()
+                val notifikasjonInputSlot = slot<ArbeidsgiverNotifikasjonNarmestelederInput>()
                 val sakInputSlot = slot<NySakInput>()
 
                 coEvery { narmesteLederService.getNarmesteLederRelasjon(FNR_1, ORGNUMMER) } returns
@@ -143,7 +143,7 @@ class OppfolgingsplanVarselServiceSpek :
                             ),
                     )
                 coEvery { arbeidsgiverNotifikasjonService.createNewSak(any()) } returns UUID.randomUUID().toString()
-                coEvery { arbeidsgiverNotifikasjonService.sendNotifikasjon(any<ArbeidsgiverNotifikasjonInput>()) } returns Unit
+                coEvery { arbeidsgiverNotifikasjonService.sendNotifikasjon(any<ArbeidsgiverNotifikasjonNarmestelederInput>()) } returns Unit
 
                 val varselHendelse =
                     NarmesteLederHendelse(

--- a/src/test/kotlin/no/nav/syfo/service/OppfolgingsplanVarselServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/service/OppfolgingsplanVarselServiceSpek.kt
@@ -143,7 +143,7 @@ class OppfolgingsplanVarselServiceSpek :
                             ),
                     )
                 coEvery { arbeidsgiverNotifikasjonService.createNewSak(any()) } returns UUID.randomUUID().toString()
-                coEvery { arbeidsgiverNotifikasjonService.sendNotifikasjon(any()) } returns Unit
+                coEvery { arbeidsgiverNotifikasjonService.sendNotifikasjon(any<ArbeidsgiverNotifikasjonInput>()) } returns Unit
 
                 val varselHendelse =
                     NarmesteLederHendelse(

--- a/src/test/kotlin/no/nav/syfo/testutil/mocks/MockServers.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/mocks/MockServers.kt
@@ -60,7 +60,12 @@ class MockServers(
                   "data": {
                     "nyBeskjed": {
                       "__typename": "NyBeskjedVellykket",
-                      "id": "d69f8c4f-8d34-47b0-9539-d3c2e54115da"
+                      "id": "d69f8c4f-8d34-47b0-9539-d3c2e54115da",
+                      "eksterneVarsler": [
+                        {
+                          "id": "d69f8c4f-8d34-47b0-9539-d3c2e54115db"
+                        }
+                      ]
                     }
                   }
                 }
@@ -75,11 +80,25 @@ class MockServers(
                   }
                 }
             """
+            val responseNyOppgaveMedFeil = """
+                {
+                  "data": null,
+                  "errors": [
+                    {
+                      "message": "Simulert feil fra arbeidsgiver notifikasjon API"
+                    }
+                  ]
+                }
+            """
             post("/") {
                 val body = call.receiveText()
                 if (body.contains("OpprettNyOppgave")) {
-                    call.respondText(responseNyOppgave, ContentType.Application.Json)
-                } else if (body.contains("OpprettNyBeskjed")) {
+                    if (body.contains("force-error")) {
+                        call.respondText(responseNyOppgaveMedFeil, ContentType.Application.Json)
+                    } else {
+                        call.respondText(responseNyOppgave, ContentType.Application.Json)
+                    }
+                } else if (body.contains("OpprettNyBeskjed") || body.contains("\"operationName\":\"nyBeskjed\"")) {
                     call.respondText(responseNyBeskjed, ContentType.Application.Json)
                 } else {
                     call.respond(HttpStatusCode.InternalServerError)


### PR DESCRIPTION
## Beskrivelse

Stotter Altinn3-ressurs som mottaker i arbeidsgivernotifikasjon-flyten og refaktorer domenemodellen slik at naermeste leder og Altinn-ressurs har egne mottakertyper.

## Endringer

- `producer/arbeidsgivernotifikasjon/domain`: innforer sealed parent og egne modeller for naermeste leder og Altinn-ressurs, inkludert GraphQL-mapping for mottakere og eksterne varsler
- `ArbeidsgiverNotifikasjonProdusent` og `ArbeidsgiverNotifikasjonService`: bruker den nye modelleringen i opprettelsesflyten og forbedrer feilhandtering for oppgave-respons
- `DialogmoteInnkallingNarmesteLederVarselService`: beregner gyldig hardDeleteDate for referat-varsler
- `src/test/...`: utvider testdekningen for Altinn-ressurs, hardDeleteDate og API-responsfeil

## Issue

Closes #940

Del av epic: navikt/syfo-dokumentporten#163

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
