### PR TITLE
feat(db): lagre hendelse-json for feilede varsler

### DIFF
--- a/src/main/kotlin/no/nav/syfo/db/DatabaseUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/db/DatabaseUtil.kt
@@ -57,4 +57,5 @@ fun ResultSet.toPUtsendtVarselFeilet() =
         isForcedLetter = getBoolean("is_forced_letter"),
         isResendt = getBoolean("is_resendt"),
         resendExhausted = getBoolean("resend_exhausted"),
+        hendelseJson = getString("hendelse_json"),
     )

--- a/src/main/kotlin/no/nav/syfo/db/UtsendtVarselFeiletDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/db/UtsendtVarselFeiletDAO.kt
@@ -101,7 +101,8 @@ fun DatabaseInterface.storeUtsendtVarselFeilet(varsel: PUtsendtVarselFeilet) {
         is_forced_letter,
         is_resendt,
         resendt_tidspunkt,
-        resend_exhausted) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        resend_exhausted,
+        hendelse_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """.trimIndent()
 
     connection.use { connection ->
@@ -122,6 +123,7 @@ fun DatabaseInterface.storeUtsendtVarselFeilet(varsel: PUtsendtVarselFeilet) {
             it.setBoolean(14, varsel.isResendt ?: false)
             it.setTimestamp(15, null)
             it.setBoolean(16, varsel.resendExhausted ?: false)
+            it.setString(17, varsel.hendelseJson)
             it.executeUpdate()
         }
 

--- a/src/main/kotlin/no/nav/syfo/db/domain/PUtsendtVarselFeilet.kt
+++ b/src/main/kotlin/no/nav/syfo/db/domain/PUtsendtVarselFeilet.kt
@@ -20,6 +20,7 @@ data class PUtsendtVarselFeilet(
     val isForcedLetter: Boolean? = false,
     val isResendt: Boolean? = false,
     val resendExhausted: Boolean? = null,
+    val hendelseJson: String? = null,
 )
 
 fun PUtsendtVarselFeilet.toArbeidstakerHendelse(): ArbeidstakerHendelse =

--- a/src/main/resources/db/migration/V42__Add_column_hendelse_json_to_utsendt_varsel_feilet.sql
+++ b/src/main/resources/db/migration/V42__Add_column_hendelse_json_to_utsendt_varsel_feilet.sql
@@ -1,0 +1,2 @@
+ALTER TABLE utsending_varsel_feilet
+    ADD COLUMN if not exists hendelse_json TEXT;

--- a/src/test/kotlin/no/nav/syfo/db/UtsendtVarselFeiletDAOSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/db/UtsendtVarselFeiletDAOSpek.kt
@@ -21,17 +21,22 @@ class UtsendtVarselFeiletDAOSpek :
 
             it("Store ikke-utsendt varsel til NL i database") {
                 val fnr = "12121212121"
-                embeddedDatabase.storeUtsendtVarselFeilet(ikkeUtsendtVarsel(fnr))
+                val hendelseJson = """{"type":"NL_DIALOGMOTE_NYTT_TID_STED","data":{"foo":"bar"}}"""
+                embeddedDatabase.storeUtsendtVarselFeilet(ikkeUtsendtVarsel(fnr, hendelseJson))
                 embeddedDatabase.skalHaLagretIkkeUtsendtVarsel(
                     HendelseType.NL_DIALOGMOTE_NYTT_TID_STED,
                     Kanal.DINE_SYKMELDTE,
                     fnr,
+                    hendelseJson,
                 )
             }
         }
     })
 
-private fun ikkeUtsendtVarsel(fnr: String) =
+private fun ikkeUtsendtVarsel(
+    fnr: String,
+    hendelseJson: String? = null,
+): PUtsendtVarselFeilet =
     PUtsendtVarselFeilet(
         uuid = UUID.randomUUID().toString(),
         uuidEksternReferanse = "00000",
@@ -46,17 +51,19 @@ private fun ikkeUtsendtVarsel(fnr: String) =
         feilmelding = "Achtung!",
         utsendtForsokTidspunkt = LocalDateTime.now(),
         isForcedLetter = false,
+        hendelseJson = hendelseJson,
     )
 
 private fun DatabaseInterface.skalHaLagretIkkeUtsendtVarsel(
     type: HendelseType,
     kanal: Kanal,
     fnr: String,
+    hendelseJson: String?,
 ) = this.should("Skal ha lagret ikke-utsendt varsel av type ${type.name} ") {
     this
         .fetchUtsendtVarselFeiletByFnr(fnr)
         .filter { it.hendelsetypeNavn == type.name }
-        .any { it.kanal.equals(kanal.name) }
+        .any { it.kanal.equals(kanal.name) && it.hendelseJson == hendelseJson }
 }
 
 fun DatabaseInterface.fetchUtsendtVarselFeiletByFnr(fnr: String): List<PUtsendtVarselFeilet> {


### PR DESCRIPTION
## Endringer

Legger til nullable hendelse_json TEXT-kolonne i UTSENDING_VARSEL_FEILET slik at vi kan ta vare på den serialiserte Kafka-hendelsen ved feil, og har all data tilgjengelig ved resend-forsøk.

### Hva er gjort
- Ny Flyway-migrering (V42) som legger til kolonnen
- Oppdatert domain-klasse, DAO (insert) og ResultSet-mapper
- Test som verifiserer round-trip

### Neste steg
- Oppdatere SenderFacade til å faktisk serialisere hendelsen ved feil
- Støtte resend av ArbeidsgiverNotifikasjonTilAltinnRessursHendelse i ResendFailedVarslerJob

Closes #967