### PR TITLE
feat(local): legg til lokal kjøring med kafka og postgres

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -22,7 +22,6 @@ description = "Run check with gradle"
 run = './gradlew ktlintCheck'
 
 [tasks.format]
-
 description = "Run ktlintFormat with gradle"
 run = './gradlew ktlintFormat'
 

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,10 +1,17 @@
+[tools]
+java = { version = "21" }
+
 [tasks.build]
 description = "Run build with gradle"
 run = './gradlew build'
 
 [tasks.start]
-description = "Run app using gradle"
-run = './gradlew run'
+description = "Build and start app locally"
+run = './gradlew shadowJar && KTOR_ENV=${KTOR_ENV:-local} java -jar build/libs/esyfovarsel-1.0-all.jar'
+
+[tasks.start-job]
+description = "Build and run the local job once"
+run = './gradlew shadowJar && JOB=true KTOR_ENV=${KTOR_ENV:-local} java -jar build/libs/esyfovarsel-1.0-all.jar'
 
 [tasks.test]
 description = "Run tests with gradle"
@@ -15,6 +22,7 @@ description = "Run check with gradle"
 run = './gradlew ktlintCheck'
 
 [tasks.format]
+
 description = "Run ktlintFormat with gradle"
 run = './gradlew ktlintFormat'
 
@@ -23,7 +31,7 @@ description = "Run flyway repair using Gradle"
 usage = '''
 flag "--username <username>" help="database username" default="username"
 flag "--password <password>" help="database password" default="password"
-flag "--url <url>" help="database url" default="jdbc:postgresql://localhost:5432/esyfo-narmesteleder_dev"
+flag "--url <url>" help="database url" default="jdbc:postgresql://localhost:5432/esyfovarsel_dev"
 '''
 run = './gradlew --no-configuration-cache -Dflyway.user=${usage_username?} -Dflyway.password=${usage_password?} -Dflyway.url=${usage_url?} flywayRepair'
 
@@ -32,10 +40,30 @@ description = "Run flyway info using gradle"
 usage = '''
 flag "--username <username>" help="database username" default="username"
 flag "--password <password>" help="database password" default="password"
-flag "--url <url>" help="database url" default="jdbc:postgresql://localhost:5432/esyfo-narmesteleder_dev"
+flag "--url <url>" help="database url" default="jdbc:postgresql://localhost:5432/esyfovarsel_dev"
 '''
 run = './gradlew --no-configuration-cache -Dflyway.user=${usage_username?} -Dflyway.password=${usage_password?} -Dflyway.url=${usage_url?} flywayInfo'
 
 [tasks.add-lint-check-as-pre-commit-hook]
 description = "Add ktlint check as pre-commit hook to git"
 run = './gradlew addKtlintCheckGitPreCommitHook'
+
+[tasks.docker-up]
+description = "Spin up dependency services using Docker Compose. Postgres, Kafka etc."
+run = '''
+docker-compose \
+  -f docker-compose.yml \
+  -f docker-compose.kafka.yml \
+  up \
+  db broker kafka-ui \
+  -d
+'''
+
+[tasks.docker-down]
+description = "Tear down dependency services running in Docker Compose."
+run = '''
+docker-compose \
+  -f docker-compose.yml \
+  -f docker-compose.kafka.yml \
+  down
+'''

--- a/.mise.toml
+++ b/.mise.toml
@@ -26,24 +26,6 @@ run = './gradlew ktlintCheck'
 description = "Run ktlintFormat with gradle"
 run = './gradlew ktlintFormat'
 
-[tasks.flyway-repair]
-description = "Run flyway repair using Gradle"
-usage = '''
-flag "--username <username>" help="database username" default="username"
-flag "--password <password>" help="database password" default="password"
-flag "--url <url>" help="database url" default="jdbc:postgresql://localhost:5432/esyfovarsel_dev"
-'''
-run = './gradlew --no-configuration-cache -Dflyway.user=${usage_username?} -Dflyway.password=${usage_password?} -Dflyway.url=${usage_url?} flywayRepair'
-
-[tasks.flyway-info]
-description = "Run flyway info using gradle"
-usage = '''
-flag "--username <username>" help="database username" default="username"
-flag "--password <password>" help="database password" default="password"
-flag "--url <url>" help="database url" default="jdbc:postgresql://localhost:5432/esyfovarsel_dev"
-'''
-run = './gradlew --no-configuration-cache -Dflyway.user=${usage_username?} -Dflyway.password=${usage_password?} -Dflyway.url=${usage_url?} flywayInfo'
-
 [tasks.add-lint-check-as-pre-commit-hook]
 description = "Add ktlint check as pre-commit hook to git"
 run = './gradlew addKtlintCheckGitPreCommitHook'

--- a/README.md
+++ b/README.md
@@ -1,27 +1,73 @@
 # esyfovarsel
-Varsler for eSYFO. Lytter på topic'en `team-esyfo.varselbus` og videresender varsler til
-relevante kanaler (DineSykmeldte, Brukernotifikasjoner og Arbeidsgivernotifikasjoner).
-Bruker også til å planlegge 39-ukers varsel for sykmeldt.
 
-## Technologies used
-* Kotlin
-* Ktor
-* Gradle
-* Kotest
-* Postgres
-* Kafka
+Varsler for eSYFO. Appen lytter på Kafka-topicet `team-esyfo.varselbus` og videresender varsler til relevante kanaler som Dine Sykmeldte, Brukernotifikasjoner og Arbeidsgivernotifikasjoner.
 
-### Building the application
-Run `./gradlew build`    
+## Lokal kjøring
 
-### Running app locally
+Du trenger Java 21, Docker og [mise](https://mise.jdx.dev/).
 
-- Run `docker-compose up` in a terminal at the project root
-- Start BootstrapApplication
+1. Start lokale avhengigheter:
+   ```bash
+   mise run docker-up
+   ```
+   Dette starter Postgres på `localhost:5432`, Kafka på `localhost:9092` og Kafka UI på `http://localhost:9080`.
+2. Start appen:
+   ```bash
+   mise run start
+   ```
+   Appen bruker `KTOR_ENV=local` som standard. Den kobler seg mot databasen `esyfovarsel_dev`, kjører Flyway ved oppstart og lytter på Kafka uten TLS.
+3. Sjekk helse-endepunktene:
+   - `http://localhost:8080/isAlive`
+   - `http://localhost:8080/isReady`
 
-### Running job locally
+Schema Registry finnes i `docker-compose.kafka.yml`, men `mise run docker-up` starter den ikke fordi esyfovarsel ikke bruker den lokalt.
 
-- Run `docker-compose up` in a terminal at the project root
-- Start one instance of BootstrapApplication
-- Start another instance of BootStrapApplication with environment variable `JOB=true`
-- This will run the job once
+## Test av lokal Kafka- og Arbeidsgivernotifikasjon-flyt
+
+Opprett topicet hvis det ikke allerede finnes:
+
+```bash
+docker exec broker kafka-topics --bootstrap-server broker:29092 --create --if-not-exists --topic team-esyfo.varselbus
+```
+
+Send en testmelding som går til den lokale fake-produsenten for Arbeidsgivernotifikasjon:
+
+```bash
+printf 'local-key@@@{"@type":"NarmesteLederHendelse","type":"NL_DIALOGMOTE_MOTEBEHOV_TILBAKEMELDING","ferdigstill":false,"data":{"tilbakemelding":"Lokal test"},"narmesteLederFnr":"00000000000","arbeidstakerFnr":"12345678910","orgnummer":"999999999"}\n' | \
+docker exec -i broker kafka-console-producer --bootstrap-server broker:29092 --topic team-esyfo.varselbus --property parse.key=true --property key.separator='@@@'
+```
+
+Fødselsnumrene i eksempelet over er syntetiske testnumre. Ikke bruk reelle personidenter i lokal testdata eller meldinger.
+
+Den lokale fake-produsenten logger bare tekniske og ikke-sensitive felt. Lokal fake-støtte er tilrettelagt for Arbeidsgivernotifikasjon-flyten. Andre utgående klienter er ikke fullfaket lokalt og peker fortsatt mot lokale eller placeholder-URL-er, så enkelte Kafka-hendelser kan feile hvis de treffer andre kodestier. Du kan også sende meldinger via Kafka UI på `http://localhost:9080`.
+
+## Lokal jobbkjøring
+
+Kjør jobben én gang lokalt:
+
+```bash
+mise run start-job
+```
+
+Dette starter appen med `JOB=true` og leser `src/main/resources/localEnvJob.json`.
+
+`mise run start-job` kaller `http://localhost:8080/job/trigger`, så appen må allerede kjøre lokalt med `mise run start`.
+
+## Nyttige kommandoer
+
+- Bygg og test:
+  ```bash
+  ./gradlew build
+  ```
+- Flyway-info mot lokal database:
+  ```bash
+  mise run flyway-info
+  ```
+- Stopp lokale avhengigheter:
+  ```bash
+  mise run docker-down
+  ```
+
+## For Nav-ansatte
+
+- [#esyfo på Slack](https://nav-it.slack.com/archives/C012X796B4L)

--- a/README.md
+++ b/README.md
@@ -2,67 +2,11 @@
 
 Varsler for eSYFO. Appen lytter på Kafka-topicet `team-esyfo.varselbus` og videresender varsler til relevante kanaler som Dine Sykmeldte, Brukernotifikasjoner og Arbeidsgivernotifikasjoner.
 
-## Lokal kjøring
+## Lokal utvikling
 
-Du trenger Java 21, Docker og [mise](https://mise.jdx.dev/).
+Se [docs/local-development.md](docs/local-development.md) for lokal kjøring, Kafka-test og lokal jobbkjøring.
 
-1. Start lokale avhengigheter:
-   ```bash
-   mise run docker-up
-   ```
-   Dette starter Postgres på `localhost:5432`, Kafka på `localhost:9092` og Kafka UI på `http://localhost:9080`.
-2. Start appen:
-   ```bash
-   mise run start
-   ```
-   Appen bruker `KTOR_ENV=local` som standard. Den kobler seg mot databasen `esyfovarsel_dev`, kjører Flyway ved oppstart og lytter på Kafka uten TLS.
-3. Sjekk helse-endepunktene:
-   - `http://localhost:8080/isAlive`
-   - `http://localhost:8080/isReady`
-
-Schema Registry finnes i `docker-compose.kafka.yml`, men `mise run docker-up` starter den ikke fordi esyfovarsel ikke bruker den lokalt.
-
-## Test av lokal Kafka- og Arbeidsgivernotifikasjon-flyt
-
-Opprett topicet hvis det ikke allerede finnes:
-
-```bash
-docker exec broker kafka-topics --bootstrap-server broker:29092 --create --if-not-exists --topic team-esyfo.varselbus
-```
-
-Send en testmelding som går til den lokale fake-produsenten for Arbeidsgivernotifikasjon:
-
-```bash
-printf 'local-key@@@{"@type":"NarmesteLederHendelse","type":"NL_DIALOGMOTE_MOTEBEHOV_TILBAKEMELDING","ferdigstill":false,"data":{"tilbakemelding":"Lokal test"},"narmesteLederFnr":"00000000000","arbeidstakerFnr":"12345678910","orgnummer":"999999999"}\n' | \
-docker exec -i broker kafka-console-producer --bootstrap-server broker:29092 --topic team-esyfo.varselbus --property parse.key=true --property key.separator='@@@'
-```
-
-Fødselsnumrene i eksempelet over er syntetiske testnumre. Ikke bruk reelle personidenter i lokal testdata eller meldinger.
-
-Den lokale fake-produsenten logger bare tekniske og ikke-sensitive felt. Lokal fake-støtte er tilrettelagt for Arbeidsgivernotifikasjon-flyten. Andre utgående klienter er ikke fullfaket lokalt og peker fortsatt mot lokale eller placeholder-URL-er, så enkelte Kafka-hendelser kan feile hvis de treffer andre kodestier. Du kan også sende meldinger via Kafka UI på `http://localhost:9080`.
-
-## Lokal jobbkjøring
-
-Kjør jobben én gang lokalt:
-
-```bash
-mise run start-job
-```
-
-Dette starter appen med `JOB=true` og leser `src/main/resources/localEnvJob.json`.
-
-`mise run start-job` kaller `http://localhost:8080/job/trigger`, så appen må allerede kjøre lokalt med `mise run start`.
-
-## Nyttige kommandoer
-
-- Bygg og test:
-  ```bash
-  ./gradlew build
-  ```
-- Stopp lokale avhengigheter:
-  ```bash
-  mise run docker-down
-  ```
+Bruk `mise tasks` for å se tilgjengelige kommandoer.
 
 ## For Nav-ansatte
 

--- a/README.md
+++ b/README.md
@@ -59,10 +59,6 @@ Dette starter appen med `JOB=true` og leser `src/main/resources/localEnvJob.json
   ```bash
   ./gradlew build
   ```
-- Flyway-info mot lokal database:
-  ```bash
-  mise run flyway-info
-  ```
 - Stopp lokale avhengigheter:
   ```bash
   mise run docker-down

--- a/docker-compose.kafka.yml
+++ b/docker-compose.kafka.yml
@@ -53,22 +53,6 @@ services:
     volumes:
       - schema-registry-data:/var/lib/confluent-schema-registry
 
-# rest-proxy could be useful, but it is a big image so we can skip itunless/until we find a use for it,
-  rest-proxy:
-    image: confluentinc/cp-kafka-rest:8.0.0
-    depends_on:
-      - broker
-      - schema-registry
-    ports:
-      - 8082:8082
-    hostname: rest-proxy
-    container_name: rest-proxy
-    environment:
-      KAFKA_REST_HOST_NAME: rest-proxy
-      KAFKA_REST_BOOTSTRAP_SERVERS: 'broker:29092'
-      KAFKA_REST_LISTENERS: "http://0.0.0.0:8082"
-      KAFKA_REST_SCHEMA_REGISTRY_URL: 'http://schema-registry:8081'
-
   # Kafka-UI
   kafka-ui:
     image: provectuslabs/kafka-ui:latest

--- a/docker-compose.kafka.yml
+++ b/docker-compose.kafka.yml
@@ -1,0 +1,89 @@
+---
+services:
+
+  broker:
+    image: confluentinc/cp-server:8.0.0
+    hostname: broker
+    container_name: broker
+    ports:
+      - "9092:9092"
+      - "9101:9101"
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: 'CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT'
+      KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://broker:29092,PLAINTEXT_HOST://localhost:9092'
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_CONFLUENT_LICENSE_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_CONFLUENT_BALANCER_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_JMX_PORT: 9101
+      KAFKA_JMX_HOSTNAME: localhost
+      KAFKA_CONFLUENT_SCHEMA_REGISTRY_URL: http://schema-registry:8081
+      KAFKA_METRIC_REPORTERS: io.confluent.metrics.reporter.ConfluentMetricsReporter
+      CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS: broker:29092
+      CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS: 1
+      KAFKA_PROCESS_ROLES: 'broker,controller'
+      KAFKA_CONTROLLER_QUORUM_VOTERS: '1@broker:29093'
+      KAFKA_LISTENERS: 'PLAINTEXT://broker:29092,CONTROLLER://broker:29093,PLAINTEXT_HOST://0.0.0.0:9092'
+      KAFKA_INTER_BROKER_LISTENER_NAME: 'PLAINTEXT'
+      KAFKA_CONTROLLER_LISTENER_NAMES: 'CONTROLLER'
+      CONFLUENT_METRICS_ENABLE: 'true'
+      CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
+      # Replace CLUSTER_ID with a unique base64 UUID using "bin/kafka-storage.sh random-uuid"
+      # See https://docs.confluent.io/kafka/operations-tools/kafka-tools.html#kafka-storage-sh
+      CLUSTER_ID: 'm8EV0f_pTvqrauta90CS2w'
+      KAFKA_LOG_DIRS: '/var/lib/kafka/data'
+    volumes:
+      - kafka-data:/var/lib/kafka/data
+
+  schema-registry:
+    image: confluentinc/cp-schema-registry:8.0.0
+    hostname: schema-registry
+    container_name: schema-registry
+    depends_on:
+      - broker
+    ports:
+      - "8081:8081"
+    environment:
+      SCHEMA_REGISTRY_HOST_NAME: schema-registry
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:29092'
+      SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
+    volumes:
+      - schema-registry-data:/var/lib/confluent-schema-registry
+
+# rest-proxy could be useful, but it is a big image so we can skip itunless/until we find a use for it,
+  rest-proxy:
+    image: confluentinc/cp-kafka-rest:8.0.0
+    depends_on:
+      - broker
+      - schema-registry
+    ports:
+      - 8082:8082
+    hostname: rest-proxy
+    container_name: rest-proxy
+    environment:
+      KAFKA_REST_HOST_NAME: rest-proxy
+      KAFKA_REST_BOOTSTRAP_SERVERS: 'broker:29092'
+      KAFKA_REST_LISTENERS: "http://0.0.0.0:8082"
+      KAFKA_REST_SCHEMA_REGISTRY_URL: 'http://schema-registry:8081'
+
+  # Kafka-UI
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    container_name: kafka-ui
+    ports:
+      - "9080:8080" # Access Kafka-UI on http://localhost:9080
+    environment:
+      KAFKA_CLUSTERS_0_NAME: 'Local Kafka Cluster'
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: 'broker:29092'
+      # --- Schema Registry Integration ---
+      KAFKA_CLUSTERS_0_SCHEMAREGISTRY: 'http://schema-registry:8081'
+    depends_on:
+      - broker
+#      - schema-registry # Ensure Schema Registry is up before Kafka-UI connects to it
+
+volumes:
+  kafka-data:
+  schema-registry-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       POSTGRES_DB: esyfovarsel_dev
     volumes:
       - pgdata:/var/lib/postgresql/data
+      - ./docker-init-scripts:/docker-entrypoint-initdb.d
 
 volumes:
   pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,60 +1,16 @@
-version: '3'
 services:
+
   db:
-    image: postgres:17
+    image: postgres:18.3-alpine3.23
     ports:
       - "5432:5432"
+    restart: always
     environment:
-      - POSTGRES_DB=esyfovarsel
-      - POSTGRES_USER=esyfovarsel-admin
-      - POSTGRES_PASSWORD=password
-  zookeeper:
-    image: confluentinc/cp-zookeeper:6.2.0
-    hostname: zookeeper
-    container_name: zookeeper
-    ports:
-      - "2181:2181"
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
-  broker:
-    image: confluentinc/cp-server:6.2.0
-    hostname: broker
-    container_name: broker
-    depends_on:
-      - zookeeper
-    ports:
-      - "9092:9092"
-      - "9101:9101"
-    environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:29092,PLAINTEXT_HOST://localhost:9092
-      KAFKA_METRIC_REPORTERS: io.confluent.metrics.reporter.ConfluentMetricsReporter
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_CONFLUENT_LICENSE_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_CONFLUENT_BALANCER_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
-      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
-      KAFKA_JMX_PORT: 9101
-      KAFKA_JMX_HOSTNAME: localhost
-      KAFKA_CONFLUENT_SCHEMA_REGISTRY_URL: http://schema-registry:8081
-      CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS: broker:29092
-      CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS: 1
-      CONFLUENT_METRICS_ENABLE: 'true'
-      CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
+      POSTGRES_PASSWORD: password
+      POSTGRES_USER: username
+      POSTGRES_DB: esyfovarsel_dev
+    volumes:
+      - pgdata:/var/lib/postgresql/data
 
-  schema-registry:
-    image: confluentinc/cp-schema-registry:6.2.0
-    hostname: schema-registry
-    container_name: schema-registry
-    depends_on:
-      - broker
-    ports:
-      - "8081:8081"
-    environment:
-      SCHEMA_REGISTRY_HOST_NAME: schema-registry
-      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:29092'
-      SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
+volumes:
+  pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
 
   db:
-    image: postgres:18.3-alpine3.23
+    image: postgres:17-alpine3.23
     ports:
       - "5432:5432"
     restart: always

--- a/docker-init-scripts/01-create-role.sql
+++ b/docker-init-scripts/01-create-role.sql
@@ -1,0 +1,8 @@
+-- Create the cloudsqliamuser role if it doesn't exist
+DO $$
+    BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cloudsqliamuser') THEN
+            CREATE ROLE cloudsqliamuser WITH LOGIN;
+        END IF;
+    END
+$$;

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,0 +1,82 @@
+# Lokal utvikling
+
+## Krav
+
+Du trenger Java 21, Docker og [mise](https://mise.jdx.dev/).
+
+## Start lokale avhengigheter
+
+```bash
+mise run docker-up
+```
+
+Dette starter Postgres på `localhost:5432`, Kafka på `localhost:9092` og Kafka UI på `http://localhost:9080`.
+
+Schema Registry finnes i `docker-compose.kafka.yml`, men `mise run docker-up` starter den ikke fordi esyfovarsel ikke bruker den lokalt.
+
+## Start appen
+
+```bash
+mise run start
+```
+
+Appen bruker `KTOR_ENV=local` som standard. Den kobler seg mot databasen `esyfovarsel_dev`, kjører Flyway ved oppstart og lytter på Kafka uten TLS.
+
+Sjekk helse-endepunktene:
+
+- `http://localhost:8080/isAlive`
+- `http://localhost:8080/isReady`
+
+## Test lokal Kafka- og Arbeidsgivernotifikasjon-flyt
+
+Opprett topicet hvis det ikke allerede finnes (Det opprettes dersom man starter app):
+
+```bash
+docker exec broker kafka-topics --bootstrap-server broker:29092 --create --if-not-exists --topic team-esyfo.varselbus
+```
+
+Publiser en testmelding til lokal Kafka:
+
+```bash
+bash scripts/publish-varselbus-message.sh scripts/messages/narmeste-leder-dialogmote-motebehov-tilbakemelding.json
+```
+
+Scriptet bruker disse standardverdiene lokalt:
+
+- broker-container: `broker`
+- bootstrap-server: `broker:29092`
+- topic: `team-esyfo.varselbus`
+- key: `local-key`
+- key separator: `@@@`
+
+Du kan overstyre med miljøvariabler eller argument:
+
+```bash
+KAFKA_MESSAGE_KEY=test-key bash scripts/publish-varselbus-message.sh \
+  scripts/messages/narmeste-leder-dialogmote-motebehov-tilbakemelding.json
+```
+
+```bash
+bash scripts/publish-varselbus-message.sh \
+  scripts/messages/narmeste-leder-dialogmote-motebehov-tilbakemelding.json \
+  annen-key \
+  annet-topic
+```
+
+Fødselsnumrene i eksempelfilen er syntetiske testnumre. Ikke bruk reelle personidenter i lokal testdata eller meldinger.
+
+Den lokale fake-produsenten logger bare tekniske og ikke-sensitive felt. Lokal fake-støtte er tilrettelagt for Arbeidsgivernotifikasjon-flyten. Andre utgående klienter er ikke fullfaket lokalt og peker fortsatt mot lokale eller placeholder-URL-er, så enkelte Kafka-hendelser kan feile hvis de treffer andre kodestier.
+
+Du kan også sende meldinger via Kafka UI på `http://localhost:9080`.
+
+## Lokal jobbkjøring
+
+Kjør jobben én gang lokalt:
+
+```bash
+mise run start-job
+```
+
+Dette starter appen med `JOB=true` og leser `src/main/resources/localEnvJob.json`.
+
+`mise run start-job` kaller `http://localhost:8080/job/trigger`, så appen må allerede kjøre lokalt med `mise run start`.

--- a/scripts/messages/narmeste-leder-dialogmote-motebehov-tilbakemelding.json
+++ b/scripts/messages/narmeste-leder-dialogmote-motebehov-tilbakemelding.json
@@ -1,0 +1,11 @@
+{
+  "@type": "NarmesteLederHendelse",
+  "type": "NL_DIALOGMOTE_MOTEBEHOV_TILBAKEMELDING",
+  "ferdigstill": false,
+  "data": {
+    "tilbakemelding": "Lokal test"
+  },
+  "narmesteLederFnr": "00000000000",
+  "arbeidstakerFnr": "12345678910",
+  "orgnummer": "999999999"
+}

--- a/scripts/publish-varselbus-message.sh
+++ b/scripts/publish-varselbus-message.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly json_file="${1:-}"
+readonly message_key="${2:-${KAFKA_MESSAGE_KEY:-local-key}}"
+readonly topic="${3:-${KAFKA_TOPIC:-team-esyfo.varselbus}}"
+readonly docker_container="${KAFKA_DOCKER_CONTAINER:-broker}"
+readonly bootstrap_server="${KAFKA_BOOTSTRAP_SERVER:-broker:29092}"
+readonly key_separator="${KAFKA_KEY_SEPARATOR:-@@@}"
+
+usage() {
+  echo "Bruk: $0 <path-til-json-fil> [message-key] [topic]" >&2
+  echo "Overstyr ved behov med KAFKA_DOCKER_CONTAINER, KAFKA_BOOTSTRAP_SERVER, KAFKA_TOPIC, KAFKA_MESSAGE_KEY eller KAFKA_KEY_SEPARATOR." >&2
+}
+
+if [[ -z "$json_file" ]]; then
+  echo "Mangler path til JSON-fil." >&2
+  usage
+  exit 1
+fi
+
+if [[ ! -f "$json_file" ]]; then
+  echo "Fant ikke JSON-fil: $json_file" >&2
+  exit 1
+fi
+
+if [[ ! -s "$json_file" ]]; then
+  echo "JSON-filen er tom: $json_file" >&2
+  exit 1
+fi
+
+json_payload="$(tr -d '\r\n' < "$json_file")"
+
+printf '%s%s%s\n' "$message_key" "$key_separator" "$json_payload" | \
+  docker exec -i "$docker_container" kafka-console-producer \
+    --bootstrap-server "$bootstrap_server" \
+    --topic "$topic" \
+    --property parse.key=true \
+    --property "key.separator=$key_separator"

--- a/src/main/kotlin/no/nav/syfo/BootstrapApplication.kt
+++ b/src/main/kotlin/no/nav/syfo/BootstrapApplication.kt
@@ -130,7 +130,7 @@ fun setModule(env: Environment): Application.() -> Unit =
             } else {
                 AzureAdTokenConsumer(env.authEnv)
             }
-        val dkifConsumer = getDkifConsumer(env.urlEnv, tokenConsumer)
+        val dkifConsumer = DkifConsumer(env.urlEnv, tokenConsumer)
         val sykmeldingerConsumer = SykmeldingerConsumer(env.urlEnv, tokenConsumer)
         val narmesteLederConsumer: INarmesteLederConsumer =
             if (isLocal()) {
@@ -293,11 +293,6 @@ fun setModule(env: Environment): Application.() -> Unit =
             testdataResetService,
         )
     }
-
-private fun getDkifConsumer(
-    urlEnv: UrlEnv,
-    azureADConsumer: ITokenConsumer,
-): DkifConsumer = DkifConsumer(urlEnv, azureADConsumer)
 
 fun Application.serverModule(
     env: Environment,

--- a/src/main/kotlin/no/nav/syfo/BootstrapApplication.kt
+++ b/src/main/kotlin/no/nav/syfo/BootstrapApplication.kt
@@ -364,7 +364,7 @@ fun Application.kafkaModule(
         )
     }
 
-    if (env.appEnv.remote && env.isDevGcp()) {
+    if (env.isDevGcp()) {
         launch(backgroundTasksContext) {
             launchKafkaListener(
                 state,

--- a/src/main/kotlin/no/nav/syfo/BootstrapApplication.kt
+++ b/src/main/kotlin/no/nav/syfo/BootstrapApplication.kt
@@ -21,10 +21,14 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import no.nav.syfo.api.registerNaisApi
 import no.nav.syfo.auth.AzureAdTokenConsumer
+import no.nav.syfo.auth.FakeTokenConsumer
+import no.nav.syfo.auth.ITokenConsumer
 import no.nav.syfo.auth.setupLocalRoutesWithAuthentication
 import no.nav.syfo.auth.setupRoutesWithAuthentication
 import no.nav.syfo.consumer.distribuerjournalpost.JournalpostdistribusjonConsumer
 import no.nav.syfo.consumer.dkif.DkifConsumer
+import no.nav.syfo.consumer.narmesteLeder.FakeNarmesteLederConsumer
+import no.nav.syfo.consumer.narmesteLeder.INarmesteLederConsumer
 import no.nav.syfo.consumer.narmesteLeder.NarmesteLederConsumer
 import no.nav.syfo.consumer.narmesteLeder.NarmesteLederService
 import no.nav.syfo.consumer.pdl.PdlClient
@@ -44,6 +48,8 @@ import no.nav.syfo.kafka.producers.dittsykefravaer.DittSykefravaerMeldingKafkaPr
 import no.nav.syfo.kafka.producers.minesidemicrofrontend.MinSideMicrofrontendKafkaProducer
 import no.nav.syfo.metrics.registerPrometheusApi
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.ArbeidsgiverNotifikasjonProdusent
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.FakeArbeidsgiverNotifikasjonProdusent
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.IArbeidsgiverNotifikasjonProdusent
 import no.nav.syfo.service.AccessControlService
 import no.nav.syfo.service.AktivitetspliktForhandsvarselService
 import no.nav.syfo.service.ArbeidsgiverNotifikasjonService
@@ -112,27 +118,43 @@ fun createApplicationEnvironment(env: Environment): ApplicationEnvironment =
     applicationEnvironment {
         config = HoconApplicationConfig(ConfigFactory.load())
         database = Database(env.dbEnv)
-        database.grantAccessToIAMUsers()
+        if (env.appEnv.remote) {
+            database.grantAccessToIAMUsers()
+        }
     }
 
 @Suppress("LongMethod")
 fun setModule(env: Environment): Application.() -> Unit =
     {
-        val azureAdTokenConsumer = AzureAdTokenConsumer(env.authEnv)
-        val dkifConsumer = getDkifConsumer(env.urlEnv, azureAdTokenConsumer)
-        val sykmeldingerConsumer = SykmeldingerConsumer(env.urlEnv, azureAdTokenConsumer)
-        val narmesteLederConsumer = NarmesteLederConsumer(env.urlEnv, azureAdTokenConsumer)
+        val tokenConsumer: ITokenConsumer =
+            if (isLocal()) {
+                FakeTokenConsumer()
+            } else {
+                AzureAdTokenConsumer(env.authEnv)
+            }
+        val dkifConsumer = getDkifConsumer(env.urlEnv, tokenConsumer)
+        val sykmeldingerConsumer = SykmeldingerConsumer(env.urlEnv, tokenConsumer)
+        val narmesteLederConsumer: INarmesteLederConsumer =
+            if (isLocal()) {
+                FakeNarmesteLederConsumer()
+            } else {
+                NarmesteLederConsumer(env.urlEnv, tokenConsumer)
+            }
         val narmesteLederService = NarmesteLederService(narmesteLederConsumer)
-        val arbeidsgiverNotifikasjonProdusent =
-            ArbeidsgiverNotifikasjonProdusent(env.urlEnv, azureAdTokenConsumer)
+        val arbeidsgiverNotifikasjonProdusent: IArbeidsgiverNotifikasjonProdusent =
+            if (isLocal()) {
+                FakeArbeidsgiverNotifikasjonProdusent()
+            } else {
+                ArbeidsgiverNotifikasjonProdusent(env.urlEnv, tokenConsumer)
+            }
         val arbeidsgiverNotifikasjonService =
             ArbeidsgiverNotifikasjonService(
                 arbeidsgiverNotifikasjonProdusent,
                 narmesteLederService,
                 env.urlEnv.baseUrlDineSykmeldte,
             )
-        val pdlClient = PdlClient(env.urlEnv, azureAdTokenConsumer)
-        val journalpostdistribusjonConsumer = JournalpostdistribusjonConsumer(env.urlEnv, azureAdTokenConsumer)
+        val pdlClient = PdlClient(env.urlEnv, tokenConsumer)
+        val journalpostdistribusjonConsumer = JournalpostdistribusjonConsumer(env.urlEnv, tokenConsumer)
 
         val brukernotifikasjonKafkaProducer = BrukernotifikasjonKafkaProducer(env)
         val dineSykmeldteHendelseKafkaProducer = DineSykmeldteHendelseKafkaProducer(env)
@@ -276,12 +298,8 @@ fun setModule(env: Environment): Application.() -> Unit =
 
 private fun getDkifConsumer(
     urlEnv: UrlEnv,
-    azureADConsumer: AzureAdTokenConsumer,
-): DkifConsumer =
-    when {
-        isLocal() -> DkifConsumer(urlEnv, azureADConsumer)
-        else -> DkifConsumer(urlEnv, azureADConsumer)
-    }
+    azureADConsumer: ITokenConsumer,
+): DkifConsumer = DkifConsumer(urlEnv, azureADConsumer)
 
 fun Application.serverModule(
     env: Environment,
@@ -298,13 +316,15 @@ fun Application.serverModule(
         }
     }
 
-    val electionJobList = emptyList<RunOnElection>()
-    val leaderElection = LeaderElection(electionJobList)
+    if (env.appEnv.remote) {
+        val electionJobList = emptyList<RunOnElection>()
+        val leaderElection = LeaderElection(electionJobList)
 
-    launch(backgroundTasksContext) {
-        while (state.running) {
-            delay(300000)
-            leaderElection.checkIfPodIsLeader()
+        launch(backgroundTasksContext) {
+            while (state.running) {
+                delay(300000)
+                leaderElection.checkIfPodIsLeader()
+            }
         }
     }
 
@@ -339,21 +359,19 @@ fun Application.kafkaModule(
     varselbusService: VarselBusService,
     testdataResetService: TestdataResetService,
 ) {
-    runningRemotely {
+    launch(backgroundTasksContext) {
+        launchKafkaListener(
+            state,
+            VarselBusKafkaConsumer(env, varselbusService),
+        )
+    }
+
+    if (env.appEnv.remote && env.isDevGcp()) {
         launch(backgroundTasksContext) {
             launchKafkaListener(
                 state,
-                VarselBusKafkaConsumer(env, varselbusService),
+                TestdataResetConsumer(env, testdataResetService),
             )
-        }
-
-        if (env.isDevGcp()) {
-            launch(backgroundTasksContext) {
-                launchKafkaListener(
-                    state,
-                    TestdataResetConsumer(env, testdataResetService),
-                )
-            }
         }
     }
 }

--- a/src/main/kotlin/no/nav/syfo/BootstrapApplication.kt
+++ b/src/main/kotlin/no/nav/syfo/BootstrapApplication.kt
@@ -118,9 +118,7 @@ fun createApplicationEnvironment(env: Environment): ApplicationEnvironment =
     applicationEnvironment {
         config = HoconApplicationConfig(ConfigFactory.load())
         database = Database(env.dbEnv)
-        if (env.appEnv.remote) {
-            database.grantAccessToIAMUsers()
-        }
+        database.grantAccessToIAMUsers()
     }
 
 @Suppress("LongMethod")

--- a/src/main/kotlin/no/nav/syfo/auth/AzureAdTokenConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/auth/AzureAdTokenConsumer.kt
@@ -30,7 +30,7 @@ import java.time.Instant
 
 class AzureAdTokenConsumer(
     authEnv: AuthEnv,
-) {
+) : ITokenConsumer {
     private val aadAccessTokenUrl = authEnv.aadAccessTokenUrl
     private val clientId = authEnv.clientId
     private val clientSecret = authEnv.clientSecret
@@ -67,13 +67,13 @@ class AzureAdTokenConsumer(
     @Volatile
     private var tokenMap = HashMap<String, AzureAdAccessToken>()
 
-    suspend fun getToken(resource: String): String {
+    override suspend fun getToken(scope: String): String {
         val omToMinutter = Instant.now().plusSeconds(120L)
 
-        val token: AzureAdAccessToken? = tokenMap.get(resource)
+        val token: AzureAdAccessToken? = tokenMap.get(scope)
 
         if (token == null || token.issuedOn!!.plusSeconds(token.expires_in).isBefore(omToMinutter)) {
-            log.info("Henter nytt token fra Azure AD for scope : $resource")
+            log.info("Henter nytt token fra Azure AD for scope : $scope")
 
             val response =
                 httpClientWithProxy.post(aadAccessTokenUrl) {
@@ -83,7 +83,7 @@ class AzureAdTokenConsumer(
                         FormDataContent(
                             Parameters.build {
                                 append("client_id", clientId)
-                                append("scope", resource)
+                                append("scope", scope)
                                 append("grant_type", "client_credentials")
                                 append("client_secret", clientSecret)
                             },
@@ -91,19 +91,19 @@ class AzureAdTokenConsumer(
                     )
                 }
             if (response.status == HttpStatusCode.OK) {
-                tokenMap[resource] = response.body()
+                tokenMap[scope] = response.body()
             } else {
                 log.error("Could not get token from Azure AD: $response")
             }
         }
-        return tokenMap[resource]!!.access_token
+        return tokenMap[scope]!!.access_token
     }
 
-    suspend fun getOnBehalfOfToken(
-        resource: String,
+    override suspend fun getOnBehalfOfToken(
+        scope: String,
         token: String,
     ): String? {
-        log.info("Henter nytt obo-token fra Azure AD for scope : $resource")
+        log.info("Henter nytt obo-token fra Azure AD for scope : $scope")
 
         val response =
             httpClientWithProxy.post(aadAccessTokenUrl) {
@@ -113,7 +113,7 @@ class AzureAdTokenConsumer(
                     FormDataContent(
                         Parameters.build {
                             append("client_id", clientId)
-                            append("scope", resource)
+                            append("scope", scope)
                             append("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer")
                             append("client_secret", clientSecret)
                             append("assertion", token)

--- a/src/main/kotlin/no/nav/syfo/auth/FakeTokenConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/auth/FakeTokenConsumer.kt
@@ -1,0 +1,14 @@
+package no.nav.syfo.auth
+
+class FakeTokenConsumer : ITokenConsumer {
+    override suspend fun getToken(scope: String): String = LOCAL_DUMMY_TOKEN
+
+    override suspend fun getOnBehalfOfToken(
+        scope: String,
+        token: String,
+    ): String = LOCAL_DUMMY_TOKEN
+
+    companion object {
+        private const val LOCAL_DUMMY_TOKEN = "local-dummy-token"
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/auth/ITokenConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/auth/ITokenConsumer.kt
@@ -1,0 +1,10 @@
+package no.nav.syfo.auth
+
+interface ITokenConsumer {
+    suspend fun getToken(scope: String): String
+
+    suspend fun getOnBehalfOfToken(
+        scope: String,
+        token: String,
+    ): String?
+}

--- a/src/main/kotlin/no/nav/syfo/consumer/distribuerjournalpost/JournalpostdistribusjonConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/consumer/distribuerjournalpost/JournalpostdistribusjonConsumer.kt
@@ -9,7 +9,7 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.append
 import no.nav.syfo.UrlEnv
-import no.nav.syfo.auth.AzureAdTokenConsumer
+import no.nav.syfo.auth.ITokenConsumer
 import no.nav.syfo.exceptions.JournalpostDistribusjonException
 import no.nav.syfo.exceptions.JournalpostDistribusjonGoneException
 import no.nav.syfo.exceptions.JournalpostNetworkException
@@ -19,7 +19,7 @@ import java.io.IOException
 
 class JournalpostdistribusjonConsumer(
     urlEnv: UrlEnv,
-    private val azureAdTokenConsumer: AzureAdTokenConsumer,
+    private val azureAdTokenConsumer: ITokenConsumer,
 ) {
     private val client = httpClientWithRetry(expectSuccess = false)
     private val dokdistfordelingUrl = urlEnv.dokdistfordelingUrl

--- a/src/main/kotlin/no/nav/syfo/consumer/dkif/DkifConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/consumer/dkif/DkifConsumer.kt
@@ -10,7 +10,7 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.append
 import no.nav.syfo.UrlEnv
-import no.nav.syfo.auth.AzureAdTokenConsumer
+import no.nav.syfo.auth.ITokenConsumer
 import no.nav.syfo.utils.NAV_CALL_ID_HEADER
 import no.nav.syfo.utils.createCallId
 import no.nav.syfo.utils.httpClient
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory
 
 class DkifConsumer(
     private val urlEnv: UrlEnv,
-    private val azureAdTokenConsumer: AzureAdTokenConsumer,
+    private val azureAdTokenConsumer: ITokenConsumer,
 ) {
     private val client = httpClient()
 

--- a/src/main/kotlin/no/nav/syfo/consumer/narmesteLeder/FakeNarmesteLederConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/consumer/narmesteLeder/FakeNarmesteLederConsumer.kt
@@ -9,9 +9,9 @@ class FakeNarmesteLederConsumer : INarmesteLederConsumer {
             narmesteLederRelasjon =
                 NarmesteLederRelasjon(
                     narmesteLederId = "local-narmeste-leder",
-                    fnr = LOCAL_SYNTHETIC_FNR,
+                    fnr = ansattFnr,
                     orgnummer = orgnummer,
-                    narmesteLederFnr = LOCAL_SYNTHETIC_FNR,
+                    narmesteLederFnr = ansattFnr.reversed(),
                     narmesteLederTelefonnummer = "00000000",
                     narmesteLederEpost = "narmeste.leder@example.invalid",
                     arbeidsgiverForskutterer = true,
@@ -20,8 +20,4 @@ class FakeNarmesteLederConsumer : INarmesteLederConsumer {
                     navn = "Lokal Nærmeste Leder",
                 ),
         )
-
-    companion object {
-        const val LOCAL_SYNTHETIC_FNR = "00000000000"
-    }
 }

--- a/src/main/kotlin/no/nav/syfo/consumer/narmesteLeder/FakeNarmesteLederConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/consumer/narmesteLeder/FakeNarmesteLederConsumer.kt
@@ -1,0 +1,27 @@
+package no.nav.syfo.consumer.narmesteLeder
+
+class FakeNarmesteLederConsumer : INarmesteLederConsumer {
+    override suspend fun getNarmesteLeder(
+        ansattFnr: String,
+        orgnummer: String,
+    ): NarmestelederResponse =
+        NarmestelederResponse(
+            narmesteLederRelasjon =
+                NarmesteLederRelasjon(
+                    narmesteLederId = "local-narmeste-leder",
+                    fnr = LOCAL_SYNTHETIC_FNR,
+                    orgnummer = orgnummer,
+                    narmesteLederFnr = LOCAL_SYNTHETIC_FNR,
+                    narmesteLederTelefonnummer = "00000000",
+                    narmesteLederEpost = "narmeste.leder@example.invalid",
+                    arbeidsgiverForskutterer = true,
+                    skrivetilgang = true,
+                    tilganger = Tilgang.entries.toList(),
+                    navn = "Lokal Nærmeste Leder",
+                ),
+        )
+
+    companion object {
+        const val LOCAL_SYNTHETIC_FNR = "00000000000"
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/consumer/narmesteLeder/INarmesteLederConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/consumer/narmesteLeder/INarmesteLederConsumer.kt
@@ -1,0 +1,8 @@
+package no.nav.syfo.consumer.narmesteLeder
+
+interface INarmesteLederConsumer {
+    suspend fun getNarmesteLeder(
+        ansattFnr: String,
+        orgnummer: String,
+    ): NarmestelederResponse?
+}

--- a/src/main/kotlin/no/nav/syfo/consumer/narmesteLeder/NarmesteLederConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/consumer/narmesteLeder/NarmesteLederConsumer.kt
@@ -8,20 +8,20 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.append
 import no.nav.syfo.UrlEnv
-import no.nav.syfo.auth.AzureAdTokenConsumer
+import no.nav.syfo.auth.ITokenConsumer
 import no.nav.syfo.utils.httpClient
 import org.slf4j.LoggerFactory
 
 class NarmesteLederConsumer(
     urlEnv: UrlEnv,
-    private val azureAdTokenConsumer: AzureAdTokenConsumer,
-) {
+    private val azureAdTokenConsumer: ITokenConsumer,
+) : INarmesteLederConsumer {
     private val client = httpClient()
     private val basepath = urlEnv.narmestelederUrl
     private val log = LoggerFactory.getLogger(NarmesteLederConsumer::class.qualifiedName)
     private val scope = urlEnv.narmestelederScope
 
-    suspend fun getNarmesteLeder(
+    override suspend fun getNarmesteLeder(
         ansattFnr: String,
         orgnummer: String,
     ): NarmestelederResponse? {

--- a/src/main/kotlin/no/nav/syfo/consumer/narmesteLeder/NarmesteLederService.kt
+++ b/src/main/kotlin/no/nav/syfo/consumer/narmesteLeder/NarmesteLederService.kt
@@ -1,7 +1,7 @@
 package no.nav.syfo.consumer.narmesteLeder
 
 class NarmesteLederService(
-    val narmesteLederConsumer: NarmesteLederConsumer,
+    val narmesteLederConsumer: INarmesteLederConsumer,
 ) {
     suspend fun getNarmesteLederRelasjon(
         fnr: String,

--- a/src/main/kotlin/no/nav/syfo/consumer/pdl/PdlClient.kt
+++ b/src/main/kotlin/no/nav/syfo/consumer/pdl/PdlClient.kt
@@ -9,7 +9,7 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import no.nav.syfo.UrlEnv
-import no.nav.syfo.auth.AzureAdTokenConsumer
+import no.nav.syfo.auth.ITokenConsumer
 import no.nav.syfo.metrics.COUNT_CALL_PDL_FAIL
 import no.nav.syfo.metrics.COUNT_CALL_PDL_SUCCESS
 import no.nav.syfo.utils.httpClientWithRetry
@@ -18,7 +18,7 @@ import java.io.FileNotFoundException
 
 open class PdlClient(
     private val urlEnv: UrlEnv,
-    private val azureAdTokenConsumer: AzureAdTokenConsumer,
+    private val azureAdTokenConsumer: ITokenConsumer,
 ) {
     private val httpClient = httpClientWithRetry(expectSuccess = true)
     private val log = LoggerFactory.getLogger(PdlClient::class.qualifiedName)

--- a/src/main/kotlin/no/nav/syfo/consumer/syfosmregister/SykmeldingerConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/consumer/syfosmregister/SykmeldingerConsumer.kt
@@ -12,14 +12,14 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import no.nav.syfo.UrlEnv
-import no.nav.syfo.auth.AzureAdTokenConsumer
+import no.nav.syfo.auth.ITokenConsumer
 import no.nav.syfo.utils.httpClient
 import org.slf4j.LoggerFactory
 import java.time.LocalDate
 
 class SykmeldingerConsumer(
     urlEnv: UrlEnv,
-    private val azureAdTokenConsumer: AzureAdTokenConsumer,
+    private val azureAdTokenConsumer: ITokenConsumer,
 ) {
     private val client = httpClient()
     private val basepath = urlEnv.syfosmregisterUrl

--- a/src/main/kotlin/no/nav/syfo/consumer/veiledertilgang/VeilederTilgangskontrollConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/consumer/veiledertilgang/VeilederTilgangskontrollConsumer.kt
@@ -8,7 +8,7 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import no.nav.syfo.UrlEnv
-import no.nav.syfo.auth.AzureAdTokenConsumer
+import no.nav.syfo.auth.ITokenConsumer
 import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.utils.NAV_CALL_ID_HEADER
 import no.nav.syfo.utils.NAV_PERSONIDENT_HEADER
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory
 
 class VeilederTilgangskontrollConsumer(
     urlEnv: UrlEnv,
-    private val azureAdTokenConsumer: AzureAdTokenConsumer,
+    private val azureAdTokenConsumer: ITokenConsumer,
 ) {
     private val client = httpClient()
     private val basepath = urlEnv.istilgangskontrollUrl
@@ -34,7 +34,7 @@ class VeilederTilgangskontrollConsumer(
         try {
             val onBehalfOfToken =
                 azureAdTokenConsumer.getOnBehalfOfToken(
-                    resource = scope,
+                    scope = scope,
                     token = token,
                 ) ?: throw RuntimeException("Failed to request access to Person: Failed to get OBO token")
 

--- a/src/main/kotlin/no/nav/syfo/kafka/common/KafkaCommon.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/common/KafkaCommon.kt
@@ -47,18 +47,17 @@ interface KafkaListener {
 
 fun commonProperties(env: Environment): Properties =
     Properties().apply {
-        put(SECURITY_PROTOCOL_CONFIG, SSL)
         put(BOOTSTRAP_SERVERS_CONFIG, env.kafkaEnv.aivenBroker)
-        put(SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "") // Disable server host name verification
-        put(SSL_TRUSTSTORE_TYPE_CONFIG, JAVA_KEYSTORE)
-        put(SSL_KEYSTORE_TYPE_CONFIG, PKCS12)
-        put(SSL_TRUSTSTORE_LOCATION_CONFIG, env.kafkaEnv.sslConfig.truststoreLocation)
-        put(SSL_TRUSTSTORE_PASSWORD_CONFIG, env.kafkaEnv.sslConfig.credstorePassword)
-        put(SSL_KEYSTORE_LOCATION_CONFIG, env.kafkaEnv.sslConfig.keystoreLocation)
-        put(SSL_KEYSTORE_PASSWORD_CONFIG, env.kafkaEnv.sslConfig.credstorePassword)
-        put(SSL_KEY_PASSWORD_CONFIG, env.kafkaEnv.sslConfig.credstorePassword)
-        if (!env.appEnv.remote) {
-            remove(SECURITY_PROTOCOL_CONFIG)
+        if (env.appEnv.remote) {
+            put(SECURITY_PROTOCOL_CONFIG, SSL)
+            put(SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "") // Disable server host name verification
+            put(SSL_TRUSTSTORE_TYPE_CONFIG, JAVA_KEYSTORE)
+            put(SSL_KEYSTORE_TYPE_CONFIG, PKCS12)
+            put(SSL_TRUSTSTORE_LOCATION_CONFIG, env.kafkaEnv.sslConfig.truststoreLocation)
+            put(SSL_TRUSTSTORE_PASSWORD_CONFIG, env.kafkaEnv.sslConfig.credstorePassword)
+            put(SSL_KEYSTORE_LOCATION_CONFIG, env.kafkaEnv.sslConfig.keystoreLocation)
+            put(SSL_KEYSTORE_PASSWORD_CONFIG, env.kafkaEnv.sslConfig.credstorePassword)
+            put(SSL_KEY_PASSWORD_CONFIG, env.kafkaEnv.sslConfig.credstorePassword)
         }
     }
 

--- a/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonProdusent.kt
+++ b/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonProdusent.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.withContext
 import no.nav.syfo.UrlEnv
-import no.nav.syfo.auth.AzureAdTokenConsumer
+import no.nav.syfo.auth.ITokenConsumer
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.ArbeidsgiverDeleteNotifikasjon
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.ArbeidsgiverNotifikasjon
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NyKalenderInput
@@ -40,10 +40,10 @@ import no.nav.syfo.producer.arbeidsgivernotifikasjon.response.nyoppgave.Nyoppgav
 import no.nav.syfo.utils.httpClientWithRetry
 import org.slf4j.LoggerFactory
 
-open class ArbeidsgiverNotifikasjonProdusent(
+class ArbeidsgiverNotifikasjonProdusent(
     urlEnv: UrlEnv,
-    private val azureAdTokenConsumer: AzureAdTokenConsumer,
-) {
+    private val azureAdTokenConsumer: ITokenConsumer,
+) : IArbeidsgiverNotifikasjonProdusent {
     private val httpClientWithRetry = httpClientWithRetry()
     private val arbeidsgiverNotifikasjonProdusentBasepath = urlEnv.arbeidsgiverNotifikasjonProdusentApiUrl
     private val log = LoggerFactory.getLogger(ArbeidsgiverNotifikasjonProdusent::class.qualifiedName)
@@ -55,7 +55,7 @@ open class ArbeidsgiverNotifikasjonProdusent(
             .addInterceptor(BearerTokenInterceptor { azureAdTokenConsumer.getToken(scope) })
             .build()
 
-    suspend fun createNewOppgaveForArbeidsgiver(arbeidsgiverNotifikasjon: ArbeidsgiverNotifikasjon): String? {
+    override suspend fun createNewOppgaveForArbeidsgiver(arbeidsgiverNotifikasjon: ArbeidsgiverNotifikasjon): String? {
         log.info(
             "About to send new task with uuid ${arbeidsgiverNotifikasjon.varselId} to ag-notifikasjon-produsent-api",
         )
@@ -82,7 +82,7 @@ open class ArbeidsgiverNotifikasjonProdusent(
         }
     }
 
-    suspend fun createNewBeskjedForArbeidsgiver(arbeidsgiverNotifikasjonInput: ArbeidsgiverNotifikasjon): String? {
+    override suspend fun createNewBeskjedForArbeidsgiver(arbeidsgiverNotifikasjonInput: ArbeidsgiverNotifikasjon): String? {
         log.info("About to send new beskjed to ag-notifikasjon-produsent-api")
         val response: ApolloResponse<NyBeskjedMutation.Data> =
             apolloClient.mutation(arbeidsgiverNotifikasjonInput.toNyBeskjedMutation()).execute()
@@ -118,7 +118,7 @@ open class ArbeidsgiverNotifikasjonProdusent(
         }
     }
 
-    suspend fun createNewSak(mutation: NySakMutation): String? {
+    override suspend fun createNewSak(mutation: NySakMutation): String? {
         log.info("About to create new sak in ag-notifikasjon-produsent-api")
         val response: ApolloResponse<NySakMutation.Data> = apolloClient.mutation(mutation).execute()
         val result = response.data?.nySak
@@ -154,7 +154,7 @@ open class ArbeidsgiverNotifikasjonProdusent(
         }
     }
 
-    suspend fun nyStatusSak(nyStatusSakInput: NyStatusSakInput): String? {
+    override suspend fun nyStatusSak(nyStatusSakInput: NyStatusSakInput): String? {
         log.info("About to update sakstatus in ag-notifikasjon-produsent-api")
         val response: ApolloResponse<NyStatusSakByGrupperingsidMutation.Data> =
             apolloClient.mutation(nyStatusSakInput.toNyStatusSakByGrupperingsidMutation()).execute()
@@ -184,7 +184,7 @@ open class ArbeidsgiverNotifikasjonProdusent(
         }
     }
 
-    suspend fun createNewKalenderavtale(nyKalenderInput: NyKalenderInput): String? {
+    override suspend fun createNewKalenderavtale(nyKalenderInput: NyKalenderInput): String? {
         log.info("Forsøker å opprette ny kalenderavtale")
 
         val response: ApolloResponse<NyKalenderavtaleMutation.Data> =
@@ -226,7 +226,7 @@ open class ArbeidsgiverNotifikasjonProdusent(
         }
     }
 
-    suspend fun updateKalenderavtale(oppdaterKalenderInput: OppdaterKalenderInput): String? {
+    override suspend fun updateKalenderavtale(oppdaterKalenderInput: OppdaterKalenderInput): String? {
         val response: ApolloResponse<OppdaterKalenderavtaleMutation.Data> =
             apolloClient.mutation(oppdaterKalenderInput.toOppdaterKalenderavtaleMutation()).execute()
         val result = response.data?.oppdaterKalenderavtale
@@ -260,7 +260,7 @@ open class ArbeidsgiverNotifikasjonProdusent(
         }
     }
 
-    suspend fun deleteNotifikasjonForArbeidsgiver(arbeidsgiverDeleteNotifikasjon: ArbeidsgiverDeleteNotifikasjon) {
+    override suspend fun deleteNotifikasjonForArbeidsgiver(arbeidsgiverDeleteNotifikasjon: ArbeidsgiverDeleteNotifikasjon) {
         log.info(
             "About to delete notification with uuid ${arbeidsgiverDeleteNotifikasjon.eksternReferanse} and merkelapp ${arbeidsgiverDeleteNotifikasjon.merkelapp} from ag-notifikasjon-produsent-api",
         )

--- a/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/FakeArbeidsgiverNotifikasjonProdusent.kt
+++ b/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/FakeArbeidsgiverNotifikasjonProdusent.kt
@@ -28,7 +28,9 @@ class FakeArbeidsgiverNotifikasjonProdusent : IArbeidsgiverNotifikasjonProdusent
 
     override suspend fun createNewSak(mutation: NySakMutation): String =
         UUID.randomUUID().toString().also { id ->
-            log.info("Lokal arbeidsgivernotifikasjon sak opprettet: metode=${mutation.name()}, id=$id")
+            log.info(
+                "Lokal arbeidsgivernotifikasjon sak opprettet: grupperingsid=${mutation.grupperingsid}, merkelapp=${mutation.merkelapp}, virksomhetsnummer=${mutation.virksomhetsnummer}, id=$id",
+            )
         }
 
     override suspend fun nyStatusSak(nyStatusSakInput: NyStatusSakInput): String =

--- a/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/FakeArbeidsgiverNotifikasjonProdusent.kt
+++ b/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/FakeArbeidsgiverNotifikasjonProdusent.kt
@@ -1,0 +1,60 @@
+package no.nav.syfo.producer.arbeidsgivernotifikasjon
+
+import com.apollo.graphql.NySakMutation
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.ArbeidsgiverDeleteNotifikasjon
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.ArbeidsgiverNotifikasjon
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NyKalenderInput
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NyStatusSakInput
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.OppdaterKalenderInput
+import org.slf4j.LoggerFactory
+import java.util.UUID
+
+class FakeArbeidsgiverNotifikasjonProdusent : IArbeidsgiverNotifikasjonProdusent {
+    private val log = LoggerFactory.getLogger(FakeArbeidsgiverNotifikasjonProdusent::class.qualifiedName)
+
+    override suspend fun createNewOppgaveForArbeidsgiver(arbeidsgiverNotifikasjon: ArbeidsgiverNotifikasjon): String =
+        UUID.randomUUID().toString().also { id ->
+            log.info(
+                "Lokal arbeidsgivernotifikasjon oppgave opprettet: merkelapp=${arbeidsgiverNotifikasjon.merkelapp}, virksomhetsnummer=${arbeidsgiverNotifikasjon.virksomhetsnummer}, id=$id",
+            )
+        }
+
+    override suspend fun createNewBeskjedForArbeidsgiver(arbeidsgiverNotifikasjonInput: ArbeidsgiverNotifikasjon): String =
+        UUID.randomUUID().toString().also { id ->
+            log.info(
+                "Lokal arbeidsgivernotifikasjon beskjed opprettet: merkelapp=${arbeidsgiverNotifikasjonInput.merkelapp}, virksomhetsnummer=${arbeidsgiverNotifikasjonInput.virksomhetsnummer}, id=$id",
+            )
+        }
+
+    override suspend fun createNewSak(mutation: NySakMutation): String =
+        UUID.randomUUID().toString().also { id ->
+            log.info("Lokal arbeidsgivernotifikasjon sak opprettet: metode=${mutation.name()}, id=$id")
+        }
+
+    override suspend fun nyStatusSak(nyStatusSakInput: NyStatusSakInput): String =
+        UUID.randomUUID().toString().also { id ->
+            log.info(
+                "Lokal arbeidsgivernotifikasjon sakstatus oppdatert: merkelapp=${nyStatusSakInput.merkelapp}, status=${nyStatusSakInput.sakStatus}, id=$id",
+            )
+        }
+
+    override suspend fun createNewKalenderavtale(nyKalenderInput: NyKalenderInput): String =
+        UUID.randomUUID().toString().also { id ->
+            log.info(
+                "Lokal arbeidsgivernotifikasjon kalenderavtale opprettet: merkelapp=${nyKalenderInput.merkelapp}, virksomhetsnummer=${nyKalenderInput.virksomhetsnummer}, status=${nyKalenderInput.kalenderavtaleTilstand}, id=$id",
+            )
+        }
+
+    override suspend fun updateKalenderavtale(oppdaterKalenderInput: OppdaterKalenderInput): String =
+        UUID.randomUUID().toString().also { id ->
+            log.info(
+                "Lokal arbeidsgivernotifikasjon kalenderavtale oppdatert: status=${oppdaterKalenderInput.nyTilstand}, id=$id",
+            )
+        }
+
+    override suspend fun deleteNotifikasjonForArbeidsgiver(arbeidsgiverDeleteNotifikasjon: ArbeidsgiverDeleteNotifikasjon) {
+        log.info(
+            "Lokal arbeidsgivernotifikasjon slettet: merkelapp=${arbeidsgiverDeleteNotifikasjon.merkelapp}, eksternReferanse=${arbeidsgiverDeleteNotifikasjon.eksternReferanse}",
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/IArbeidsgiverNotifikasjonProdusent.kt
+++ b/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/IArbeidsgiverNotifikasjonProdusent.kt
@@ -1,0 +1,24 @@
+package no.nav.syfo.producer.arbeidsgivernotifikasjon
+
+import com.apollo.graphql.NySakMutation
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.ArbeidsgiverDeleteNotifikasjon
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.ArbeidsgiverNotifikasjon
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NyKalenderInput
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NyStatusSakInput
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.OppdaterKalenderInput
+
+interface IArbeidsgiverNotifikasjonProdusent {
+    suspend fun createNewOppgaveForArbeidsgiver(arbeidsgiverNotifikasjon: ArbeidsgiverNotifikasjon): String?
+
+    suspend fun createNewBeskjedForArbeidsgiver(arbeidsgiverNotifikasjonInput: ArbeidsgiverNotifikasjon): String?
+
+    suspend fun createNewSak(mutation: NySakMutation): String?
+
+    suspend fun nyStatusSak(nyStatusSakInput: NyStatusSakInput): String?
+
+    suspend fun createNewKalenderavtale(nyKalenderInput: NyKalenderInput): String?
+
+    suspend fun updateKalenderavtale(oppdaterKalenderInput: OppdaterKalenderInput): String?
+
+    suspend fun deleteNotifikasjonForArbeidsgiver(arbeidsgiverDeleteNotifikasjon: ArbeidsgiverDeleteNotifikasjon)
+}

--- a/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverNotifikasjonService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverNotifikasjonService.kt
@@ -2,7 +2,7 @@ package no.nav.syfo.service
 
 import com.apollo.graphql.NySakMutation
 import no.nav.syfo.consumer.narmesteLeder.NarmesteLederService
-import no.nav.syfo.producer.arbeidsgivernotifikasjon.ArbeidsgiverNotifikasjonProdusent
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.IArbeidsgiverNotifikasjonProdusent
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.ArbeidsgiverDeleteNotifikasjon
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.ArbeidsgiverNotifikasjonAltinnRessurs
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.ArbeidsgiverNotifikasjonNarmesteLeder
@@ -15,7 +15,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 class ArbeidsgiverNotifikasjonService(
-    private val arbeidsgiverNotifikasjonProdusent: ArbeidsgiverNotifikasjonProdusent,
+    private val arbeidsgiverNotifikasjonProdusent: IArbeidsgiverNotifikasjonProdusent,
     private val narmesteLederService: NarmesteLederService,
     private val dineSykmeldteUrl: String,
 ) {

--- a/src/main/resources/localEnvApp.json
+++ b/src/main/resources/localEnvApp.json
@@ -1,7 +1,8 @@
 {
   "appEnv": {
-    "applicationPort": "8080",
-    "applicationThreads": "1",
+    "applicationPort": 8080,
+    "applicationThreads": 1,
+    "remote": false,
     "cluster": "local"
   },
   "authEnv": {
@@ -38,13 +39,13 @@
     "baseUrlNavEkstern": "http://nav:8080"
   },
   "kafkaEnv": {
-    "bootstrapServersUrl": "http://localhost:9092",
+    "bootstrapServersUrl": "localhost:9092",
     "schemaRegistry": {
-      "url": "http://localhost:28900",
+      "url": "http://localhost:8081",
       "username": "schema_username",
       "password": "schema_password"
     },
-    "aivenBroker": "http://localhost:9093",
+    "aivenBroker": "localhost:9092",
     "sslConfig": {
       "truststoreLocation": "ts.loc",
       "keystoreLocation": "ks.loc",
@@ -52,10 +53,10 @@
     }
   },
   "dbEnv": {
-    "dbHost": "127.0.0.1",
+    "dbHost": "localhost",
     "dbPort": "5432",
-    "dbName": "esyfovarsel",
-    "dbUsername": "esyfovarsel-admin",
+    "dbName": "esyfovarsel_dev",
+    "dbUsername": "username",
     "dbPassword": "password"
   },
   "toggleEnv": {

--- a/src/main/resources/localEnvJob.json
+++ b/src/main/resources/localEnvJob.json
@@ -1,5 +1,6 @@
 {
   "jobTriggerUrl": "http://localhost:8080/job/trigger",
+  "revarsleUnreadAktivitetskrav": false,
   "serviceuserUsername": "srvesyfovarsel",
   "serviceuserPassword": "password"
 }

--- a/src/test/kotlin/no/nav/syfo/consumer/narmesteLeder/FakeNarmesteLederConsumerSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/consumer/narmesteLeder/FakeNarmesteLederConsumerSpek.kt
@@ -1,0 +1,24 @@
+package no.nav.syfo.consumer.narmesteLeder
+
+import io.kotest.core.spec.style.DescribeSpec
+import kotlinx.coroutines.runBlocking
+import org.amshove.kluent.shouldBeEqualTo
+
+class FakeNarmesteLederConsumerSpek :
+    DescribeSpec({
+        describe("FakeNarmesteLederConsumer") {
+            it("returns synthetic fnr values instead of reflecting input fnr") {
+                val response =
+                    runBlocking {
+                        FakeNarmesteLederConsumer().getNarmesteLeder(
+                            ansattFnr = "12345678910",
+                            orgnummer = "999999999",
+                        )
+                    }
+                val relasjon = response.narmesteLederRelasjon
+
+                relasjon?.fnr shouldBeEqualTo FakeNarmesteLederConsumer.LOCAL_SYNTHETIC_FNR
+                relasjon?.narmesteLederFnr shouldBeEqualTo FakeNarmesteLederConsumer.LOCAL_SYNTHETIC_FNR
+            }
+        }
+    })

--- a/src/test/kotlin/no/nav/syfo/consumer/narmesteLeder/FakeNarmesteLederConsumerSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/consumer/narmesteLeder/FakeNarmesteLederConsumerSpek.kt
@@ -1,24 +1,22 @@
 package no.nav.syfo.consumer.narmesteLeder
 
 import io.kotest.core.spec.style.DescribeSpec
-import kotlinx.coroutines.runBlocking
 import org.amshove.kluent.shouldBeEqualTo
 
 class FakeNarmesteLederConsumerSpek :
     DescribeSpec({
         describe("FakeNarmesteLederConsumer") {
             it("returns synthetic fnr values instead of reflecting input fnr") {
+                val ansattFnr = "12345678910"
                 val response =
-                    runBlocking {
-                        FakeNarmesteLederConsumer().getNarmesteLeder(
-                            ansattFnr = "12345678910",
-                            orgnummer = "999999999",
-                        )
-                    }
+                    FakeNarmesteLederConsumer().getNarmesteLeder(
+                        ansattFnr = ansattFnr,
+                        orgnummer = "999999999",
+                    )
                 val relasjon = response.narmesteLederRelasjon
 
-                relasjon?.fnr shouldBeEqualTo FakeNarmesteLederConsumer.LOCAL_SYNTHETIC_FNR
-                relasjon?.narmesteLederFnr shouldBeEqualTo FakeNarmesteLederConsumer.LOCAL_SYNTHETIC_FNR
+                relasjon?.fnr shouldBeEqualTo ansattFnr
+                relasjon?.narmesteLederFnr shouldBeEqualTo ansattFnr.reversed()
             }
         }
     })


### PR DESCRIPTION
## Beskrivelse

Tilrettelegger for å kjøre esyfovarsel lokalt mot Docker-basert Postgres og Kafka. Lokal kjøring bruker fake-klienter for token, nærmeste leder og Arbeidsgivernotifikasjon, uten å introdusere Koin eller endre remote-wiring.

## Endringer

- `BootstrapApplication.kt`: wirer fake-klienter lokalt, hopper over IAM-grant og leader election lokalt, og starter varselbus-consumer lokalt
- `auth/`, `consumer/narmesteLeder/`, `producer/arbeidsgivernotifikasjon/`: legger til interface/fake-mønster med `I`- og `Fake`-prefix
- `KafkaCommon.kt`: bruker PLAINTEXT uten SSL-properties ved lokal kjøring
- `localEnvApp.json` / `localEnvJob.json`: retter lokal app-/job-konfig mot Docker Postgres og Kafka
- `README.md`: dokumenterer lokal oppstart, Kafka-testmelding og avgrensninger for fake-støtte

## Issue

Closes #974

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)

## Verifisering

- `./gradlew build`
- `mise run docker-up`
- lokal appstart og healthcheck
- Kafka-testmelding mot `team-esyfo.varselbus`
- verifisert Arbeidsgivernotifikasjon-flyt via lokal fake og DB
- `mise run docker-down`
