### PR TITLE
feat(arbeidsgiver): send dialogmøtevarsel uten leder

### DIFF
--- a/scripts/messages/narmeste-leder-dialogmote-motebehov-tilbakemelding.json
+++ b/scripts/messages/narmeste-leder-dialogmote-motebehov-tilbakemelding.json
@@ -1,11 +1,11 @@
 {
   "@type": "NarmesteLederHendelse",
-  "type": "NL_DIALOGMOTE_MOTEBEHOV_TILBAKEMELDING",
+  "type": "NL_OPPFOLGINGSPLAN_FORESPORSEL",
   "ferdigstill": false,
   "data": {
     "tilbakemelding": "Lokal test"
   },
-  "narmesteLederFnr": "00000000000",
-  "arbeidstakerFnr": "12345678910",
+  "narmesteLederFnr": "01987654322",
+  "arbeidstakerFnr": "22345678910",
   "orgnummer": "999999999"
 }

--- a/src/main/kotlin/no/nav/syfo/BootstrapApplication.kt
+++ b/src/main/kotlin/no/nav/syfo/BootstrapApplication.kt
@@ -173,7 +173,11 @@ fun setModule(env: Environment): Application.() -> Unit =
                 fysiskBrevUtsendingService,
                 database,
             )
-        val arbeidsgiverVarselService = ArbeidsgiverVarselService()
+        val arbeidsgiverVarselService =
+            ArbeidsgiverVarselService(
+                database = database,
+                arbeidsgiverNotifikasjonService = arbeidsgiverNotifikasjonService,
+            )
         val motebehovVarselService =
             MotebehovVarselService(
                 senderFacade,
@@ -256,6 +260,7 @@ fun setModule(env: Environment): Application.() -> Unit =
                 merVeiledningVarselService = merVeiledningVarselService,
                 kartleggingVarselService = kartleggingssporsmalVarselService,
                 senderFacade = senderFacade,
+                arbeidsgiverVarselService = arbeidsgiverVarselService,
             )
 
         val varselBusService =

--- a/src/main/kotlin/no/nav/syfo/db/ArbeidsgivernotifikasjonerDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/db/ArbeidsgivernotifikasjonerDAO.kt
@@ -4,6 +4,7 @@ import com.apollo.graphql.type.SaksStatus
 import no.nav.syfo.db.domain.PKalenderInput
 import no.nav.syfo.db.domain.PSakInput
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.KalenderTilstand
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.MottakerType
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NySakAltinnInput
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NySakInput
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NySakNarmesteLederInput
@@ -22,7 +23,6 @@ fun DatabaseInterface.storeArbeidsgivernotifikasjonerSak(
     val uuid = UUID.randomUUID()
     val narmesteLederInput = sakInput as? NySakNarmesteLederInput
     val altinnInput = sakInput as? NySakAltinnInput
-    val lenkeForDatabase = altinnInput?.ressursUrl ?: sakInput.lenke
     val insertStatement =
         """
         INSERT INTO ARBEIDSGIVERNOTIFIKASJONER_SAK (
@@ -39,12 +39,13 @@ fun DatabaseInterface.storeArbeidsgivernotifikasjonerSak(
             tittel,
             tilleggsinformasjon,
             lenke,
+            mottaker_type,
             initiellStatus,
             nesteSteg,
             overstyrStatustekstMed,
             hardDeleteDate,
             opprettet
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """.trimIndent()
 
     return try {
@@ -62,12 +63,13 @@ fun DatabaseInterface.storeArbeidsgivernotifikasjonerSak(
                 preparedStatement.setString(10, altinnInput?.ressursId)
                 preparedStatement.setString(11, sakInput.tittel)
                 preparedStatement.setString(12, sakInput.tilleggsinformasjon)
-                preparedStatement.setString(13, lenkeForDatabase)
-                preparedStatement.setString(14, sakInput.initiellStatus.name)
-                preparedStatement.setString(15, sakInput.nesteSteg)
-                preparedStatement.setString(16, sakInput.overstyrStatustekstMed)
-                preparedStatement.setTimestamp(17, Timestamp.valueOf(sakInput.hardDeleteDate))
-                preparedStatement.setTimestamp(18, Timestamp.valueOf(LocalDateTime.now()))
+                preparedStatement.setString(13, sakInput.lenke)
+                preparedStatement.setString(14, sakInput.mottakerType.name)
+                preparedStatement.setString(15, sakInput.initiellStatus.name)
+                preparedStatement.setString(16, sakInput.nesteSteg)
+                preparedStatement.setString(17, sakInput.overstyrStatustekstMed)
+                preparedStatement.setTimestamp(18, Timestamp.valueOf(sakInput.hardDeleteDate))
+                preparedStatement.setTimestamp(19, Timestamp.valueOf(LocalDateTime.now()))
 
                 preparedStatement.executeUpdate()
             }
@@ -231,6 +233,7 @@ fun ResultSet.toPSakInput() =
         tittel = getString("tittel"),
         tilleggsinformasjon = getString("tilleggsinformasjon"),
         lenke = getString("lenke"),
+        mottakerType = MottakerType.valueOf(getString("mottaker_type")),
         initiellStatus = SaksStatus.valueOf(getString("initiellStatus")),
         nesteSteg = getString("nesteSteg"),
         overstyrStatustekstMed = getString("overstyrStatustekstMed"),

--- a/src/main/kotlin/no/nav/syfo/db/ArbeidsgivernotifikasjonerDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/db/ArbeidsgivernotifikasjonerDAO.kt
@@ -168,6 +168,7 @@ fun DatabaseInterface.getPaagaaendeArbeidsgivernotifikasjonerSakByType(
     virksomhetsnummer: String,
     type: String,
     mottakerType: MottakerType,
+    ressursId: String? = null,
 ): PSakInput? {
     val queryStatement =
         """
@@ -177,6 +178,7 @@ fun DatabaseInterface.getPaagaaendeArbeidsgivernotifikasjonerSakByType(
         AND virksomhetsnummer = ?
         AND type = ?
         AND mottaker_type = ?
+        AND (? IS NULL OR ressursId = ?)
         AND hardDeleteDate > CURRENT_TIMESTAMP
         AND initiellStatus not in ('FERDIG', 'AVHOLDT')
         ORDER BY opprettet DESC
@@ -189,37 +191,9 @@ fun DatabaseInterface.getPaagaaendeArbeidsgivernotifikasjonerSakByType(
             it.setString(2, virksomhetsnummer)
             it.setString(3, type)
             it.setString(4, mottakerType.name)
+            it.setString(5, ressursId)
+            it.setString(6, ressursId)
             it.executeQuery().toList { toPSakInput() }.firstOrNull()
-        }
-    }
-}
-
-fun DatabaseInterface.countArbeidsgivernotifikasjonerSakerByType(
-    ansattFnr: String,
-    virksomhetsnummer: String,
-    type: String,
-): Int {
-    val queryStatement =
-        """
-        SELECT COUNT(*)
-        FROM ARBEIDSGIVERNOTIFIKASJONER_SAK
-        WHERE ansattFnr = ?
-        AND virksomhetsnummer = ?
-        AND type = ?
-        """.trimIndent()
-
-    return connection.use { connection ->
-        connection.prepareStatement(queryStatement).use {
-            it.setString(1, ansattFnr)
-            it.setString(2, virksomhetsnummer)
-            it.setString(3, type)
-            it.executeQuery().use { resultSet ->
-                if (resultSet.next()) {
-                    resultSet.getInt(1)
-                } else {
-                    0
-                }
-            }
         }
     }
 }

--- a/src/main/kotlin/no/nav/syfo/db/ArbeidsgivernotifikasjonerDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/db/ArbeidsgivernotifikasjonerDAO.kt
@@ -160,6 +160,36 @@ fun DatabaseInterface.getPaagaaendeArbeidsgivernotifikasjonerSakByType(
     }
 }
 
+fun DatabaseInterface.countArbeidsgivernotifikasjonerSakerByType(
+    ansattFnr: String,
+    virksomhetsnummer: String,
+    type: String,
+): Int {
+    val queryStatement =
+        """
+        SELECT COUNT(*)
+        FROM ARBEIDSGIVERNOTIFIKASJONER_SAK
+        WHERE ansattFnr = ?
+        AND virksomhetsnummer = ?
+        AND type = ?
+        """.trimIndent()
+
+    return connection.use { connection ->
+        connection.prepareStatement(queryStatement).use {
+            it.setString(1, ansattFnr)
+            it.setString(2, virksomhetsnummer)
+            it.setString(3, type)
+            it.executeQuery().use { resultSet ->
+                if (resultSet.next()) {
+                    resultSet.getInt(1)
+                } else {
+                    0
+                }
+            }
+        }
+    }
+}
+
 fun ResultSet.toPSakInput() =
     PSakInput(
         id = getString("id"),

--- a/src/main/kotlin/no/nav/syfo/db/ArbeidsgivernotifikasjonerDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/db/ArbeidsgivernotifikasjonerDAO.kt
@@ -22,6 +22,7 @@ fun DatabaseInterface.storeArbeidsgivernotifikasjonerSak(
     val uuid = UUID.randomUUID()
     val narmesteLederInput = sakInput as? NySakNarmesteLederInput
     val altinnInput = sakInput as? NySakAltinnInput
+    val lenkeForDatabase = altinnInput?.ressursUrl ?: sakInput.lenke
     val insertStatement =
         """
         INSERT INTO ARBEIDSGIVERNOTIFIKASJONER_SAK (
@@ -61,7 +62,7 @@ fun DatabaseInterface.storeArbeidsgivernotifikasjonerSak(
                 preparedStatement.setString(10, altinnInput?.ressursId)
                 preparedStatement.setString(11, sakInput.tittel)
                 preparedStatement.setString(12, sakInput.tilleggsinformasjon)
-                preparedStatement.setString(13, sakInput.lenke)
+                preparedStatement.setString(13, lenkeForDatabase)
                 preparedStatement.setString(14, sakInput.initiellStatus.name)
                 preparedStatement.setString(15, sakInput.nesteSteg)
                 preparedStatement.setString(16, sakInput.overstyrStatustekstMed)

--- a/src/main/kotlin/no/nav/syfo/db/ArbeidsgivernotifikasjonerDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/db/ArbeidsgivernotifikasjonerDAO.kt
@@ -178,6 +178,9 @@ fun DatabaseInterface.getPaagaaendeArbeidsgivernotifikasjonerSakByType(
         AND virksomhetsnummer = ?
         AND type = ?
         AND mottaker_type = ?
+        -- ressursId er valgfri for eksisterende kall; når den er satt skal sak kun gjenbrukes for samme ressursId.
+        -- Så det blir null is null for spørre uten ressursId eller where klaul som matcher feltet ressursId med
+        -- innsendt variable ressurdId.
         AND (? IS NULL OR ressursId = ?)
         AND hardDeleteDate > CURRENT_TIMESTAMP
         AND initiellStatus not in ('FERDIG', 'AVHOLDT')

--- a/src/main/kotlin/no/nav/syfo/db/ArbeidsgivernotifikasjonerDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/db/ArbeidsgivernotifikasjonerDAO.kt
@@ -107,6 +107,31 @@ fun DatabaseInterface.updateArbeidsgivernotifikasjonerSakStatus(
     }
 }
 
+fun DatabaseInterface.updateArbeidsgivernotifikasjonerSakStatusAndHardDeleteDate(
+    sakId: String,
+    sakStatus: SakStatus,
+    hardDeleteDate: LocalDateTime,
+) {
+    val updateStatement =
+        """
+        UPDATE ARBEIDSGIVERNOTIFIKASJONER_SAK
+        SET initiellStatus = ?, hardDeleteDate = ?
+        WHERE id = ?
+        """.trimIndent()
+
+    connection.use { connection ->
+        connection.prepareStatement(updateStatement).use { preparedStatement ->
+            preparedStatement.setString(1, sakStatus.name)
+            preparedStatement.setTimestamp(2, Timestamp.valueOf(hardDeleteDate))
+            preparedStatement.setObject(3, UUID.fromString(sakId))
+
+            preparedStatement.executeUpdate()
+        }
+
+        connection.commit()
+    }
+}
+
 fun DatabaseInterface.getPaagaaendeArbeidsgivernotifikasjonerSak(
     narmestelederId: String,
     merkelapp: String,

--- a/src/main/kotlin/no/nav/syfo/db/ArbeidsgivernotifikasjonerDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/db/ArbeidsgivernotifikasjonerDAO.kt
@@ -138,6 +138,7 @@ fun DatabaseInterface.updateArbeidsgivernotifikasjonerSakStatusAndHardDeleteDate
 fun DatabaseInterface.getPaagaaendeArbeidsgivernotifikasjonerSak(
     narmestelederId: String,
     merkelapp: String,
+    mottakerType: MottakerType,
 ): PSakInput? {
     val queryStatement =
         """
@@ -145,6 +146,7 @@ fun DatabaseInterface.getPaagaaendeArbeidsgivernotifikasjonerSak(
         FROM ARBEIDSGIVERNOTIFIKASJONER_SAK
         WHERE narmestelederId = ?
         AND merkelapp = ?
+        AND mottaker_type = ?
         AND hardDeleteDate > CURRENT_TIMESTAMP
         AND initiellStatus not in ('FERDIG', 'AVHOLDT')
         ORDER BY opprettet DESC
@@ -155,6 +157,7 @@ fun DatabaseInterface.getPaagaaendeArbeidsgivernotifikasjonerSak(
         connection.prepareStatement(queryStatement).use {
             it.setString(1, narmestelederId)
             it.setString(2, merkelapp)
+            it.setString(3, mottakerType.name)
             it.executeQuery().toList { toPSakInput() }.firstOrNull()
         }
     }
@@ -164,6 +167,7 @@ fun DatabaseInterface.getPaagaaendeArbeidsgivernotifikasjonerSakByType(
     ansattFnr: String,
     virksomhetsnummer: String,
     type: String,
+    mottakerType: MottakerType,
 ): PSakInput? {
     val queryStatement =
         """
@@ -172,6 +176,7 @@ fun DatabaseInterface.getPaagaaendeArbeidsgivernotifikasjonerSakByType(
         WHERE ansattFnr = ?
         AND virksomhetsnummer = ?
         AND type = ?
+        AND mottaker_type = ?
         AND hardDeleteDate > CURRENT_TIMESTAMP
         AND initiellStatus not in ('FERDIG', 'AVHOLDT')
         ORDER BY opprettet DESC
@@ -183,6 +188,7 @@ fun DatabaseInterface.getPaagaaendeArbeidsgivernotifikasjonerSakByType(
             it.setString(1, ansattFnr)
             it.setString(2, virksomhetsnummer)
             it.setString(3, type)
+            it.setString(4, mottakerType.name)
             it.executeQuery().toList { toPSakInput() }.firstOrNull()
         }
     }

--- a/src/main/kotlin/no/nav/syfo/db/UtsendtVarselDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/db/UtsendtVarselDAO.kt
@@ -140,6 +140,28 @@ fun DatabaseInterface.fetchUtsendtVarselByFnr(fnr: String): List<PUtsendtVarsel>
     }
 }
 
+fun DatabaseInterface.isUtsendtVarselStored(
+    eksternReferanse: String,
+    kanal: String,
+): Boolean {
+    val queryStatement =
+        """
+        SELECT 1
+        FROM UTSENDT_VARSEL
+        WHERE ekstern_ref = ?
+        AND kanal = ?
+        LIMIT 1
+        """.trimIndent()
+
+    return connection.use { connection ->
+        connection.prepareStatement(queryStatement).use {
+            it.setString(1, eksternReferanse)
+            it.setString(2, kanal)
+            it.executeQuery().next()
+        }
+    }
+}
+
 fun DatabaseInterface.setUtsendtVarselToFerdigstilt(eksternRef: String): Int {
     val now = Timestamp.valueOf(LocalDateTime.now())
     val updateStatement =

--- a/src/main/kotlin/no/nav/syfo/db/UtsendtVarselFeiletDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/db/UtsendtVarselFeiletDAO.kt
@@ -48,7 +48,6 @@ fun DatabaseInterface.fetchUtsendtArbeidsgivernotifikasjonVarselFeilet(): List<P
             SELECT 1
             FROM UTSENDT_VARSEL UV
             WHERE UV.KANAL = 'ARBEIDSGIVERNOTIFIKASJON'
-            AND UV.UTSENDT_TIDSPUNKT >= '2025-05-19'
             AND UV.EKSTERN_REF = feilet.UUID_EKSTERN_REFERANSE
         )
         ORDER BY feilet.utsendt_forsok_tidspunkt ASC

--- a/src/main/kotlin/no/nav/syfo/db/UtsendtVarselFeiletDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/db/UtsendtVarselFeiletDAO.kt
@@ -43,7 +43,14 @@ fun DatabaseInterface.fetchUtsendtArbeidsgivernotifikasjonVarselFeilet(): List<P
         AND feilet.is_resendt = FALSE
         AND feilet.resend_exhausted IS NOT TRUE
         AND feilet.hendelsetype_navn in 
-        ('NL_DIALOGMOTE_SVAR_MOTEBEHOV')
+        ('NL_DIALOGMOTE_SVAR_MOTEBEHOV', 'AG_VARSEL_ALTINN_RESSURS')
+        AND NOT EXISTS (
+            SELECT 1
+            FROM UTSENDT_VARSEL UV
+            WHERE UV.KANAL = 'ARBEIDSGIVERNOTIFIKASJON'
+            AND UV.UTSENDT_TIDSPUNKT >= '2025-05-19'
+            AND UV.EKSTERN_REF = feilet.UUID_EKSTERN_REFERANSE
+        )
         ORDER BY feilet.utsendt_forsok_tidspunkt ASC
         LIMIT 1000
         """.trimIndent()
@@ -131,17 +138,22 @@ fun DatabaseInterface.storeUtsendtVarselFeilet(varsel: PUtsendtVarselFeilet) {
     }
 }
 
-fun DatabaseInterface.updateUtsendtVarselFeiletToResendt(uuid: String) {
+fun DatabaseInterface.updateUtsendtVarselFeiletToResendt(
+    uuid: String,
+    nullstillHendelseJson: Boolean = false,
+) {
     val updateStatement =
         """UPDATE UTSENDING_VARSEL_FEILET
                    SET is_resendt = TRUE,
-                       resendt_tidspunkt = CURRENT_TIMESTAMP
-                   WHERE uuid = ?
+                       resendt_tidspunkt = CURRENT_TIMESTAMP,
+                       hendelse_json = CASE WHEN ? THEN NULL ELSE hendelse_json END
+                    WHERE uuid = ?
         """.trimMargin()
 
     return connection.use { connection ->
         connection.prepareStatement(updateStatement).use {
-            it.setObject(1, UUID.fromString(uuid))
+            it.setBoolean(1, nullstillHendelseJson)
+            it.setObject(2, UUID.fromString(uuid))
             it.executeUpdate()
         }
         connection.commit()

--- a/src/main/kotlin/no/nav/syfo/db/domain/PSakInput.kt
+++ b/src/main/kotlin/no/nav/syfo/db/domain/PSakInput.kt
@@ -1,6 +1,7 @@
 package no.nav.syfo.db.domain
 
 import com.apollo.graphql.type.SaksStatus
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.MottakerType
 import java.time.LocalDateTime
 
 data class PSakInput(
@@ -16,7 +17,8 @@ data class PSakInput(
     val ressursId: String? = null,
     val tittel: String,
     val tilleggsinformasjon: String? = null,
-    val lenke: String,
+    val lenke: String?,
+    val mottakerType: MottakerType,
     val initiellStatus: SaksStatus,
     val nesteSteg: String? = null,
     val overstyrStatustekstMed: String? = null,

--- a/src/main/kotlin/no/nav/syfo/db/domain/PUtsendtVarselFeilet.kt
+++ b/src/main/kotlin/no/nav/syfo/db/domain/PUtsendtVarselFeilet.kt
@@ -1,8 +1,13 @@
 package no.nav.syfo.db.domain
 
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.syfo.kafka.common.createObjectMapper
+import no.nav.syfo.kafka.consumers.varselbus.domain.ArbeidsgiverNotifikasjonTilAltinnRessursHendelse
 import no.nav.syfo.kafka.consumers.varselbus.domain.ArbeidstakerHendelse
 import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType
 import java.time.LocalDateTime
+
+private val objectMapper = createObjectMapper()
 
 data class PUtsendtVarselFeilet(
     val uuid: String,
@@ -31,3 +36,11 @@ fun PUtsendtVarselFeilet.toArbeidstakerHendelse(): ArbeidstakerHendelse =
         ferdigstill = false,
         data = null,
     )
+
+fun PUtsendtVarselFeilet.toArbeidsgiverNotifikasjonTilAltinnRessursHendelse(): ArbeidsgiverNotifikasjonTilAltinnRessursHendelse {
+    val hendelseJson =
+        requireNotNull(hendelseJson) {
+            "Mangler hendelseJson for feilet arbeidsgiverhendelse"
+        }
+    return objectMapper.readValue(hendelseJson)
+}

--- a/src/main/kotlin/no/nav/syfo/job/ResendFailedVarslerJob.kt
+++ b/src/main/kotlin/no/nav/syfo/job/ResendFailedVarslerJob.kt
@@ -207,7 +207,11 @@ class ResendFailedVarslerJob(
         }
         if (db.isUtsendtVarselStored(eksternReferanse, Kanal.ARBEIDSGIVERNOTIFIKASJON.name)) {
             db.updateUtsendtVarselFeiletToResendt(failedVarsel.uuid, nullstillHendelseJson = true)
-            return 1
+            log.info(
+                "Skip resending arbeidsgiver Altinn-varsel: varsel er allerede lagret som utsendt for failedVarsel med uuid {}",
+                failedVarsel.uuid,
+            )
+            return 0
         }
 
         return when (arbeidsgiverVarselService.resendVarselTilArbeidsgiver(failedVarsel)) {

--- a/src/main/kotlin/no/nav/syfo/job/ResendFailedVarslerJob.kt
+++ b/src/main/kotlin/no/nav/syfo/job/ResendFailedVarslerJob.kt
@@ -2,15 +2,20 @@ package no.nav.syfo.job
 
 import no.nav.syfo.consumer.distribuerjournalpost.DistibusjonsType
 import no.nav.syfo.db.DatabaseInterface
+import no.nav.syfo.db.domain.Kanal
 import no.nav.syfo.db.domain.PUtsendtVarselFeilet
 import no.nav.syfo.db.domain.toArbeidstakerHendelse
 import no.nav.syfo.db.fetchDineSykemeldteMotebehovOppgaverFor
 import no.nav.syfo.db.fetchUtsendtArbeidsgivernotifikasjonVarselFeilet
 import no.nav.syfo.db.fetchUtsendtBrukernotifikasjonVarselFeilet
 import no.nav.syfo.db.fetchUtsendtDokDistVarselFeilet
+import no.nav.syfo.db.isUtsendtVarselStored
+import no.nav.syfo.db.updateUtsendtVarselFeiletToResendExhausted
 import no.nav.syfo.db.updateUtsendtVarselFeiletToResendt
 import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType
+import no.nav.syfo.service.ArbeidsgiverVarselResendResult
+import no.nav.syfo.service.ArbeidsgiverVarselService
 import no.nav.syfo.service.DialogmoteInnkallingSykmeldtVarselService
 import no.nav.syfo.service.KartleggingssporsmalVarselService
 import no.nav.syfo.service.MerVeiledningVarselService
@@ -26,6 +31,7 @@ class ResendFailedVarslerJob(
     private val merVeiledningVarselService: MerVeiledningVarselService,
     private val kartleggingVarselService: KartleggingssporsmalVarselService,
     private val senderFacade: SenderFacade,
+    private val arbeidsgiverVarselService: ArbeidsgiverVarselService,
 ) {
     private val log = LoggerFactory.getLogger(ResendFailedVarslerJob::class.java)
 
@@ -124,6 +130,7 @@ class ResendFailedVarslerJob(
             failedVarsler
                 .map { failedVarsel ->
                     when (failedVarsel.hendelsetypeNavn) {
+                        "AG_VARSEL_ALTINN_RESSURS" -> tryResendArbeidsgiverAltinnRessursVarsel(failedVarsel)
                         "NL_DIALOGMOTE_SVAR_MOTEBEHOV" -> tryResendArbeidsgivernotifikasjonMoteBehov(failedVarsel)
                         else -> {
                             log.warn("Not resending varsel for hendelsetypeNavn: ${failedVarsel.hendelsetypeNavn}")
@@ -186,6 +193,36 @@ class ResendFailedVarslerJob(
         }
 
         return resentCount
+    }
+
+    private suspend fun tryResendArbeidsgiverAltinnRessursVarsel(failedVarsel: PUtsendtVarselFeilet): Int {
+        val eksternReferanse = failedVarsel.uuidEksternReferanse
+        if (eksternReferanse == null) {
+            log.error(
+                "Skip resending arbeidsgiver Altinn-varsel: uuidEksternReferanse mangler for failedVarsel med uuid {}",
+                failedVarsel.uuid,
+            )
+            db.updateUtsendtVarselFeiletToResendExhausted(failedVarsel.uuid)
+            return 0
+        }
+        if (db.isUtsendtVarselStored(eksternReferanse, Kanal.ARBEIDSGIVERNOTIFIKASJON.name)) {
+            db.updateUtsendtVarselFeiletToResendt(failedVarsel.uuid, nullstillHendelseJson = true)
+            return 1
+        }
+
+        return when (arbeidsgiverVarselService.resendVarselTilArbeidsgiver(failedVarsel)) {
+            ArbeidsgiverVarselResendResult.RESENT -> {
+                db.updateUtsendtVarselFeiletToResendt(failedVarsel.uuid, nullstillHendelseJson = true)
+                1
+            }
+
+            ArbeidsgiverVarselResendResult.PERMANENT_FAILURE -> {
+                db.updateUtsendtVarselFeiletToResendExhausted(failedVarsel.uuid)
+                0
+            }
+
+            ArbeidsgiverVarselResendResult.RETRYABLE_FAILURE -> 0
+        }
     }
 
     private suspend fun tryResendArbeidsgivernotifikasjonMoteBehov(failedVarsel: PUtsendtVarselFeilet): Int {

--- a/src/main/kotlin/no/nav/syfo/kafka/consumers/varselbus/domain/EsyfovarselHendelse.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/consumers/varselbus/domain/EsyfovarselHendelse.kt
@@ -42,7 +42,7 @@ data class ArbeidsgiverNotifikasjonTilAltinnRessursHendelse(
     override val type: HendelseType,
     override val ferdigstill: Boolean?,
     override var data: Any?,
-    val arbeidstakerFnr: String? = null,
+    val arbeidstakerFnr: String,
     val eksternReferanseId: String,
     val kilde: String,
     val orgnummer: String,

--- a/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/FakeArbeidsgiverNotifikasjonProdusent.kt
+++ b/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/FakeArbeidsgiverNotifikasjonProdusent.kt
@@ -36,7 +36,7 @@ class FakeArbeidsgiverNotifikasjonProdusent : IArbeidsgiverNotifikasjonProdusent
     override suspend fun nyStatusSak(nyStatusSakInput: NyStatusSakInput): String =
         UUID.randomUUID().toString().also { id ->
             log.info(
-                "Lokal arbeidsgivernotifikasjon sakstatus oppdatert: merkelapp=${nyStatusSakInput.merkelapp}, status=${nyStatusSakInput.sakStatus}, id=$id",
+                "Lokal arbeidsgivernotifikasjon sakstatus oppdatert: merkelapp=${nyStatusSakInput.merkelapp}, status=${nyStatusSakInput.sakStatus}, id=$id, hardDeleteDate=${nyStatusSakInput.oppdatertHardDeleteDateTime}",
             )
         }
 

--- a/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/domain/MottakerType.kt
+++ b/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/domain/MottakerType.kt
@@ -1,0 +1,6 @@
+package no.nav.syfo.producer.arbeidsgivernotifikasjon.domain
+
+enum class MottakerType {
+    NAERMESTE_LEDER,
+    ALTINN,
+}

--- a/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/domain/NySakInput.kt
+++ b/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/domain/NySakInput.kt
@@ -23,17 +23,18 @@ sealed interface NySakInput {
     val ansattFnr: String
     val tittel: String
     val tilleggsinformasjon: String?
-    val lenke: String
+    val lenke: String?
     val initiellStatus: SakStatus
     val nesteSteg: String?
     val overstyrStatustekstMed: String?
     val hardDeleteDate: LocalDateTime
+    val mottakerType: MottakerType
 
     fun toNySakMutation(): NySakMutation
 
     fun toSakType(): String
 
-    fun toLenkeForNySakMutation(): Optional<String?> = Optional.present(lenke)
+    fun toLenkeForNySakMutation(): Optional<String?> = Optional.presentIfNotNull(lenke)
 
     fun buildNySakMutation(mottakere: List<MottakerInput>): NySakMutation =
         NySakMutation(
@@ -74,6 +75,8 @@ data class NySakNarmesteLederInput(
     override val overstyrStatustekstMed: String? = null,
     override val hardDeleteDate: LocalDateTime,
 ) : NySakInput {
+    override val mottakerType = MottakerType.NAERMESTE_LEDER
+
     override fun toNySakMutation(): NySakMutation =
         buildNySakMutation(
             listOf(
@@ -109,10 +112,9 @@ data class NySakAltinnInput(
     override val overstyrStatustekstMed: String? = null,
     override val hardDeleteDate: LocalDateTime,
     val ressursId: String,
-    val ressursUrl: String,
 ) : NySakInput {
-    override val lenke: String
-        get() = ressursUrl
+    override val lenke: String? = null
+    override val mottakerType = MottakerType.ALTINN
 
     override fun toNySakMutation(): NySakMutation =
         buildNySakMutation(
@@ -127,8 +129,6 @@ data class NySakAltinnInput(
                 ),
             ),
         )
-
-    override fun toLenkeForNySakMutation(): Optional<String?> = Optional.Absent
 
     override fun toSakType(): String = SAK_TYPE_DIALOGMOTE_UTEN_LEDER
 }

--- a/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/domain/NySakInput.kt
+++ b/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/domain/NySakInput.kt
@@ -33,6 +33,8 @@ sealed interface NySakInput {
 
     fun toSakType(): String
 
+    fun toLenkeForNySakMutation(): Optional<String?> = Optional.present(lenke)
+
     fun buildNySakMutation(mottakere: List<MottakerInput>): NySakMutation =
         NySakMutation(
             grupperingsid = grupperingsid,
@@ -41,7 +43,7 @@ sealed interface NySakInput {
             mottakere = mottakere,
             tittel = tittel,
             tilleggsinformasjon = Optional.presentIfNotNull(tilleggsinformasjon),
-            lenke = Optional.present(lenke),
+            lenke = toLenkeForNySakMutation(),
             initiellStatus = SaksStatus.valueOf(initiellStatus.name),
             nesteSteg = Optional.presentIfNotNull(nesteSteg),
             overstyrStatustekstMed = Optional.presentIfNotNull(overstyrStatustekstMed),
@@ -102,13 +104,16 @@ data class NySakAltinnInput(
     override val ansattFnr: String,
     override val tittel: String,
     override val tilleggsinformasjon: String? = null,
-    override val lenke: String,
     override val initiellStatus: SakStatus,
     override val nesteSteg: String? = null,
     override val overstyrStatustekstMed: String? = null,
     override val hardDeleteDate: LocalDateTime,
     val ressursId: String,
+    val ressursUrl: String,
 ) : NySakInput {
+    override val lenke: String
+        get() = ressursUrl
+
     override fun toNySakMutation(): NySakMutation =
         buildNySakMutation(
             listOf(
@@ -122,6 +127,8 @@ data class NySakAltinnInput(
                 ),
             ),
         )
+
+    override fun toLenkeForNySakMutation(): Optional<String?> = Optional.Absent
 
     override fun toSakType(): String = SAK_TYPE_DIALOGMOTE_UTEN_LEDER
 }

--- a/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverNotifikasjonService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverNotifikasjonService.kt
@@ -73,7 +73,7 @@ class ArbeidsgiverNotifikasjonService(
         }
     }
 
-    suspend fun sendNotifikasjon(arbeidsgiverNotifikasjon: ArbeidsgiverNotifikasjonAltinnRessursInput) {
+    suspend fun sendNotifikasjon(arbeidsgiverNotifikasjon: ArbeidsgiverNotifikasjonAltinnRessursInput): String? {
         val arbeidsgiverNotifikasjonAltinnRessurs =
             ArbeidsgiverNotifikasjonAltinnRessurs(
                 varselId = arbeidsgiverNotifikasjon.uuid.toString(),
@@ -87,7 +87,7 @@ class ArbeidsgiverNotifikasjonService(
                 grupperingsid = arbeidsgiverNotifikasjon.grupperingsid,
                 ressursId = arbeidsgiverNotifikasjon.ressursId,
             )
-        when (arbeidsgiverNotifikasjon.meldingstype) {
+        return when (arbeidsgiverNotifikasjon.meldingstype) {
             BESKJED ->
                 arbeidsgiverNotifikasjonProdusent.createNewBeskjedForArbeidsgiver(
                     arbeidsgiverNotifikasjonAltinnRessurs,

--- a/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverVarselService.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.JsonNode
 import no.nav.syfo.ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_MERKELAPP
 import no.nav.syfo.db.DatabaseInterface
-import no.nav.syfo.db.countArbeidsgivernotifikasjonerSakerByType
 import no.nav.syfo.db.domain.Kanal
 import no.nav.syfo.db.domain.PSakInput
 import no.nav.syfo.db.domain.PUtsendtVarsel
@@ -27,7 +26,6 @@ import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.SAK_TYPE_DIALOGMOTE_
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.SakStatus
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.nio.charset.StandardCharsets
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
@@ -128,6 +126,7 @@ class ArbeidsgiverVarselService(
                 virksomhetsnummer = hendelse.orgnummer,
                 type = SAK_TYPE_DIALOGMOTE_UTEN_LEDER,
                 mottakerType = MottakerType.ALTINN,
+                ressursId = hendelse.ressursId,
             )
         if (existingSak != null) {
             updateExistingSakHardDeleteDate(
@@ -140,7 +139,7 @@ class ArbeidsgiverVarselService(
             )
         }
 
-        val sakInput = hendelse.toNySakAltinnInput(SAK_TYPE_DIALOGMOTE_UTEN_LEDER, hardDeleteDate)
+        val sakInput = hendelse.toNySakAltinnInput(hardDeleteDate)
         val eksternSakId =
             arbeidsgiverNotifikasjonService.createNewSak(sakInput.toNySakMutation())
                 ?: throw ArbeidsgiverVarselRetryableException(
@@ -180,30 +179,6 @@ class ArbeidsgiverVarselService(
             sakStatus = sakStatus,
             hardDeleteDate = hardDeleteDate,
         )
-    }
-
-    private fun generateGrupperingsid(
-        arbeidstakerFnr: String,
-        virksomhetsnummer: String,
-        saktype: String,
-    ): String {
-        val existingSaker =
-            database.countArbeidsgivernotifikasjonerSakerByType(
-                ansattFnr = arbeidstakerFnr,
-                virksomhetsnummer = virksomhetsnummer,
-                type = saktype,
-            )
-        val seed =
-            buildString {
-                append(virksomhetsnummer)
-                append('|')
-                append(saktype)
-                append('|')
-                append(if (existingSaker == 0) "1" else existingSaker + 1)
-                append('|')
-                append(arbeidstakerFnr)
-            }
-        return UUID.nameUUIDFromBytes(seed.toByteArray(StandardCharsets.UTF_8)).toString()
     }
 
     private fun lagreIkkeUtsendtArbeidsgiverVarsel(
@@ -264,19 +239,17 @@ class ArbeidsgiverVarselService(
         return isStored
     }
 
-    private fun ArbeidsgiverNotifikasjonTilAltinnRessursHendelse.toNySakAltinnInput(
-        sakType: String,
-        hardDeleteDate: LocalDateTime,
-    ) = NySakAltinnInput(
-        grupperingsid = generateGrupperingsid(arbeidstakerFnr, orgnummer, sakType),
-        merkelapp = ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_MERKELAPP,
-        virksomhetsnummer = orgnummer,
-        ansattFnr = arbeidstakerFnr,
-        tittel = SAK_TITTEL_DIALOGMOTE,
-        initiellStatus = SakStatus.MOTTATT,
-        hardDeleteDate = hardDeleteDate,
-        ressursId = ressursId,
-    )
+    private fun ArbeidsgiverNotifikasjonTilAltinnRessursHendelse.toNySakAltinnInput(hardDeleteDate: LocalDateTime) =
+        NySakAltinnInput(
+            grupperingsid = UUID.randomUUID().toString(),
+            merkelapp = ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_MERKELAPP,
+            virksomhetsnummer = orgnummer,
+            ansattFnr = arbeidstakerFnr,
+            tittel = SAK_TITTEL_DIALOGMOTE,
+            initiellStatus = SakStatus.MOTTATT,
+            hardDeleteDate = hardDeleteDate,
+            ressursId = ressursId,
+        )
 
     private fun ArbeidsgiverNotifikasjonTilAltinnRessursHendelse.requireNotifikasjonInnhold(): VarselDataNotifikasjonInnhold =
         parseVarselData().notifikasjonInnhold

--- a/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverVarselService.kt
@@ -20,6 +20,7 @@ import no.nav.syfo.kafka.common.createObjectMapper
 import no.nav.syfo.kafka.consumers.varselbus.domain.ArbeidsgiverNotifikasjonTilAltinnRessursHendelse
 import no.nav.syfo.kafka.consumers.varselbus.domain.VarselDataNotifikasjonInnhold
 import no.nav.syfo.kafka.consumers.varselbus.domain.toVarselData
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.MottakerType
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NySakAltinnInput
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NyStatusSakInput
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.SAK_TYPE_DIALOGMOTE_UTEN_LEDER
@@ -126,6 +127,7 @@ class ArbeidsgiverVarselService(
                 ansattFnr = hendelse.arbeidstakerFnr,
                 virksomhetsnummer = hendelse.orgnummer,
                 type = SAK_TYPE_DIALOGMOTE_UTEN_LEDER,
+                mottakerType = MottakerType.ALTINN,
             )
         if (existingSak != null) {
             updateExistingSakHardDeleteDate(

--- a/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverVarselService.kt
@@ -1,58 +1,356 @@
 package no.nav.syfo.service
 
 import com.fasterxml.jackson.databind.JsonMappingException
+import com.fasterxml.jackson.databind.JsonNode
+import no.nav.syfo.ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_MERKELAPP
+import no.nav.syfo.db.DatabaseInterface
+import no.nav.syfo.db.countArbeidsgivernotifikasjonerSakerByType
+import no.nav.syfo.db.domain.Kanal
+import no.nav.syfo.db.domain.PUtsendtVarsel
+import no.nav.syfo.db.domain.PUtsendtVarselFeilet
+import no.nav.syfo.db.domain.toArbeidsgiverNotifikasjonTilAltinnRessursHendelse
+import no.nav.syfo.db.getPaagaaendeArbeidsgivernotifikasjonerSakByType
+import no.nav.syfo.db.isUtsendtVarselStored
+import no.nav.syfo.db.storeArbeidsgivernotifikasjonerSak
+import no.nav.syfo.db.storeUtsendtVarsel
+import no.nav.syfo.db.storeUtsendtVarselFeilet
+import no.nav.syfo.kafka.common.createObjectMapper
 import no.nav.syfo.kafka.consumers.varselbus.domain.ArbeidsgiverNotifikasjonTilAltinnRessursHendelse
 import no.nav.syfo.kafka.consumers.varselbus.domain.toVarselData
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NySakAltinnInput
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.SAK_TYPE_DIALOGMOTE_UTEN_LEDER
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.SakStatus
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import java.nio.charset.StandardCharsets
+import java.time.LocalDateTime
+import java.util.UUID
 
-class ArbeidsgiverVarselService {
+private const val WEEKS_BEFORE_DELETE = 4L
+private const val SAK_TITTEL_DIALOGMOTE = "Dialogmøte"
+private val arbeidsgiverVarselObjectMapper = createObjectMapper()
+
+class ArbeidsgiverVarselService(
+    private val database: DatabaseInterface,
+    private val arbeidsgiverNotifikasjonService: ArbeidsgiverNotifikasjonService,
+) {
     private val log: Logger = LoggerFactory.getLogger(ArbeidsgiverVarselService::class.qualifiedName)
+    private val objectMapper = arbeidsgiverVarselObjectMapper
 
     suspend fun sendVarselTilArbeidsgiver(hendelse: ArbeidsgiverNotifikasjonTilAltinnRessursHendelse) {
-        val data =
-            requireNotNull(hendelse.data) {
-                "ArbeidsgiverHendelse mangler feltet: data"
+        sendVarselTilArbeidsgiver(
+            hendelse = hendelse,
+            lagreFeiletUtsending = true,
+        )
+    }
+
+    suspend fun resendVarselTilArbeidsgiver(varselFeilet: PUtsendtVarselFeilet): ArbeidsgiverVarselResendResult {
+        val hendelse =
+            try {
+                varselFeilet.toResendArbeidsgiverHendelse()
+            } catch (exception: ArbeidsgiverVarselPermanentException) {
+                log.error(
+                    "Kunne ikke deserialisere feilet arbeidsgivervarsel for retry: type={}, kanal={}, feil={}",
+                    varselFeilet.hendelsetypeNavn,
+                    varselFeilet.kanal,
+                    exception.message,
+                )
+                return ArbeidsgiverVarselResendResult.PERMANENT_FAILURE
             }
-        val varselData =
+
+        return sendVarselTilArbeidsgiver(
+            hendelse = hendelse,
+            lagreFeiletUtsending = false,
+        )
+    }
+
+    private suspend fun sendVarselTilArbeidsgiver(
+        hendelse: ArbeidsgiverNotifikasjonTilAltinnRessursHendelse,
+        lagreFeiletUtsending: Boolean,
+    ): ArbeidsgiverVarselResendResult {
+        val eksternReferanseUuid =
+            runCatching { UUID.fromString(hendelse.eksternReferanseId) }
+                .getOrElse {
+                    val exception = ArbeidsgiverVarselPermanentException("ArbeidsgiverHendelse har ugyldig eksternReferanseId-format")
+                    if (lagreFeiletUtsending) {
+                        lagreIkkeUtsendtArbeidsgiverVarsel(hendelse, exception)
+                    }
+                    log.warn(
+                        "Avviser arbeidsgivervarsel med ugyldig eksternReferanseId: type={}, orgnummer={}, ressursId={}, kilde={}",
+                        hendelse.type,
+                        hendelse.orgnummer,
+                        hendelse.ressursId,
+                        hendelse.kilde,
+                    )
+                    return ArbeidsgiverVarselResendResult.PERMANENT_FAILURE
+                }
+
+        if (database.isUtsendtVarselStored(hendelse.eksternReferanseId, Kanal.ARBEIDSGIVERNOTIFIKASJON.name)) {
+            log.info(
+                "Arbeidsgivervarsel er allerede lagret som sendt: type={}, orgnummer={}, ressursId={}, kilde={}",
+                hendelse.type,
+                hendelse.orgnummer,
+                hendelse.ressursId,
+                hendelse.kilde,
+            )
+            return ArbeidsgiverVarselResendResult.RESENT
+        }
+
+        return try {
+            val varselData = hendelse.parseVarselData()
+            val notifikasjonInnhold =
+                varselData.notifikasjonInnhold
+                    ?: throw ArbeidsgiverVarselPermanentException(
+                        "ArbeidsgiverHendelse mangler feltet: data.notifikasjonInnhold",
+                    )
+            val hardDeleteDate =
+                varselData.motetidspunkt?.tidspunkt?.plusWeeks(WEEKS_BEFORE_DELETE)
+                    ?: LocalDateTime.now().plusWeeks(WEEKS_BEFORE_DELETE)
+            val sak = getOrCreateSak(hendelse, hardDeleteDate)
+
+            arbeidsgiverNotifikasjonService
+                .sendNotifikasjon(
+                    ArbeidsgiverNotifikasjonAltinnRessursInput(
+                        uuid = eksternReferanseUuid,
+                        virksomhetsnummer = hendelse.orgnummer,
+                        merkelapp = ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_MERKELAPP,
+                        messageText = notifikasjonInnhold.smsTekst,
+                        epostTittel = notifikasjonInnhold.epostTittel,
+                        epostHtmlBody = notifikasjonInnhold.epostBody,
+                        hardDeleteDate = hardDeleteDate,
+                        grupperingsid = sak.grupperingsid,
+                        link = hendelse.ressursUrl,
+                        ressursId = hendelse.ressursId,
+                        ressursUrl = hendelse.ressursUrl,
+                    ),
+                ) ?: throw ArbeidsgiverVarselRetryableException(
+                "ArbeidsgiverNotifikasjonService returnerte null ID ved utsending av arbeidsgivervarsel",
+            )
+
+            database.storeUtsendtVarsel(
+                PUtsendtVarsel(
+                    uuid = UUID.randomUUID().toString(),
+                    fnr = hendelse.arbeidstakerFnr,
+                    aktorId = null,
+                    narmesteLederFnr = null,
+                    orgnummer = hendelse.orgnummer,
+                    type = hendelse.type.name,
+                    kanal = Kanal.ARBEIDSGIVERNOTIFIKASJON.name,
+                    utsendtTidspunkt = LocalDateTime.now(),
+                    planlagtVarselId = null,
+                    eksternReferanse = hendelse.eksternReferanseId,
+                    ferdigstiltTidspunkt = null,
+                    arbeidsgivernotifikasjonMerkelapp = ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_MERKELAPP,
+                    isForcedLetter = false,
+                    journalpostId = null,
+                ),
+            )
+
+            ArbeidsgiverVarselResendResult.RESENT
+        } catch (exception: Exception) {
+            if (lagreFeiletUtsending) {
+                lagreIkkeUtsendtArbeidsgiverVarsel(hendelse, exception)
+            }
+            val sanitizedFeilmelding = exception.toSanitizedArbeidsgiverFeilmelding()
+            when (exception) {
+                is ArbeidsgiverVarselPermanentException ->
+                    log.error(
+                        "Permanent feil ved behandling av arbeidsgivervarsel: type={}, orgnummer={}, ressursId={}, kilde={}, feil={}",
+                        hendelse.type,
+                        hendelse.orgnummer,
+                        hendelse.ressursId,
+                        hendelse.kilde,
+                        sanitizedFeilmelding,
+                    )
+
+                else ->
+                    log.error(
+                        "Feilet ved behandling av arbeidsgivervarsel: type={}, orgnummer={}, ressursId={}, kilde={}, feil={}",
+                        hendelse.type,
+                        hendelse.orgnummer,
+                        hendelse.ressursId,
+                        hendelse.kilde,
+                        sanitizedFeilmelding,
+                    )
+            }
+            exception.toArbeidsgiverVarselResendResult()
+        }
+    }
+
+    private suspend fun getOrCreateSak(
+        hendelse: ArbeidsgiverNotifikasjonTilAltinnRessursHendelse,
+        hardDeleteDate: LocalDateTime,
+    ): ArbeidsgiverNotifikasjonSak {
+        val existingSak =
+            database.getPaagaaendeArbeidsgivernotifikasjonerSakByType(
+                ansattFnr = hendelse.arbeidstakerFnr,
+                virksomhetsnummer = hendelse.orgnummer,
+                type = SAK_TYPE_DIALOGMOTE_UTEN_LEDER,
+            )
+        if (existingSak != null) {
+            return ArbeidsgiverNotifikasjonSak(
+                id = existingSak.id,
+                grupperingsid = existingSak.grupperingsid,
+            )
+        }
+
+        val grupperingsid =
+            generateGrupperingsid(
+                arbeidstakerFnr = hendelse.arbeidstakerFnr,
+                virksomhetsnummer = hendelse.orgnummer,
+                saktype = SAK_TYPE_DIALOGMOTE_UTEN_LEDER,
+            )
+        val sakInput =
+            NySakAltinnInput(
+                grupperingsid = grupperingsid,
+                merkelapp = ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_MERKELAPP,
+                virksomhetsnummer = hendelse.orgnummer,
+                ansattFnr = hendelse.arbeidstakerFnr,
+                tittel = SAK_TITTEL_DIALOGMOTE,
+                lenke = hendelse.ressursUrl,
+                initiellStatus = SakStatus.MOTTATT,
+                hardDeleteDate = hardDeleteDate,
+                ressursId = hendelse.ressursId,
+            )
+        val eksternSakId =
+            arbeidsgiverNotifikasjonService.createNewSak(sakInput.toNySakMutation())
+                ?: throw ArbeidsgiverVarselRetryableException(
+                    "ArbeidsgiverNotifikasjonService returnerte null ID ved opprettelse av sak",
+                )
+        val sakId =
+            database.storeArbeidsgivernotifikasjonerSak(
+                sakInput = sakInput,
+                eksternSakId = eksternSakId,
+            )
+
+        return ArbeidsgiverNotifikasjonSak(
+            id = sakId,
+            grupperingsid = grupperingsid,
+        )
+    }
+
+    private fun generateGrupperingsid(
+        arbeidstakerFnr: String,
+        virksomhetsnummer: String,
+        saktype: String,
+    ): String {
+        val existingSaker =
+            database.countArbeidsgivernotifikasjonerSakerByType(
+                ansattFnr = arbeidstakerFnr,
+                virksomhetsnummer = virksomhetsnummer,
+                type = saktype,
+            )
+        val seed =
+            buildString {
+                append(virksomhetsnummer)
+                append('|')
+                append(saktype)
+                append('|')
+                append(if (existingSaker == 0) "1" else existingSaker + 1)
+                append('|')
+                append(arbeidstakerFnr)
+            }
+        return UUID.nameUUIDFromBytes(seed.toByteArray(StandardCharsets.UTF_8)).toString()
+    }
+
+    private fun lagreIkkeUtsendtArbeidsgiverVarsel(
+        hendelse: ArbeidsgiverNotifikasjonTilAltinnRessursHendelse,
+        exception: Throwable,
+    ) {
+        database.storeUtsendtVarselFeilet(
+            PUtsendtVarselFeilet(
+                uuid = UUID.randomUUID().toString(),
+                uuidEksternReferanse = hendelse.eksternReferanseId,
+                arbeidstakerFnr = hendelse.arbeidstakerFnr,
+                narmesteLederFnr = null,
+                orgnummer = hendelse.orgnummer,
+                hendelsetypeNavn = hendelse.type.name,
+                arbeidsgivernotifikasjonMerkelapp = ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_MERKELAPP,
+                brukernotifikasjonerMeldingType = null,
+                journalpostId = null,
+                kanal = Kanal.ARBEIDSGIVERNOTIFIKASJON.name,
+                feilmelding = exception.toSanitizedArbeidsgiverFeilmelding(),
+                utsendtForsokTidspunkt = LocalDateTime.now(),
+                isForcedLetter = false,
+                isResendt = false,
+                resendExhausted = false,
+                hendelseJson = hendelse.serializeSafely(),
+            ),
+        )
+    }
+
+    private fun ArbeidsgiverNotifikasjonTilAltinnRessursHendelse.parseVarselData() =
+        (data ?: throw ArbeidsgiverVarselPermanentException("ArbeidsgiverHendelse mangler feltet: data")).let { data ->
             runCatching {
                 data.toVarselData()
-            }.onFailure { exception ->
-                log.warn(
-                    "ArbeidsgiverVarselService stub klarte ikke å parse varselData for type={}, orgnummer={}, ressursId={}",
-                    hendelse.type,
-                    hendelse.orgnummer,
-                    hendelse.ressursId,
-                    exception.toVarselDataPath(),
-                )
             }.getOrElse { exception ->
-                throw IllegalArgumentException(
+                throw ArbeidsgiverVarselPermanentException(
                     "ArbeidsgiverHendelse har ugyldig format i feltet: ${exception.toVarselDataPath()}",
                 )
             }
-        val notifikasjonInnhold =
-            requireNotNull(varselData.notifikasjonInnhold) {
-                "ArbeidsgiverHendelse mangler feltet: data.notifikasjonInnhold"
-            }
-        with(notifikasjonInnhold) {
-            log.info(
-                "ArbeidsgiverVarselService stub kalt: type={}, orgnummer={}, kilde={}, ressursId={}, ressursUrl={}, eksternRefereanseId={}, harEpostTittel={}, epostTittelLengde={}, harEpostBody={}, epostBodyLengde={}, harSmsTekst={}, smsTekstLengde={}",
-                hendelse.type,
-                hendelse.orgnummer,
-                hendelse.kilde,
-                hendelse.ressursId,
-                hendelse.ressursUrl,
-                hendelse.eksternReferanseId,
-                epostTittel.isNotBlank(),
-                epostTittel.length,
-                epostBody.isNotBlank(),
-                epostBody.length,
-                smsTekst.isNotBlank(),
-                smsTekst.length,
-            )
         }
-    }
+
+    private fun ArbeidsgiverNotifikasjonTilAltinnRessursHendelse.serializeSafely(): String? =
+        runCatching { objectMapper.writeValueAsString(this) }
+            .onFailure { exception ->
+                log.error(
+                    "Kunne ikke serialisere arbeidsgiverhendelse for feillagring: type={}, orgnummer={}, ressursId={}, kilde={}, feil={}",
+                    type,
+                    orgnummer,
+                    ressursId,
+                    kilde,
+                    exception.toSanitizedArbeidsgiverFeilmelding(),
+                )
+            }.getOrNull()
 }
+
+private data class ArbeidsgiverNotifikasjonSak(
+    val id: String,
+    val grupperingsid: String,
+)
+
+enum class ArbeidsgiverVarselResendResult {
+    RESENT,
+    RETRYABLE_FAILURE,
+    PERMANENT_FAILURE,
+}
+
+private class ArbeidsgiverVarselRetryableException(
+    override val message: String,
+) : RuntimeException(message)
+
+private class ArbeidsgiverVarselPermanentException(
+    override val message: String,
+) : RuntimeException(message)
+
+private fun Throwable.toArbeidsgiverVarselResendResult(): ArbeidsgiverVarselResendResult =
+    when (this) {
+        is ArbeidsgiverVarselPermanentException -> ArbeidsgiverVarselResendResult.PERMANENT_FAILURE
+        else -> ArbeidsgiverVarselResendResult.RETRYABLE_FAILURE
+    }
+
+private fun PUtsendtVarselFeilet.toResendArbeidsgiverHendelse(): ArbeidsgiverNotifikasjonTilAltinnRessursHendelse {
+    val serializedHendelse =
+        hendelseJson ?: throw ArbeidsgiverVarselPermanentException("Mangler hendelseJson for feilet arbeidsgiverhendelse")
+    val rootNode =
+        runCatching { arbeidsgiverVarselObjectMapper.readTree(serializedHendelse) }
+            .getOrElse {
+                throw ArbeidsgiverVarselPermanentException("Kunne ikke lese hendelseJson for feilet arbeidsgiverhendelse")
+            }
+    val dataNode = rootNode.requireDataNode()
+    val hendelse =
+        runCatching { toArbeidsgiverNotifikasjonTilAltinnRessursHendelse() }
+            .getOrElse {
+                throw ArbeidsgiverVarselPermanentException("Kunne ikke deserialisere feilet arbeidsgiverhendelse")
+            }
+    hendelse.data = dataNode
+    return hendelse
+}
+
+private fun JsonNode.requireDataNode(): JsonNode =
+    get("data")
+        ?.takeUnless { it.isNull }
+        ?: throw ArbeidsgiverVarselPermanentException("ArbeidsgiverHendelse mangler feltet: data")
 
 private fun Throwable.toVarselDataPath(): String {
     val mappingPath =
@@ -72,3 +370,13 @@ private fun Throwable.toVarselDataPath(): String {
     }
     return "data.$mappingPath"
 }
+
+private fun Throwable.toSanitizedArbeidsgiverFeilmelding(): String =
+    when (this) {
+        is ArbeidsgiverVarselRetryableException,
+        is ArbeidsgiverVarselPermanentException,
+        -> message
+
+        is JsonMappingException -> "JsonMappingException i ${toVarselDataPath()}"
+        else -> "Uventet feil (${this::class.simpleName ?: "UnknownException"})"
+    } ?: "Uventet feil (UnknownException)"

--- a/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverVarselService.kt
@@ -271,10 +271,10 @@ class ArbeidsgiverVarselService(
         virksomhetsnummer = orgnummer,
         ansattFnr = arbeidstakerFnr,
         tittel = SAK_TITTEL_DIALOGMOTE,
-        lenke = ressursUrl,
         initiellStatus = SakStatus.MOTTATT,
         hardDeleteDate = hardDeleteDate,
         ressursId = ressursId,
+        ressursUrl = ressursUrl,
     )
 
     private fun ArbeidsgiverNotifikasjonTilAltinnRessursHendelse.requireNotifikasjonInnhold(): VarselDataNotifikasjonInnhold =

--- a/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverVarselService.kt
@@ -31,7 +31,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
 
-private const val WEEKS_BEFORE_DELETE = 4L
+private const val MONTHS_BEFORE_DELETE = 4L
 private const val SAK_TITTEL_DIALOGMOTE = "Dialogmøte"
 private val arbeidsgiverVarselObjectMapper = createObjectMapper()
 
@@ -288,7 +288,7 @@ class ArbeidsgiverVarselService(
             .now()
             .atStartOfDay()
             .plusDays(1)
-            .plusMonths(WEEKS_BEFORE_DELETE)
+            .plusMonths(MONTHS_BEFORE_DELETE)
 
     private fun ArbeidsgiverNotifikasjonTilAltinnRessursHendelse.toArbeidsgiverNotifikasjonAltinnRessursInput(
         eksternReferanseUuid: UUID,

--- a/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverVarselService.kt
@@ -23,6 +23,7 @@ import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.SakStatus
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.nio.charset.StandardCharsets
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -71,7 +72,8 @@ class ArbeidsgiverVarselService(
         val eksternReferanseUuid =
             runCatching { UUID.fromString(hendelse.eksternReferanseId) }
                 .getOrElse {
-                    val exception = ArbeidsgiverVarselPermanentException("ArbeidsgiverHendelse har ugyldig eksternReferanseId-format")
+                    val exception =
+                        ArbeidsgiverVarselPermanentException("ArbeidsgiverHendelse har ugyldig eksternReferanseId-format")
                     if (lagreFeiletUtsending) {
                         lagreIkkeUtsendtArbeidsgiverVarsel(hendelse, exception)
                     }
@@ -104,8 +106,11 @@ class ArbeidsgiverVarselService(
                         "ArbeidsgiverHendelse mangler feltet: data.notifikasjonInnhold",
                     )
             val hardDeleteDate =
-                varselData.motetidspunkt?.tidspunkt?.plusWeeks(WEEKS_BEFORE_DELETE)
-                    ?: LocalDateTime.now().plusWeeks(WEEKS_BEFORE_DELETE)
+                LocalDate
+                    .now()
+                    .atStartOfDay()
+                    .plusDays(1)
+                    .plusMonths(WEEKS_BEFORE_DELETE)
             val sak = getOrCreateSak(hendelse, hardDeleteDate)
 
             arbeidsgiverNotifikasjonService
@@ -331,7 +336,8 @@ private fun Throwable.toArbeidsgiverVarselResendResult(): ArbeidsgiverVarselRese
 
 private fun PUtsendtVarselFeilet.toResendArbeidsgiverHendelse(): ArbeidsgiverNotifikasjonTilAltinnRessursHendelse {
     val serializedHendelse =
-        hendelseJson ?: throw ArbeidsgiverVarselPermanentException("Mangler hendelseJson for feilet arbeidsgiverhendelse")
+        hendelseJson
+            ?: throw ArbeidsgiverVarselPermanentException("Mangler hendelseJson for feilet arbeidsgiverhendelse")
     val rootNode =
         runCatching { arbeidsgiverVarselObjectMapper.readTree(serializedHendelse) }
             .getOrElse {

--- a/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverVarselService.kt
@@ -274,7 +274,6 @@ class ArbeidsgiverVarselService(
         initiellStatus = SakStatus.MOTTATT,
         hardDeleteDate = hardDeleteDate,
         ressursId = ressursId,
-        ressursUrl = ressursUrl,
     )
 
     private fun ArbeidsgiverNotifikasjonTilAltinnRessursHendelse.requireNotifikasjonInnhold(): VarselDataNotifikasjonInnhold =

--- a/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverVarselService.kt
@@ -16,6 +16,7 @@ import no.nav.syfo.db.storeUtsendtVarsel
 import no.nav.syfo.db.storeUtsendtVarselFeilet
 import no.nav.syfo.kafka.common.createObjectMapper
 import no.nav.syfo.kafka.consumers.varselbus.domain.ArbeidsgiverNotifikasjonTilAltinnRessursHendelse
+import no.nav.syfo.kafka.consumers.varselbus.domain.VarselDataNotifikasjonInnhold
 import no.nav.syfo.kafka.consumers.varselbus.domain.toVarselData
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NySakAltinnInput
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.SAK_TYPE_DIALOGMOTE_UTEN_LEDER
@@ -70,116 +71,47 @@ class ArbeidsgiverVarselService(
         lagreFeiletUtsending: Boolean,
     ): ArbeidsgiverVarselResendResult {
         val eksternReferanseUuid =
-            runCatching { UUID.fromString(hendelse.eksternReferanseId) }
-                .getOrElse {
-                    val exception =
-                        ArbeidsgiverVarselPermanentException("ArbeidsgiverHendelse har ugyldig eksternReferanseId-format")
-                    if (lagreFeiletUtsending) {
-                        lagreIkkeUtsendtArbeidsgiverVarsel(hendelse, exception)
-                    }
-                    log.warn(
-                        "Avviser arbeidsgivervarsel med ugyldig eksternReferanseId: type={}, orgnummer={}, ressursId={}, kilde={}",
-                        hendelse.type,
-                        hendelse.orgnummer,
-                        hendelse.ressursId,
-                        hendelse.kilde,
-                    )
-                    return ArbeidsgiverVarselResendResult.PERMANENT_FAILURE
-                }
-
-        if (database.isUtsendtVarselStored(hendelse.eksternReferanseId, Kanal.ARBEIDSGIVERNOTIFIKASJON.name)) {
-            log.info(
-                "Arbeidsgivervarsel er allerede lagret som sendt: type={}, orgnummer={}, ressursId={}, kilde={}",
-                hendelse.type,
-                hendelse.orgnummer,
-                hendelse.ressursId,
-                hendelse.kilde,
-            )
-            return ArbeidsgiverVarselResendResult.RESENT
-        }
+            hendelse.parseEksternReferanseUuid(lagreFeiletUtsending)
+                ?: return ArbeidsgiverVarselResendResult.PERMANENT_FAILURE
+        if (hendelse.isAlreadyStoredAsSent()) return ArbeidsgiverVarselResendResult.RESENT
 
         return try {
-            val varselData = hendelse.parseVarselData()
-            val notifikasjonInnhold =
-                varselData.notifikasjonInnhold
-                    ?: throw ArbeidsgiverVarselPermanentException(
-                        "ArbeidsgiverHendelse mangler feltet: data.notifikasjonInnhold",
-                    )
-            val hardDeleteDate =
-                LocalDate
-                    .now()
-                    .atStartOfDay()
-                    .plusDays(1)
-                    .plusMonths(WEEKS_BEFORE_DELETE)
-            val sak = getOrCreateSak(hendelse, hardDeleteDate)
+            sendOgLagreArbeidsgiverVarsel(
+                hendelse = hendelse,
+                eksternReferanseUuid = eksternReferanseUuid,
+            )
+            ArbeidsgiverVarselResendResult.RESENT
+        } catch (exception: Exception) {
+            handleArbeidsgiverVarselFailure(
+                hendelse = hendelse,
+                lagreFeiletUtsending = lagreFeiletUtsending,
+                exception = exception,
+            )
+        }
+    }
 
-            arbeidsgiverNotifikasjonService
-                .sendNotifikasjon(
-                    ArbeidsgiverNotifikasjonAltinnRessursInput(
-                        uuid = eksternReferanseUuid,
-                        virksomhetsnummer = hendelse.orgnummer,
-                        merkelapp = ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_MERKELAPP,
-                        messageText = notifikasjonInnhold.smsTekst,
-                        epostTittel = notifikasjonInnhold.epostTittel,
-                        epostHtmlBody = notifikasjonInnhold.epostBody,
-                        hardDeleteDate = hardDeleteDate,
-                        grupperingsid = sak.grupperingsid,
-                        link = hendelse.ressursUrl,
-                        ressursId = hendelse.ressursId,
-                        ressursUrl = hendelse.ressursUrl,
-                    ),
-                ) ?: throw ArbeidsgiverVarselRetryableException(
+    private suspend fun sendOgLagreArbeidsgiverVarsel(
+        hendelse: ArbeidsgiverNotifikasjonTilAltinnRessursHendelse,
+        eksternReferanseUuid: UUID,
+    ) {
+        val notifikasjonInnhold = hendelse.requireNotifikasjonInnhold()
+        val hardDeleteDate = createHardDeleteDate()
+        val sak = getOrCreateSak(hendelse, hardDeleteDate)
+
+        arbeidsgiverNotifikasjonService
+            .sendNotifikasjon(
+                hendelse.toArbeidsgiverNotifikasjonAltinnRessursInput(
+                    eksternReferanseUuid = eksternReferanseUuid,
+                    notifikasjonInnhold = notifikasjonInnhold,
+                    sak = sak,
+                    hardDeleteDate = hardDeleteDate,
+                ),
+            )
+            ?: throw ArbeidsgiverVarselRetryableException(
                 "ArbeidsgiverNotifikasjonService returnerte null ID ved utsending av arbeidsgivervarsel",
             )
 
-            database.storeUtsendtVarsel(
-                PUtsendtVarsel(
-                    uuid = UUID.randomUUID().toString(),
-                    fnr = hendelse.arbeidstakerFnr,
-                    aktorId = null,
-                    narmesteLederFnr = null,
-                    orgnummer = hendelse.orgnummer,
-                    type = hendelse.type.name,
-                    kanal = Kanal.ARBEIDSGIVERNOTIFIKASJON.name,
-                    utsendtTidspunkt = LocalDateTime.now(),
-                    planlagtVarselId = null,
-                    eksternReferanse = hendelse.eksternReferanseId,
-                    ferdigstiltTidspunkt = null,
-                    arbeidsgivernotifikasjonMerkelapp = ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_MERKELAPP,
-                    isForcedLetter = false,
-                    journalpostId = null,
-                ),
-            )
-
-            ArbeidsgiverVarselResendResult.RESENT
-        } catch (exception: Exception) {
-            if (lagreFeiletUtsending) {
-                lagreIkkeUtsendtArbeidsgiverVarsel(hendelse, exception)
-            }
-            val sanitizedFeilmelding = exception.toSanitizedArbeidsgiverFeilmelding()
-            when (exception) {
-                is ArbeidsgiverVarselPermanentException ->
-                    log.error(
-                        "Permanent feil ved behandling av arbeidsgivervarsel: type={}, orgnummer={}, ressursId={}, kilde={}, feil={}",
-                        hendelse.type,
-                        hendelse.orgnummer,
-                        hendelse.ressursId,
-                        hendelse.kilde,
-                        sanitizedFeilmelding,
-                    )
-
-                else ->
-                    log.error(
-                        "Feilet ved behandling av arbeidsgivervarsel: type={}, orgnummer={}, ressursId={}, kilde={}, feil={}",
-                        hendelse.type,
-                        hendelse.orgnummer,
-                        hendelse.ressursId,
-                        hendelse.kilde,
-                        sanitizedFeilmelding,
-                    )
-            }
-            exception.toArbeidsgiverVarselResendResult()
-        }
+        database.storeUtsendtVarsel(hendelse.toPUtsendtVarsel())
     }
 
     private suspend fun getOrCreateSak(
@@ -199,24 +131,7 @@ class ArbeidsgiverVarselService(
             )
         }
 
-        val grupperingsid =
-            generateGrupperingsid(
-                arbeidstakerFnr = hendelse.arbeidstakerFnr,
-                virksomhetsnummer = hendelse.orgnummer,
-                saktype = SAK_TYPE_DIALOGMOTE_UTEN_LEDER,
-            )
-        val sakInput =
-            NySakAltinnInput(
-                grupperingsid = grupperingsid,
-                merkelapp = ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_MERKELAPP,
-                virksomhetsnummer = hendelse.orgnummer,
-                ansattFnr = hendelse.arbeidstakerFnr,
-                tittel = SAK_TITTEL_DIALOGMOTE,
-                lenke = hendelse.ressursUrl,
-                initiellStatus = SakStatus.MOTTATT,
-                hardDeleteDate = hardDeleteDate,
-                ressursId = hendelse.ressursId,
-            )
+        val sakInput = hendelse.toNySakAltinnInput(SAK_TYPE_DIALOGMOTE_UTEN_LEDER)
         val eksternSakId =
             arbeidsgiverNotifikasjonService.createNewSak(sakInput.toNySakMutation())
                 ?: throw ArbeidsgiverVarselRetryableException(
@@ -230,7 +145,7 @@ class ArbeidsgiverVarselService(
 
         return ArbeidsgiverNotifikasjonSak(
             id = sakId,
-            grupperingsid = grupperingsid,
+            sakInput.grupperingsid,
         )
     }
 
@@ -282,6 +197,141 @@ class ArbeidsgiverVarselService(
                 hendelseJson = hendelse.serializeSafely(),
             ),
         )
+    }
+
+    private fun ArbeidsgiverNotifikasjonTilAltinnRessursHendelse.parseEksternReferanseUuid(lagreFeiletUtsending: Boolean): UUID? =
+        runCatching { UUID.fromString(eksternReferanseId) }
+            .getOrElse {
+                val exception =
+                    ArbeidsgiverVarselPermanentException("ArbeidsgiverHendelse har ugyldig eksternReferanseId-format")
+                if (lagreFeiletUtsending) {
+                    lagreIkkeUtsendtArbeidsgiverVarsel(this, exception)
+                }
+                log.warn(
+                    "Avviser arbeidsgivervarsel med ugyldig eksternReferanseId: type={}, orgnummer={}, ressursId={}, kilde={}",
+                    type,
+                    orgnummer,
+                    ressursId,
+                    kilde,
+                )
+                null
+            }
+
+    private fun ArbeidsgiverNotifikasjonTilAltinnRessursHendelse.isAlreadyStoredAsSent(): Boolean {
+        val isStored = database.isUtsendtVarselStored(eksternReferanseId, Kanal.ARBEIDSGIVERNOTIFIKASJON.name)
+        if (isStored) {
+            log.info(
+                "Arbeidsgivervarsel er allerede lagret som sendt: type={}, orgnummer={}, ressursId={}, kilde={}",
+                type,
+                orgnummer,
+                ressursId,
+                kilde,
+            )
+        }
+        return isStored
+    }
+
+    private fun ArbeidsgiverNotifikasjonTilAltinnRessursHendelse.toNySakAltinnInput(sakType: String) =
+        NySakAltinnInput(
+            grupperingsid = generateGrupperingsid(arbeidstakerFnr, orgnummer, sakType),
+            merkelapp = ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_MERKELAPP,
+            virksomhetsnummer = orgnummer,
+            ansattFnr = arbeidstakerFnr,
+            tittel = SAK_TITTEL_DIALOGMOTE,
+            lenke = ressursUrl,
+            initiellStatus = SakStatus.MOTTATT,
+            hardDeleteDate = createHardDeleteDate(),
+            ressursId = ressursId,
+        )
+
+    private fun ArbeidsgiverNotifikasjonTilAltinnRessursHendelse.requireNotifikasjonInnhold(): VarselDataNotifikasjonInnhold =
+        parseVarselData().notifikasjonInnhold
+            ?: throw ArbeidsgiverVarselPermanentException(
+                "ArbeidsgiverHendelse mangler feltet: data.notifikasjonInnhold",
+            )
+
+    private fun createHardDeleteDate(): LocalDateTime =
+        LocalDate
+            .now()
+            .atStartOfDay()
+            .plusDays(1)
+            .plusMonths(WEEKS_BEFORE_DELETE)
+
+    private fun ArbeidsgiverNotifikasjonTilAltinnRessursHendelse.toArbeidsgiverNotifikasjonAltinnRessursInput(
+        eksternReferanseUuid: UUID,
+        notifikasjonInnhold: VarselDataNotifikasjonInnhold,
+        sak: ArbeidsgiverNotifikasjonSak,
+        hardDeleteDate: LocalDateTime,
+    ) = ArbeidsgiverNotifikasjonAltinnRessursInput(
+        uuid = eksternReferanseUuid,
+        virksomhetsnummer = orgnummer,
+        merkelapp = ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_MERKELAPP,
+        messageText = notifikasjonInnhold.smsTekst,
+        epostTittel = notifikasjonInnhold.epostTittel,
+        epostHtmlBody = notifikasjonInnhold.epostBody,
+        hardDeleteDate = hardDeleteDate,
+        grupperingsid = sak.grupperingsid,
+        link = ressursUrl,
+        ressursId = ressursId,
+        ressursUrl = ressursUrl,
+    )
+
+    private fun ArbeidsgiverNotifikasjonTilAltinnRessursHendelse.toPUtsendtVarsel() =
+        PUtsendtVarsel(
+            uuid = UUID.randomUUID().toString(),
+            fnr = arbeidstakerFnr,
+            aktorId = null,
+            narmesteLederFnr = null,
+            orgnummer = orgnummer,
+            type = type.name,
+            kanal = Kanal.ARBEIDSGIVERNOTIFIKASJON.name,
+            utsendtTidspunkt = LocalDateTime.now(),
+            planlagtVarselId = null,
+            eksternReferanse = eksternReferanseId,
+            ferdigstiltTidspunkt = null,
+            arbeidsgivernotifikasjonMerkelapp = ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_MERKELAPP,
+            isForcedLetter = false,
+            journalpostId = null,
+        )
+
+    private fun handleArbeidsgiverVarselFailure(
+        hendelse: ArbeidsgiverNotifikasjonTilAltinnRessursHendelse,
+        lagreFeiletUtsending: Boolean,
+        exception: Exception,
+    ): ArbeidsgiverVarselResendResult {
+        if (lagreFeiletUtsending) {
+            lagreIkkeUtsendtArbeidsgiverVarsel(hendelse, exception)
+        }
+        logArbeidsgiverVarselFailure(hendelse, exception)
+        return exception.toArbeidsgiverVarselResendResult()
+    }
+
+    private fun logArbeidsgiverVarselFailure(
+        hendelse: ArbeidsgiverNotifikasjonTilAltinnRessursHendelse,
+        exception: Exception,
+    ) {
+        val sanitizedFeilmelding = exception.toSanitizedArbeidsgiverFeilmelding()
+        when (exception) {
+            is ArbeidsgiverVarselPermanentException ->
+                log.error(
+                    "Permanent feil ved behandling av arbeidsgivervarsel: type={}, orgnummer={}, ressursId={}, kilde={}, feil={}",
+                    hendelse.type,
+                    hendelse.orgnummer,
+                    hendelse.ressursId,
+                    hendelse.kilde,
+                    sanitizedFeilmelding,
+                )
+
+            else ->
+                log.error(
+                    "Feilet ved behandling av arbeidsgivervarsel: type={}, orgnummer={}, ressursId={}, kilde={}, feil={}",
+                    hendelse.type,
+                    hendelse.orgnummer,
+                    hendelse.ressursId,
+                    hendelse.kilde,
+                    sanitizedFeilmelding,
+                )
+        }
     }
 
     private fun ArbeidsgiverNotifikasjonTilAltinnRessursHendelse.parseVarselData() =

--- a/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverVarselService.kt
@@ -6,6 +6,7 @@ import no.nav.syfo.ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_MERKELAPP
 import no.nav.syfo.db.DatabaseInterface
 import no.nav.syfo.db.countArbeidsgivernotifikasjonerSakerByType
 import no.nav.syfo.db.domain.Kanal
+import no.nav.syfo.db.domain.PSakInput
 import no.nav.syfo.db.domain.PUtsendtVarsel
 import no.nav.syfo.db.domain.PUtsendtVarselFeilet
 import no.nav.syfo.db.domain.toArbeidsgiverNotifikasjonTilAltinnRessursHendelse
@@ -14,11 +15,13 @@ import no.nav.syfo.db.isUtsendtVarselStored
 import no.nav.syfo.db.storeArbeidsgivernotifikasjonerSak
 import no.nav.syfo.db.storeUtsendtVarsel
 import no.nav.syfo.db.storeUtsendtVarselFeilet
+import no.nav.syfo.db.updateArbeidsgivernotifikasjonerSakStatusAndHardDeleteDate
 import no.nav.syfo.kafka.common.createObjectMapper
 import no.nav.syfo.kafka.consumers.varselbus.domain.ArbeidsgiverNotifikasjonTilAltinnRessursHendelse
 import no.nav.syfo.kafka.consumers.varselbus.domain.VarselDataNotifikasjonInnhold
 import no.nav.syfo.kafka.consumers.varselbus.domain.toVarselData
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NySakAltinnInput
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NyStatusSakInput
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.SAK_TYPE_DIALOGMOTE_UTEN_LEDER
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.SakStatus
 import org.slf4j.Logger
@@ -125,13 +128,17 @@ class ArbeidsgiverVarselService(
                 type = SAK_TYPE_DIALOGMOTE_UTEN_LEDER,
             )
         if (existingSak != null) {
+            updateExistingSakHardDeleteDate(
+                existingSak = existingSak,
+                hardDeleteDate = hardDeleteDate,
+            )
             return ArbeidsgiverNotifikasjonSak(
                 id = existingSak.id,
                 grupperingsid = existingSak.grupperingsid,
             )
         }
 
-        val sakInput = hendelse.toNySakAltinnInput(SAK_TYPE_DIALOGMOTE_UTEN_LEDER)
+        val sakInput = hendelse.toNySakAltinnInput(SAK_TYPE_DIALOGMOTE_UTEN_LEDER, hardDeleteDate)
         val eksternSakId =
             arbeidsgiverNotifikasjonService.createNewSak(sakInput.toNySakMutation())
                 ?: throw ArbeidsgiverVarselRetryableException(
@@ -146,6 +153,30 @@ class ArbeidsgiverVarselService(
         return ArbeidsgiverNotifikasjonSak(
             id = sakId,
             sakInput.grupperingsid,
+        )
+    }
+
+    private suspend fun updateExistingSakHardDeleteDate(
+        existingSak: PSakInput,
+        hardDeleteDate: LocalDateTime,
+    ) {
+        val sakStatus = SakStatus.valueOf(existingSak.initiellStatus.name)
+
+        arbeidsgiverNotifikasjonService.nyStatusSak(
+            NyStatusSakInput(
+                grupperingsId = existingSak.grupperingsid,
+                merkelapp = existingSak.merkelapp,
+                sakStatus = sakStatus,
+                oppdatertHardDeleteDateTime = hardDeleteDate,
+            ),
+        ) ?: throw ArbeidsgiverVarselRetryableException(
+            "ArbeidsgiverNotifikasjonService returnerte null ID ved oppdatering av hardDeleteDate på sak",
+        )
+
+        database.updateArbeidsgivernotifikasjonerSakStatusAndHardDeleteDate(
+            sakId = existingSak.id,
+            sakStatus = sakStatus,
+            hardDeleteDate = hardDeleteDate,
         )
     }
 
@@ -231,18 +262,20 @@ class ArbeidsgiverVarselService(
         return isStored
     }
 
-    private fun ArbeidsgiverNotifikasjonTilAltinnRessursHendelse.toNySakAltinnInput(sakType: String) =
-        NySakAltinnInput(
-            grupperingsid = generateGrupperingsid(arbeidstakerFnr, orgnummer, sakType),
-            merkelapp = ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_MERKELAPP,
-            virksomhetsnummer = orgnummer,
-            ansattFnr = arbeidstakerFnr,
-            tittel = SAK_TITTEL_DIALOGMOTE,
-            lenke = ressursUrl,
-            initiellStatus = SakStatus.MOTTATT,
-            hardDeleteDate = createHardDeleteDate(),
-            ressursId = ressursId,
-        )
+    private fun ArbeidsgiverNotifikasjonTilAltinnRessursHendelse.toNySakAltinnInput(
+        sakType: String,
+        hardDeleteDate: LocalDateTime,
+    ) = NySakAltinnInput(
+        grupperingsid = generateGrupperingsid(arbeidstakerFnr, orgnummer, sakType),
+        merkelapp = ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_MERKELAPP,
+        virksomhetsnummer = orgnummer,
+        ansattFnr = arbeidstakerFnr,
+        tittel = SAK_TITTEL_DIALOGMOTE,
+        lenke = ressursUrl,
+        initiellStatus = SakStatus.MOTTATT,
+        hardDeleteDate = hardDeleteDate,
+        ressursId = ressursId,
+    )
 
     private fun ArbeidsgiverNotifikasjonTilAltinnRessursHendelse.requireNotifikasjonInnhold(): VarselDataNotifikasjonInnhold =
         parseVarselData().notifikasjonInnhold

--- a/src/main/kotlin/no/nav/syfo/service/SenderFacade.kt
+++ b/src/main/kotlin/no/nav/syfo/service/SenderFacade.kt
@@ -232,12 +232,14 @@ class SenderFacade(
         virksomhetsnummer: String,
         type: String,
         mottakerType: MottakerType,
+        ressursId: String? = null,
     ): PSakInput? =
         database.getPaagaaendeArbeidsgivernotifikasjonerSakByType(
             ansattFnr = ansattFnr,
             virksomhetsnummer = virksomhetsnummer,
             type = type,
             mottakerType = mottakerType,
+            ressursId = ressursId,
         )
 
     suspend fun nyStatusSak(

--- a/src/main/kotlin/no/nav/syfo/service/SenderFacade.kt
+++ b/src/main/kotlin/no/nav/syfo/service/SenderFacade.kt
@@ -35,6 +35,7 @@ import no.nav.syfo.kafka.producers.dinesykmeldte.domain.DineSykmeldteVarsel
 import no.nav.syfo.kafka.producers.dittsykefravaer.DittSykefravaerMeldingKafkaProducer
 import no.nav.syfo.kafka.producers.dittsykefravaer.domain.DittSykefravaerVarsel
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.KalenderTilstand
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.MottakerType
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NyKalenderInput
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NySakInput
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NyStatusSakInput
@@ -223,17 +224,20 @@ class SenderFacade(
         database.getPaagaaendeArbeidsgivernotifikasjonerSak(
             narmestelederId = narmesteLederId,
             merkelapp = merkelapp,
+            mottakerType = MottakerType.NAERMESTE_LEDER,
         )
 
     fun getPaagaaendeSakByType(
         ansattFnr: String,
         virksomhetsnummer: String,
         type: String,
+        mottakerType: MottakerType,
     ): PSakInput? =
         database.getPaagaaendeArbeidsgivernotifikasjonerSakByType(
             ansattFnr = ansattFnr,
             virksomhetsnummer = virksomhetsnummer,
             type = type,
+            mottakerType = mottakerType,
         )
 
     suspend fun nyStatusSak(

--- a/src/main/resources/db/migration/V43__add_index_utsendt_varsel_kanal_ekstern_ref.sql
+++ b/src/main/resources/db/migration/V43__add_index_utsendt_varsel_kanal_ekstern_ref.sql
@@ -1,0 +1,1 @@
+CREATE INDEX utsendt_varsel_kanal_ekstern_ref_index ON UTSENDT_VARSEL (kanal, ekstern_ref);

--- a/src/main/resources/db/migration/V44__alter_arbeidsgivernotifikasjoner_sak_lenke_nullable_add_mottaker_type.sql
+++ b/src/main/resources/db/migration/V44__alter_arbeidsgivernotifikasjoner_sak_lenke_nullable_add_mottaker_type.sql
@@ -1,0 +1,5 @@
+ALTER TABLE ARBEIDSGIVERNOTIFIKASJONER_SAK
+    ALTER COLUMN lenke DROP NOT NULL,
+    ADD COLUMN mottaker_type TEXT NOT NULL DEFAULT 'NAERMESTE_LEDER',
+    ADD CONSTRAINT arbeidsgivernotifikasjoner_sak_mottaker_type_check
+        CHECK (mottaker_type IN ('NAERMESTE_LEDER', 'ALTINN')) NOT VALID;

--- a/src/test/kotlin/no/nav/syfo/db/UtsendtVarselFeiletDAOSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/db/UtsendtVarselFeiletDAOSpek.kt
@@ -58,21 +58,35 @@ class UtsendtVarselFeiletDAOSpek :
 
                 embeddedDatabase.storeUtsendtVarselFeilet(varsel)
                 embeddedDatabase.storeUtsendtVarsel(
-                    PUtsendtVarsel(
-                        uuid = UUID.randomUUID().toString(),
+                    utsendtArbeidsgivervarsel(
                         fnr = fnr,
-                        aktorId = null,
-                        narmesteLederFnr = null,
-                        orgnummer = "999888777",
-                        type = HendelseType.AG_VARSEL_ALTINN_RESSURS.name,
-                        kanal = Kanal.ARBEIDSGIVERNOTIFIKASJON.name,
-                        utsendtTidspunkt = LocalDateTime.now(),
-                        planlagtVarselId = null,
                         eksternReferanse = eksternReferanse,
-                        ferdigstiltTidspunkt = null,
                         arbeidsgivernotifikasjonMerkelapp = varsel.arbeidsgivernotifikasjonMerkelapp,
-                        isForcedLetter = false,
-                        journalpostId = null,
+                    ),
+                )
+
+                embeddedDatabase.fetchUtsendtArbeidsgivernotifikasjonVarselFeilet().size shouldBe 0
+            }
+
+            it("Henter ikke AG-feiletvarsel når utsendt varsel med samme ekstern referanse er eldre enn retry-cutoff") {
+                val fnr = "12121212121"
+                val eksternReferanse = UUID.randomUUID().toString()
+                val varsel =
+                    ikkeUtsendtVarsel(fnr, """{"type":"AG_VARSEL_ALTINN_RESSURS","data":{"foo":"bar"}}""")
+                        .copy(
+                            uuidEksternReferanse = eksternReferanse,
+                            orgnummer = "999888777",
+                            kanal = Kanal.ARBEIDSGIVERNOTIFIKASJON.name,
+                            hendelsetypeNavn = HendelseType.AG_VARSEL_ALTINN_RESSURS.name,
+                        )
+
+                embeddedDatabase.storeUtsendtVarselFeilet(varsel)
+                embeddedDatabase.storeUtsendtVarsel(
+                    utsendtArbeidsgivervarsel(
+                        fnr = fnr,
+                        eksternReferanse = eksternReferanse,
+                        arbeidsgivernotifikasjonMerkelapp = varsel.arbeidsgivernotifikasjonMerkelapp,
+                        utsendtTidspunkt = LocalDateTime.of(2025, 5, 18, 23, 59),
                     ),
                 )
 
@@ -101,6 +115,28 @@ private fun ikkeUtsendtVarsel(
         isForcedLetter = false,
         hendelseJson = hendelseJson,
     )
+
+private fun utsendtArbeidsgivervarsel(
+    fnr: String,
+    eksternReferanse: String,
+    arbeidsgivernotifikasjonMerkelapp: String?,
+    utsendtTidspunkt: LocalDateTime = LocalDateTime.now(),
+) = PUtsendtVarsel(
+    uuid = UUID.randomUUID().toString(),
+    fnr = fnr,
+    aktorId = null,
+    narmesteLederFnr = null,
+    orgnummer = "999888777",
+    type = HendelseType.AG_VARSEL_ALTINN_RESSURS.name,
+    kanal = Kanal.ARBEIDSGIVERNOTIFIKASJON.name,
+    utsendtTidspunkt = utsendtTidspunkt,
+    planlagtVarselId = null,
+    eksternReferanse = eksternReferanse,
+    ferdigstiltTidspunkt = null,
+    arbeidsgivernotifikasjonMerkelapp = arbeidsgivernotifikasjonMerkelapp,
+    isForcedLetter = false,
+    journalpostId = null,
+)
 
 private fun DatabaseInterface.skalHaLagretIkkeUtsendtVarsel(
     type: HendelseType,

--- a/src/test/kotlin/no/nav/syfo/db/UtsendtVarselFeiletDAOSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/db/UtsendtVarselFeiletDAOSpek.kt
@@ -1,8 +1,10 @@
 package no.nav.syfo.db
 
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
 import no.nav.syfo.ARBEIDSGIVERNOTIFIKASJON_OPPFOLGING_MERKELAPP
 import no.nav.syfo.db.domain.Kanal
+import no.nav.syfo.db.domain.PUtsendtVarsel
 import no.nav.syfo.db.domain.PUtsendtVarselFeilet
 import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType
 import no.nav.syfo.testutil.EmbeddedDatabase
@@ -29,6 +31,52 @@ class UtsendtVarselFeiletDAOSpek :
                     fnr,
                     hendelseJson,
                 )
+            }
+
+            it("Nullstiller hendelseJson når feilet varsel markeres som resendt") {
+                val fnr = "12121212121"
+                val hendelseJson = """{"type":"AG_VARSEL_ALTINN_RESSURS","data":{"foo":"bar"}}"""
+                val varsel = ikkeUtsendtVarsel(fnr, hendelseJson).copy(hendelsetypeNavn = HendelseType.AG_VARSEL_ALTINN_RESSURS.name)
+
+                embeddedDatabase.storeUtsendtVarselFeilet(varsel)
+                embeddedDatabase.updateUtsendtVarselFeiletToResendt(varsel.uuid, nullstillHendelseJson = true)
+
+                embeddedDatabase.fetchUtsendtVarselFeiletByFnr(fnr).single().hendelseJson shouldBe null
+            }
+
+            it("Henter ikke AG-feiletvarsel som allerede finnes i UTSENDT_VARSEL") {
+                val fnr = "12121212121"
+                val eksternReferanse = UUID.randomUUID().toString()
+                val varsel =
+                    ikkeUtsendtVarsel(fnr, """{"type":"AG_VARSEL_ALTINN_RESSURS","data":{"foo":"bar"}}""")
+                        .copy(
+                            uuidEksternReferanse = eksternReferanse,
+                            orgnummer = "999888777",
+                            kanal = Kanal.ARBEIDSGIVERNOTIFIKASJON.name,
+                            hendelsetypeNavn = HendelseType.AG_VARSEL_ALTINN_RESSURS.name,
+                        )
+
+                embeddedDatabase.storeUtsendtVarselFeilet(varsel)
+                embeddedDatabase.storeUtsendtVarsel(
+                    PUtsendtVarsel(
+                        uuid = UUID.randomUUID().toString(),
+                        fnr = fnr,
+                        aktorId = null,
+                        narmesteLederFnr = null,
+                        orgnummer = "999888777",
+                        type = HendelseType.AG_VARSEL_ALTINN_RESSURS.name,
+                        kanal = Kanal.ARBEIDSGIVERNOTIFIKASJON.name,
+                        utsendtTidspunkt = LocalDateTime.now(),
+                        planlagtVarselId = null,
+                        eksternReferanse = eksternReferanse,
+                        ferdigstiltTidspunkt = null,
+                        arbeidsgivernotifikasjonMerkelapp = varsel.arbeidsgivernotifikasjonMerkelapp,
+                        isForcedLetter = false,
+                        journalpostId = null,
+                    ),
+                )
+
+                embeddedDatabase.fetchUtsendtArbeidsgivernotifikasjonVarselFeilet().size shouldBe 0
             }
         }
     })

--- a/src/test/kotlin/no/nav/syfo/job/ResendFailedVarslerJobTest.kt
+++ b/src/test/kotlin/no/nav/syfo/job/ResendFailedVarslerJobTest.kt
@@ -1,6 +1,7 @@
 package no.nav.syfo.job
 
 import io.kotest.core.spec.style.DescribeSpec
+import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -12,9 +13,15 @@ import no.nav.syfo.db.domain.PUtsendtVarselFeilet
 import no.nav.syfo.db.domain.toArbeidstakerHendelse
 import no.nav.syfo.db.fetchUtsendtBrukernotifikasjonVarselFeilet
 import no.nav.syfo.db.fetchUtsendtDokDistVarselFeilet
+import no.nav.syfo.db.fetchUtsendtVarselFeiletByFnr
 import no.nav.syfo.db.setUtsendtVarselToFerdigstilt
 import no.nav.syfo.db.storeUtsendtVarsel
 import no.nav.syfo.db.storeUtsendtVarselFeilet
+import no.nav.syfo.kafka.common.createObjectMapper
+import no.nav.syfo.kafka.consumers.varselbus.domain.ArbeidsgiverNotifikasjonTilAltinnRessursHendelse
+import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType
+import no.nav.syfo.service.ArbeidsgiverVarselResendResult
+import no.nav.syfo.service.ArbeidsgiverVarselService
 import no.nav.syfo.service.DialogmoteInnkallingSykmeldtVarselService
 import no.nav.syfo.service.KartleggingssporsmalVarselService
 import no.nav.syfo.service.MerVeiledningVarselService
@@ -33,9 +40,11 @@ class ResendFailedVarslerJobTest :
         val merVeiledningVarselService = mockk<MerVeiledningVarselService>(relaxed = true)
         val kartleggingVarselService = mockk<KartleggingssporsmalVarselService>(relaxed = true)
         val senderFacade = mockk<SenderFacade>(relaxed = true)
+        val arbeidsgiverVarselService = mockk<ArbeidsgiverVarselService>(relaxed = true)
 
         beforeTest {
             embeddedDatabase.dropData()
+            clearAllMocks()
             coEvery { motebehovVarselService.resendVarselTilBrukernotifikasjoner(any()) } returns true
             coEvery { motebehovVarselService.resendVarselTilArbeidsgiverNotifikasjon(any()) } returns true
             every {
@@ -43,6 +52,7 @@ class ResendFailedVarslerJobTest :
             } returns true
             coEvery { merVeiledningVarselService.resendDigitaltVarselTilArbeidstaker(any()) } returns true
             coEvery { senderFacade.sendBrevTilFysiskPrint(any(), any(), any(), any(), any()) } returns true
+            coEvery { arbeidsgiverVarselService.resendVarselTilArbeidsgiver(any()) } returns ArbeidsgiverVarselResendResult.RESENT
         }
 
         val job =
@@ -53,6 +63,7 @@ class ResendFailedVarslerJobTest :
                 merVeiledningVarselService = merVeiledningVarselService,
                 kartleggingVarselService = kartleggingVarselService,
                 senderFacade = senderFacade,
+                arbeidsgiverVarselService = arbeidsgiverVarselService,
             )
 
         describe("Resend brukernotifikasjon varsler") {
@@ -437,5 +448,158 @@ class ResendFailedVarslerJobTest :
 
                 result shouldBeEqualTo 0
             }
+
+            it("Resends failed AG_VARSEL_ALTINN_RESSURS and clears hendelseJson after success") {
+                val failedVarsel = failedArbeidsgiverAltinnVarsel()
+
+                embeddedDatabase.storeUtsendtVarselFeilet(failedVarsel)
+
+                val result = runBlocking { job.resendFailedArbeidsgivernotifikasjonVarsler() }
+
+                result shouldBeEqualTo 1
+                val storedFailedVarsel =
+                    embeddedDatabase
+                        .fetchUtsendtVarselFeiletByFnr(failedVarsel.arbeidstakerFnr)
+                        .first { it.uuid == failedVarsel.uuid }
+                storedFailedVarsel.isResendt shouldBeEqualTo true
+                storedFailedVarsel.hendelseJson shouldBeEqualTo null
+                coVerify(exactly = 1) { arbeidsgiverVarselService.resendVarselTilArbeidsgiver(any()) }
+            }
+
+            it("Does not pick failed AG_VARSEL_ALTINN_RESSURS for resend when varsel is already stored as sent") {
+                val failedVarsel = failedArbeidsgiverAltinnVarsel()
+                val utsendtVarsel =
+                    PUtsendtVarsel(
+                        uuid = UUID.randomUUID().toString(),
+                        fnr = failedVarsel.arbeidstakerFnr,
+                        aktorId = null,
+                        narmesteLederFnr = null,
+                        orgnummer = failedVarsel.orgnummer,
+                        type = failedVarsel.hendelsetypeNavn,
+                        kanal = "ARBEIDSGIVERNOTIFIKASJON",
+                        utsendtTidspunkt = LocalDateTime.now(),
+                        planlagtVarselId = null,
+                        eksternReferanse = failedVarsel.uuidEksternReferanse,
+                        ferdigstiltTidspunkt = null,
+                        arbeidsgivernotifikasjonMerkelapp = failedVarsel.arbeidsgivernotifikasjonMerkelapp,
+                        isForcedLetter = false,
+                        journalpostId = null,
+                    )
+
+                embeddedDatabase.storeUtsendtVarselFeilet(failedVarsel)
+                embeddedDatabase.storeUtsendtVarsel(utsendtVarsel)
+
+                val result = runBlocking { job.resendFailedArbeidsgivernotifikasjonVarsler() }
+
+                result shouldBeEqualTo 0
+                val storedFailedVarsel =
+                    embeddedDatabase
+                        .fetchUtsendtVarselFeiletByFnr(failedVarsel.arbeidstakerFnr)
+                        .first { it.uuid == failedVarsel.uuid }
+                storedFailedVarsel.isResendt shouldBeEqualTo false
+                storedFailedVarsel.hendelseJson shouldBeEqualTo failedVarsel.hendelseJson
+                coVerify(exactly = 0) { arbeidsgiverVarselService.resendVarselTilArbeidsgiver(any()) }
+            }
+
+            it("Keeps hendelseJson when resend of AG_VARSEL_ALTINN_RESSURS still fails") {
+                val failedVarsel = failedArbeidsgiverAltinnVarsel()
+                coEvery {
+                    arbeidsgiverVarselService.resendVarselTilArbeidsgiver(any())
+                } returns ArbeidsgiverVarselResendResult.RETRYABLE_FAILURE
+
+                embeddedDatabase.storeUtsendtVarselFeilet(failedVarsel)
+
+                val result = runBlocking { job.resendFailedArbeidsgivernotifikasjonVarsler() }
+
+                result shouldBeEqualTo 0
+                val storedFailedVarsel =
+                    embeddedDatabase
+                        .fetchUtsendtVarselFeiletByFnr(failedVarsel.arbeidstakerFnr)
+                        .first { it.uuid == failedVarsel.uuid }
+                storedFailedVarsel.isResendt shouldBeEqualTo false
+                storedFailedVarsel.hendelseJson shouldBeEqualTo failedVarsel.hendelseJson
+            }
+
+            it("Marks AG_VARSEL_ALTINN_RESSURS as resend exhausted when service returns permanent failure") {
+                val failedVarsel = failedArbeidsgiverAltinnVarsel()
+                coEvery {
+                    arbeidsgiverVarselService.resendVarselTilArbeidsgiver(any())
+                } returns ArbeidsgiverVarselResendResult.PERMANENT_FAILURE
+
+                embeddedDatabase.storeUtsendtVarselFeilet(failedVarsel)
+
+                val result = runBlocking { job.resendFailedArbeidsgivernotifikasjonVarsler() }
+
+                result shouldBeEqualTo 0
+                val storedFailedVarsel =
+                    embeddedDatabase
+                        .fetchUtsendtVarselFeiletByFnr(failedVarsel.arbeidstakerFnr)
+                        .first { it.uuid == failedVarsel.uuid }
+                storedFailedVarsel.resendExhausted shouldBeEqualTo true
+                storedFailedVarsel.isResendt shouldBeEqualTo false
+                storedFailedVarsel.hendelseJson shouldBeEqualTo failedVarsel.hendelseJson
+            }
+
+            it("Marks AG_VARSEL_ALTINN_RESSURS as resend exhausted when uuidEksternReferanse mangler") {
+                val failedVarsel = failedArbeidsgiverAltinnVarsel().copy(uuidEksternReferanse = null)
+
+                embeddedDatabase.storeUtsendtVarselFeilet(failedVarsel)
+
+                val result = runBlocking { job.resendFailedArbeidsgivernotifikasjonVarsler() }
+
+                result shouldBeEqualTo 0
+                val storedFailedVarsel =
+                    embeddedDatabase
+                        .fetchUtsendtVarselFeiletByFnr(failedVarsel.arbeidstakerFnr)
+                        .first { it.uuid == failedVarsel.uuid }
+                storedFailedVarsel.resendExhausted shouldBeEqualTo true
+                storedFailedVarsel.isResendt shouldBeEqualTo false
+                storedFailedVarsel.hendelseJson shouldBeEqualTo failedVarsel.hendelseJson
+                coVerify(exactly = 0) { arbeidsgiverVarselService.resendVarselTilArbeidsgiver(any()) }
+            }
         }
     })
+
+private fun failedArbeidsgiverAltinnVarsel(
+    eksternReferanseId: String = UUID.randomUUID().toString(),
+    hendelseJson: String? = null,
+): PUtsendtVarselFeilet {
+    val hendelse =
+        ArbeidsgiverNotifikasjonTilAltinnRessursHendelse(
+            type = HendelseType.AG_VARSEL_ALTINN_RESSURS,
+            ferdigstill = false,
+            data =
+                createObjectMapper().readTree(
+                    """
+                    {
+                      "notifikasjonInnhold": {
+                        "epostTittel": "Dialogmøte",
+                        "epostBody": "Du har mottatt et nytt dialogmøtevarsel",
+                        "smsTekst": "Du har mottatt et nytt dialogmøtevarsel"
+                      }
+                    }
+                    """.trimIndent(),
+                ),
+            arbeidstakerFnr = "12121212121",
+            eksternReferanseId = eksternReferanseId,
+            kilde = "dokumentporten.dialogmote",
+            orgnummer = "999888777",
+            ressursId = "nav_syfo_dialogmote",
+            ressursUrl = "https://www.altinn.no",
+        )
+    return PUtsendtVarselFeilet(
+        uuid = UUID.randomUUID().toString(),
+        uuidEksternReferanse = hendelse.eksternReferanseId,
+        arbeidstakerFnr = hendelse.arbeidstakerFnr,
+        narmesteLederFnr = null,
+        orgnummer = hendelse.orgnummer,
+        hendelsetypeNavn = hendelse.type.name,
+        arbeidsgivernotifikasjonMerkelapp = "Dialogmøte",
+        brukernotifikasjonerMeldingType = null,
+        journalpostId = null,
+        kanal = "ARBEIDSGIVERNOTIFIKASJON",
+        feilmelding = "noe gikk galt",
+        utsendtForsokTidspunkt = LocalDateTime.now().minusHours(2),
+        hendelseJson = hendelseJson ?: createObjectMapper().writeValueAsString(hendelse),
+    )
+}

--- a/src/test/kotlin/no/nav/syfo/kafka/consumers/varselbus/domain/EsyfovarselHendelseTest.kt
+++ b/src/test/kotlin/no/nav/syfo/kafka/consumers/varselbus/domain/EsyfovarselHendelseTest.kt
@@ -1,6 +1,7 @@
 package no.nav.syfo.kafka.consumers.varselbus.domain
 
 import com.fasterxml.jackson.module.kotlin.readValue
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import no.nav.syfo.kafka.common.createObjectMapper
@@ -47,6 +48,27 @@ class EsyfovarselHendelseTest :
                 val hendelse: EsyfovarselHendelse = objectMapper.readValue(arbeidsgiverHendelseJson)
 
                 hendelse.isArbeidstakerHendelse() shouldBe false
+            }
+
+            it("feiler deserialisering når arbeidstakerFnr mangler for arbeidsgiverhendelse") {
+                val jsonUtenArbeidstakerFnr =
+                    """
+                    {
+                      "@type": "ArbeidsgiverNotifikasjonTilAltinnRessursHendelse",
+                      "type": "AG_VARSEL_ALTINN_RESSURS",
+                      "ferdigstill": false,
+                      "data": {},
+                      "orgnummer": "999888777",
+                      "ressursId": "nav_syfo_dialogmote",
+                      "ressursUrl": "https://www.altinn.no",
+                      "kilde": "dokumentporten.dialogmote",
+                      "eksternReferanseId": "123e4567-e89b-12d3-a456-426614174000"
+                    }
+                    """.trimIndent()
+
+                shouldThrow<Exception> {
+                    objectMapper.readValue<EsyfovarselHendelse>(jsonUtenArbeidstakerFnr)
+                }
             }
         }
     })

--- a/src/test/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/domain/NySakInputSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/domain/NySakInputSpek.kt
@@ -43,7 +43,6 @@ class NySakInputSpek :
                         initiellStatus = SakStatus.MOTTATT,
                         hardDeleteDate = hardDeleteDate,
                         ressursId = "nav_syfo_dialogmote",
-                        ressursUrl = "https://www.altinn.no",
                     )
 
                 val mutation = input.toNySakMutation()

--- a/src/test/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/domain/NySakInputSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/domain/NySakInputSpek.kt
@@ -1,0 +1,54 @@
+package no.nav.syfo.producer.arbeidsgivernotifikasjon.domain
+
+import com.apollographql.apollo.api.Optional
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import java.time.LocalDateTime
+import java.util.UUID
+
+class NySakInputSpek :
+    DescribeSpec({
+        val hardDeleteDate = LocalDateTime.now().plusDays(1)
+
+        describe("toNySakMutation") {
+            it("sender lenke for nærmeste leder-saker") {
+                val lenke = "https://www.nav.no"
+                val input =
+                    NySakNarmesteLederInput(
+                        grupperingsid = UUID.randomUUID().toString(),
+                        narmestelederId = "narmeste-leder-id",
+                        merkelapp = "Oppfølging",
+                        virksomhetsnummer = "999999999",
+                        narmesteLederFnr = "12345678910",
+                        ansattFnr = "10987654321",
+                        tittel = "Oppfølging av sykmeldt",
+                        lenke = lenke,
+                        initiellStatus = SakStatus.MOTTATT,
+                        hardDeleteDate = hardDeleteDate,
+                    )
+
+                val mutation = input.toNySakMutation()
+
+                mutation.lenke.getOrThrow() shouldBe lenke
+            }
+
+            it("utelater lenke for Altinn-saker") {
+                val input =
+                    NySakAltinnInput(
+                        grupperingsid = UUID.randomUUID().toString(),
+                        merkelapp = "Dialogmøte",
+                        virksomhetsnummer = "999999999",
+                        ansattFnr = "10987654321",
+                        tittel = "Dialogmøte",
+                        initiellStatus = SakStatus.MOTTATT,
+                        hardDeleteDate = hardDeleteDate,
+                        ressursId = "nav_syfo_dialogmote",
+                        ressursUrl = "https://www.altinn.no",
+                    )
+
+                val mutation = input.toNySakMutation()
+
+                mutation.lenke shouldBe Optional.Absent
+            }
+        }
+    })

--- a/src/test/kotlin/no/nav/syfo/service/ArbeidsgiverVarselServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/service/ArbeidsgiverVarselServiceTest.kt
@@ -23,6 +23,7 @@ import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NySakAltinnInput
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.SAK_TYPE_DIALOGMOTE_UTEN_LEDER
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.SakStatus
 import no.nav.syfo.testutil.EmbeddedDatabase
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -69,7 +70,12 @@ class ArbeidsgiverVarselServiceTest :
                 sak?.ressursId shouldBe hendelse.ressursId
                 inputSlot.single().uuid shouldBe UUID.fromString(hendelse.eksternReferanseId)
                 inputSlot.single().grupperingsid shouldBe sak?.grupperingsid
-                inputSlot.single().hardDeleteDate shouldBe hendelseMotetidspunkt().plusWeeks(4)
+                inputSlot.single().hardDeleteDate shouldBe
+                    LocalDate
+                        .now()
+                        .atStartOfDay()
+                        .plusDays(1)
+                        .plusMonths(4)
             }
 
             it("gjenbruker eksisterende pågående sak") {

--- a/src/test/kotlin/no/nav/syfo/service/ArbeidsgiverVarselServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/service/ArbeidsgiverVarselServiceTest.kt
@@ -1,91 +1,337 @@
 package no.nav.syfo.service
 
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import no.nav.syfo.ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_MERKELAPP
+import no.nav.syfo.db.ARBEIDSTAKER_FNR_1
+import no.nav.syfo.db.ORGNUMMER_1
+import no.nav.syfo.db.fetchUtsendtVarselByFnr
+import no.nav.syfo.db.fetchUtsendtVarselFeiletByFnr
+import no.nav.syfo.db.getPaagaaendeArbeidsgivernotifikasjonerSakByType
+import no.nav.syfo.db.storeArbeidsgivernotifikasjonerSak
 import no.nav.syfo.kafka.common.createObjectMapper
 import no.nav.syfo.kafka.consumers.varselbus.domain.ArbeidsgiverNotifikasjonTilAltinnRessursHendelse
 import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NySakAltinnInput
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.SAK_TYPE_DIALOGMOTE_UTEN_LEDER
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.SakStatus
+import no.nav.syfo.testutil.EmbeddedDatabase
+import java.time.LocalDateTime
 import java.util.UUID
 
 class ArbeidsgiverVarselServiceTest :
     DescribeSpec({
-        val service = ArbeidsgiverVarselService()
+        val embeddedDatabase = EmbeddedDatabase()
+        val arbeidsgiverNotifikasjonService = mockk<ArbeidsgiverNotifikasjonService>()
+        val service =
+            ArbeidsgiverVarselService(
+                database = embeddedDatabase,
+                arbeidsgiverNotifikasjonService = arbeidsgiverNotifikasjonService,
+            )
         val objectMapper = createObjectMapper()
 
-        val grunnHendelse =
-            ArbeidsgiverNotifikasjonTilAltinnRessursHendelse(
-                type = HendelseType.AG_VARSEL_ALTINN_RESSURS,
-                ferdigstill = false,
-                data = null,
-                orgnummer = "999888777",
-                ressursId = "nav_syfo_dialogmote",
-                ressursUrl = "https://www.altinn.no",
-                arbeidstakerFnr = "012345678901",
-                kilde = "tjeneste.type",
-                eksternReferanseId = UUID.randomUUID().toString(),
-            )
+        beforeTest {
+            embeddedDatabase.dropData()
+            clearAllMocks()
+        }
 
-        describe("ArbeidsgiverVarselService stub") {
-            it("tåler gyldig varselData uten exception") {
-                val gyldigData =
-                    objectMapper.readTree(
-                        """{"notifikasjonInnhold":{"epostTittel":"Hei","epostBody":"Body","smsTekst":"SMS"}}""",
+        describe("ArbeidsgiverVarselService") {
+            it("sender arbeidsgivervarsel, oppretter ny sak og lagrer utsendt varsel") {
+                val hendelse = arbeidsgiverHendelse()
+                val eksternSakId = UUID.randomUUID().toString()
+                val inputSlot = mutableListOf<ArbeidsgiverNotifikasjonAltinnRessursInput>()
+
+                coEvery { arbeidsgiverNotifikasjonService.createNewSak(any()) } returns eksternSakId
+                coEvery { arbeidsgiverNotifikasjonService.sendNotifikasjon(capture(inputSlot)) } returns "notifikasjon-id"
+
+                service.sendVarselTilArbeidsgiver(hendelse)
+
+                val utsendteVarsler = embeddedDatabase.fetchUtsendtVarselByFnr(ARBEIDSTAKER_FNR_1)
+                utsendteVarsler shouldHaveSize 1
+                utsendteVarsler.single().kanal shouldBe "ARBEIDSGIVERNOTIFIKASJON"
+                utsendteVarsler.single().type shouldBe HendelseType.AG_VARSEL_ALTINN_RESSURS.name
+                utsendteVarsler.single().eksternReferanse shouldBe hendelse.eksternReferanseId
+
+                val sak =
+                    embeddedDatabase.getPaagaaendeArbeidsgivernotifikasjonerSakByType(
+                        ansattFnr = hendelse.arbeidstakerFnr,
+                        virksomhetsnummer = hendelse.orgnummer,
+                        type = SAK_TYPE_DIALOGMOTE_UTEN_LEDER,
+                    )
+                sak?.eksternSakId shouldBe eksternSakId
+                sak?.ressursId shouldBe hendelse.ressursId
+                inputSlot.single().uuid shouldBe UUID.fromString(hendelse.eksternReferanseId)
+                inputSlot.single().grupperingsid shouldBe sak?.grupperingsid
+                inputSlot.single().hardDeleteDate shouldBe hendelseMotetidspunkt().plusWeeks(4)
+            }
+
+            it("gjenbruker eksisterende pågående sak") {
+                val hendelse = arbeidsgiverHendelse()
+                val eksisterendeSak =
+                    NySakAltinnInput(
+                        grupperingsid = UUID.randomUUID().toString(),
+                        merkelapp = ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_MERKELAPP,
+                        virksomhetsnummer = hendelse.orgnummer,
+                        ansattFnr = hendelse.arbeidstakerFnr,
+                        tittel = "Dialogmøte",
+                        lenke = hendelse.ressursUrl,
+                        initiellStatus = SakStatus.MOTTATT,
+                        hardDeleteDate = LocalDateTime.now().plusDays(1),
+                        ressursId = hendelse.ressursId,
+                    )
+                embeddedDatabase.storeArbeidsgivernotifikasjonerSak(eksisterendeSak, eksternSakId = "sak-1")
+                val inputSlot = mutableListOf<ArbeidsgiverNotifikasjonAltinnRessursInput>()
+
+                coEvery { arbeidsgiverNotifikasjonService.sendNotifikasjon(capture(inputSlot)) } returns "notifikasjon-id"
+
+                service.sendVarselTilArbeidsgiver(hendelse)
+
+                coVerify(exactly = 0) { arbeidsgiverNotifikasjonService.createNewSak(any()) }
+                inputSlot.single().grupperingsid shouldBe eksisterendeSak.grupperingsid
+            }
+
+            it("gjenbruker ikke ferdigstilte saker") {
+                val hendelse = arbeidsgiverHendelse()
+                val avsluttetSak =
+                    NySakAltinnInput(
+                        grupperingsid = UUID.randomUUID().toString(),
+                        merkelapp = ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_MERKELAPP,
+                        virksomhetsnummer = hendelse.orgnummer,
+                        ansattFnr = hendelse.arbeidstakerFnr,
+                        tittel = "Dialogmøte",
+                        lenke = hendelse.ressursUrl,
+                        initiellStatus = SakStatus.FERDIG,
+                        hardDeleteDate = LocalDateTime.now().plusDays(1),
+                        ressursId = hendelse.ressursId,
+                    )
+                embeddedDatabase.storeArbeidsgivernotifikasjonerSak(avsluttetSak, eksternSakId = "sak-avsluttet")
+                val inputSlot = mutableListOf<ArbeidsgiverNotifikasjonAltinnRessursInput>()
+
+                coEvery { arbeidsgiverNotifikasjonService.createNewSak(any()) } returns "sak-ny"
+                coEvery { arbeidsgiverNotifikasjonService.sendNotifikasjon(capture(inputSlot)) } returns "notifikasjon-id"
+
+                service.sendVarselTilArbeidsgiver(hendelse)
+
+                val nySak =
+                    embeddedDatabase.getPaagaaendeArbeidsgivernotifikasjonerSakByType(
+                        ansattFnr = hendelse.arbeidstakerFnr,
+                        virksomhetsnummer = hendelse.orgnummer,
+                        type = SAK_TYPE_DIALOGMOTE_UTEN_LEDER,
+                    )
+                coVerify(exactly = 1) { arbeidsgiverNotifikasjonService.createNewSak(any()) }
+                nySak?.grupperingsid shouldBe inputSlot.single().grupperingsid
+                nySak?.grupperingsid shouldNotBe avsluttetSak.grupperingsid
+            }
+
+            it("registrerer ugyldig eksternReferanseId som feilet utsending med hendelseJson") {
+                val hendelse = arbeidsgiverHendelse(eksternReferanseId = "ugyldig-uuid")
+
+                service.sendVarselTilArbeidsgiver(hendelse)
+
+                val feiledeVarsler = embeddedDatabase.fetchUtsendtVarselFeiletByFnr(ARBEIDSTAKER_FNR_1)
+                feiledeVarsler shouldHaveSize 1
+                feiledeVarsler.single().uuidEksternReferanse shouldBe "ugyldig-uuid"
+                feiledeVarsler.single().feilmelding shouldBe "ArbeidsgiverHendelse har ugyldig eksternReferanseId-format"
+                feiledeVarsler.single().hendelseJson shouldContain """"eksternReferanseId":"ugyldig-uuid""""
+                coVerify(exactly = 0) { arbeidsgiverNotifikasjonService.createNewSak(any()) }
+                coVerify(exactly = 0) {
+                    arbeidsgiverNotifikasjonService.sendNotifikasjon(
+                        any<ArbeidsgiverNotifikasjonAltinnRessursInput>(),
+                    )
+                }
+            }
+
+            it("lagrer ikke feilet utsending dobbelt når sakopprettelse feiler") {
+                val hendelse = arbeidsgiverHendelse()
+                coEvery { arbeidsgiverNotifikasjonService.createNewSak(any()) } returns null
+
+                service.sendVarselTilArbeidsgiver(hendelse)
+
+                val feiledeVarsler = embeddedDatabase.fetchUtsendtVarselFeiletByFnr(ARBEIDSTAKER_FNR_1)
+                feiledeVarsler shouldHaveSize 1
+                feiledeVarsler.single().feilmelding shouldBe
+                    "ArbeidsgiverNotifikasjonService returnerte null ID ved opprettelse av sak"
+                embeddedDatabase.fetchUtsendtVarselByFnr(ARBEIDSTAKER_FNR_1) shouldHaveSize 0
+                coVerify(exactly = 0) {
+                    arbeidsgiverNotifikasjonService.sendNotifikasjon(
+                        any<ArbeidsgiverNotifikasjonAltinnRessursInput>(),
+                    )
+                }
+            }
+
+            it("lagrer feilet utsending når Altinn-send returnerer null ID") {
+                val hendelse = arbeidsgiverHendelse()
+                coEvery { arbeidsgiverNotifikasjonService.createNewSak(any()) } returns "sak-1"
+                coEvery {
+                    arbeidsgiverNotifikasjonService.sendNotifikasjon(any<ArbeidsgiverNotifikasjonAltinnRessursInput>())
+                } returns null
+
+                service.sendVarselTilArbeidsgiver(hendelse)
+
+                val feiledeVarsler = embeddedDatabase.fetchUtsendtVarselFeiletByFnr(ARBEIDSTAKER_FNR_1)
+                feiledeVarsler shouldHaveSize 1
+                feiledeVarsler.single().feilmelding shouldBe
+                    "ArbeidsgiverNotifikasjonService returnerte null ID ved utsending av arbeidsgivervarsel"
+                feiledeVarsler.single().hendelseJson shouldContain """"ressursId":"nav_syfo_dialogmote""""
+                embeddedDatabase.fetchUtsendtVarselByFnr(ARBEIDSTAKER_FNR_1) shouldHaveSize 0
+            }
+
+            it("saniterer feilmelding når sending feiler med exception") {
+                val hendelse = arbeidsgiverHendelse()
+                coEvery { arbeidsgiverNotifikasjonService.createNewSak(any()) } returns "sak-1"
+                coEvery {
+                    arbeidsgiverNotifikasjonService.sendNotifikasjon(any<ArbeidsgiverNotifikasjonAltinnRessursInput>())
+                } throws RuntimeException("boom Body 12345678910")
+
+                service.sendVarselTilArbeidsgiver(hendelse)
+
+                val feiledeVarsler = embeddedDatabase.fetchUtsendtVarselFeiletByFnr(ARBEIDSTAKER_FNR_1)
+                feiledeVarsler shouldHaveSize 1
+                feiledeVarsler.single().hendelseJson shouldContain """"ressursId":"nav_syfo_dialogmote""""
+                feiledeVarsler.single().feilmelding shouldBe "Uventet feil (RuntimeException)"
+                embeddedDatabase.fetchUtsendtVarselByFnr(ARBEIDSTAKER_FNR_1) shouldHaveSize 0
+            }
+
+            it("hopper over ekstern kall når varselet allerede er lagret som sendt") {
+                val hendelse = arbeidsgiverHendelse()
+                coEvery { arbeidsgiverNotifikasjonService.createNewSak(any()) } returns "sak-1"
+                coEvery {
+                    arbeidsgiverNotifikasjonService.sendNotifikasjon(any<ArbeidsgiverNotifikasjonAltinnRessursInput>())
+                } returns "notifikasjon-id"
+                service.sendVarselTilArbeidsgiver(hendelse)
+                clearAllMocks()
+
+                service.sendVarselTilArbeidsgiver(hendelse)
+
+                embeddedDatabase.fetchUtsendtVarselByFnr(ARBEIDSTAKER_FNR_1) shouldHaveSize 1
+                coVerify(exactly = 0) { arbeidsgiverNotifikasjonService.createNewSak(any()) }
+                coVerify(exactly = 0) {
+                    arbeidsgiverNotifikasjonService.sendNotifikasjon(
+                        any<ArbeidsgiverNotifikasjonAltinnRessursInput>(),
+                    )
+                }
+            }
+
+            it("lagrer feilet utsending når data-felt mangler") {
+                service.sendVarselTilArbeidsgiver(arbeidsgiverHendelse(data = null))
+
+                val feiledeVarsler = embeddedDatabase.fetchUtsendtVarselFeiletByFnr(ARBEIDSTAKER_FNR_1)
+                feiledeVarsler shouldHaveSize 1
+                feiledeVarsler.single().feilmelding shouldContain "ArbeidsgiverHendelse mangler feltet: data"
+            }
+
+            it("lagrer feilet utsending når notifikasjonInnhold mangler") {
+                service.sendVarselTilArbeidsgiver(
+                    arbeidsgiverHendelse(
+                        data = objectMapper.readTree("""{}"""),
+                    ),
+                )
+
+                val feiledeVarsler = embeddedDatabase.fetchUtsendtVarselFeiletByFnr(ARBEIDSTAKER_FNR_1)
+                feiledeVarsler shouldHaveSize 1
+                feiledeVarsler.single().feilmelding shouldContain "ArbeidsgiverHendelse mangler feltet: data.notifikasjonInnhold"
+            }
+
+            it("returnerer permanent feil ved retry når hendelseJson mangler") {
+                val result =
+                    service.resendVarselTilArbeidsgiver(
+                        arbeidsgiverVarselFeilet(hendelseJson = null),
                     )
 
-                val result = runCatching { service.sendVarselTilArbeidsgiver(grunnHendelse.copy(data = gyldigData)) }
-
-                result.isSuccess shouldBe true
+                result shouldBe ArbeidsgiverVarselResendResult.PERMANENT_FAILURE
+                coVerify(exactly = 0) { arbeidsgiverNotifikasjonService.createNewSak(any()) }
+                coVerify(exactly = 0) {
+                    arbeidsgiverNotifikasjonService.sendNotifikasjon(
+                        any<ArbeidsgiverNotifikasjonAltinnRessursInput>(),
+                    )
+                }
             }
 
-            it("håndterer parse-feil i data strengt og kaster exception") {
-                val exception =
-                    shouldThrow<IllegalArgumentException> {
-                        service.sendVarselTilArbeidsgiver(grunnHendelse.copy(data = "ikke-json"))
-                    }
-                exception.message shouldContain "ArbeidsgiverHendelse har ugyldig format i feltet: data"
-            }
-
-            it("kaster exception ved manglende data-felt") {
-                val exception =
-                    shouldThrow<IllegalArgumentException> {
-                        service.sendVarselTilArbeidsgiver(grunnHendelse.copy(data = null))
-                    }
-
-                exception.message shouldContain "ArbeidsgiverHendelse mangler feltet: data"
-            }
-
-            it("kaster exception ved manglende notifikasjonInnhold i varselData") {
-                val manglendeNotifikasjonInnhold =
-                    objectMapper.readTree(
-                        """{}""",
+            it("returnerer permanent feil ved retry når hendelseJson er korrupt") {
+                val result =
+                    service.resendVarselTilArbeidsgiver(
+                        arbeidsgiverVarselFeilet(hendelseJson = """{"data":"""),
                     )
 
-                val exception =
-                    shouldThrow<IllegalArgumentException> {
-                        service.sendVarselTilArbeidsgiver(
-                            grunnHendelse.copy(data = manglendeNotifikasjonInnhold),
-                        )
-                    }
-
-                exception.message shouldContain "ArbeidsgiverHendelse mangler feltet: data.notifikasjonInnhold"
+                result shouldBe ArbeidsgiverVarselResendResult.PERMANENT_FAILURE
+                coVerify(exactly = 0) { arbeidsgiverNotifikasjonService.createNewSak(any()) }
+                coVerify(exactly = 0) {
+                    arbeidsgiverNotifikasjonService.sendNotifikasjon(
+                        any<ArbeidsgiverNotifikasjonAltinnRessursInput>(),
+                    )
+                }
             }
 
-            it("kaster exception ved manglende obligatorisk felt i notifikasjonInnhold") {
-                val manglendeEpostBody =
-                    objectMapper.readTree(
-                        """{"notifikasjonInnhold":{"epostTittel":"Hei","smsTekst":"SMS"}}""",
+            it("returnerer permanent feil ved retry når eksternReferanseId er ugyldig") {
+                val result =
+                    service.resendVarselTilArbeidsgiver(
+                        arbeidsgiverVarselFeilet(eksternReferanseId = "ugyldig-uuid"),
                     )
 
-                val exception =
-                    shouldThrow<IllegalArgumentException> {
-                        service.sendVarselTilArbeidsgiver(
-                            grunnHendelse.copy(data = manglendeEpostBody),
-                        )
-                    }
-
-                exception.message shouldContain "ArbeidsgiverHendelse har ugyldig format i feltet: data.notifikasjonInnhold.epostBody"
+                result shouldBe ArbeidsgiverVarselResendResult.PERMANENT_FAILURE
+                coVerify(exactly = 0) { arbeidsgiverNotifikasjonService.createNewSak(any()) }
+                coVerify(exactly = 0) {
+                    arbeidsgiverNotifikasjonService.sendNotifikasjon(
+                        any<ArbeidsgiverNotifikasjonAltinnRessursInput>(),
+                    )
+                }
             }
         }
     })
+
+private fun arbeidsgiverHendelse(
+    eksternReferanseId: String = UUID.randomUUID().toString(),
+    data: Any? =
+        createObjectMapper().readTree(
+            """
+            {
+              "motetidspunkt": {
+                "tidspunkt": "${hendelseMotetidspunkt()}"
+              },
+              "notifikasjonInnhold": {
+                "epostTittel": "Dialogmøte",
+                "epostBody": "Body",
+                "smsTekst": "SMS"
+              }
+            }
+            """.trimIndent(),
+        ),
+) = ArbeidsgiverNotifikasjonTilAltinnRessursHendelse(
+    type = HendelseType.AG_VARSEL_ALTINN_RESSURS,
+    ferdigstill = false,
+    data = data,
+    orgnummer = ORGNUMMER_1,
+    ressursId = "nav_syfo_dialogmote",
+    ressursUrl = "https://www.altinn.no",
+    arbeidstakerFnr = ARBEIDSTAKER_FNR_1,
+    kilde = "tjeneste.type",
+    eksternReferanseId = eksternReferanseId,
+)
+
+private fun hendelseMotetidspunkt(): LocalDateTime = LocalDateTime.of(2030, 1, 15, 10, 0)
+
+private fun arbeidsgiverVarselFeilet(
+    eksternReferanseId: String = UUID.randomUUID().toString(),
+    hendelseJson: String? = createObjectMapper().writeValueAsString(arbeidsgiverHendelse(eksternReferanseId = eksternReferanseId)),
+) = no.nav.syfo.db.domain.PUtsendtVarselFeilet(
+    uuid = UUID.randomUUID().toString(),
+    uuidEksternReferanse = eksternReferanseId,
+    arbeidstakerFnr = ARBEIDSTAKER_FNR_1,
+    narmesteLederFnr = null,
+    orgnummer = ORGNUMMER_1,
+    hendelsetypeNavn = HendelseType.AG_VARSEL_ALTINN_RESSURS.name,
+    arbeidsgivernotifikasjonMerkelapp = ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_MERKELAPP,
+    brukernotifikasjonerMeldingType = null,
+    journalpostId = null,
+    kanal = "ARBEIDSGIVERNOTIFIKASJON",
+    feilmelding = "noe gikk galt",
+    utsendtForsokTidspunkt = LocalDateTime.now(),
+    hendelseJson = hendelseJson,
+)

--- a/src/test/kotlin/no/nav/syfo/service/ArbeidsgiverVarselServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/service/ArbeidsgiverVarselServiceTest.kt
@@ -22,6 +22,7 @@ import no.nav.syfo.db.storeArbeidsgivernotifikasjonerSak
 import no.nav.syfo.kafka.common.createObjectMapper
 import no.nav.syfo.kafka.consumers.varselbus.domain.ArbeidsgiverNotifikasjonTilAltinnRessursHendelse
 import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.MottakerType
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NySakAltinnInput
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.SAK_TYPE_DIALOGMOTE_UTEN_LEDER
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.SakStatus
@@ -72,10 +73,12 @@ class ArbeidsgiverVarselServiceTest :
                     )
                 sak?.eksternSakId shouldBe eksternSakId
                 sak?.ressursId shouldBe hendelse.ressursId
-                sak?.lenke shouldBe hendelse.ressursUrl
+                sak?.lenke shouldBe null
+                sak?.mottakerType shouldBe MottakerType.ALTINN
                 mutationSlot.captured.lenke shouldBe Optional.Absent
                 inputSlot.single().uuid shouldBe UUID.fromString(hendelse.eksternReferanseId)
                 inputSlot.single().grupperingsid shouldBe sak?.grupperingsid
+                inputSlot.single().link shouldBe hendelse.ressursUrl
                 sak?.hardDeleteDate shouldBe inputSlot.single().hardDeleteDate
                 inputSlot.single().hardDeleteDate shouldBe
                     LocalDate
@@ -97,7 +100,6 @@ class ArbeidsgiverVarselServiceTest :
                         initiellStatus = SakStatus.MOTTATT,
                         hardDeleteDate = existingHardDeleteDate(),
                         ressursId = hendelse.ressursId,
-                        ressursUrl = hendelse.ressursUrl,
                     )
                 embeddedDatabase.storeArbeidsgivernotifikasjonerSak(eksisterendeSak, eksternSakId = "sak-1")
                 val inputSlot = mutableListOf<ArbeidsgiverNotifikasjonAltinnRessursInput>()
@@ -135,7 +137,6 @@ class ArbeidsgiverVarselServiceTest :
                         initiellStatus = SakStatus.MOTTATT,
                         hardDeleteDate = existingHardDeleteDate(),
                         ressursId = hendelse.ressursId,
-                        ressursUrl = hendelse.ressursUrl,
                     )
                 embeddedDatabase.storeArbeidsgivernotifikasjonerSak(eksisterendeSak, eksternSakId = "sak-1")
 
@@ -174,7 +175,6 @@ class ArbeidsgiverVarselServiceTest :
                         initiellStatus = SakStatus.FERDIG,
                         hardDeleteDate = existingHardDeleteDate(),
                         ressursId = hendelse.ressursId,
-                        ressursUrl = hendelse.ressursUrl,
                     )
                 embeddedDatabase.storeArbeidsgivernotifikasjonerSak(avsluttetSak, eksternSakId = "sak-avsluttet")
                 val inputSlot = mutableListOf<ArbeidsgiverNotifikasjonAltinnRessursInput>()

--- a/src/test/kotlin/no/nav/syfo/service/ArbeidsgiverVarselServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/service/ArbeidsgiverVarselServiceTest.kt
@@ -91,7 +91,7 @@ class ArbeidsgiverVarselServiceTest :
                         tittel = "Dialogmøte",
                         lenke = hendelse.ressursUrl,
                         initiellStatus = SakStatus.MOTTATT,
-                        hardDeleteDate = LocalDateTime.now().plusDays(1),
+                        hardDeleteDate = existingHardDeleteDate(),
                         ressursId = hendelse.ressursId,
                     )
                 embeddedDatabase.storeArbeidsgivernotifikasjonerSak(eksisterendeSak, eksternSakId = "sak-1")
@@ -129,7 +129,7 @@ class ArbeidsgiverVarselServiceTest :
                         tittel = "Dialogmøte",
                         lenke = hendelse.ressursUrl,
                         initiellStatus = SakStatus.MOTTATT,
-                        hardDeleteDate = LocalDateTime.now().plusDays(1),
+                        hardDeleteDate = existingHardDeleteDate(),
                         ressursId = hendelse.ressursId,
                     )
                 embeddedDatabase.storeArbeidsgivernotifikasjonerSak(eksisterendeSak, eksternSakId = "sak-1")
@@ -168,7 +168,7 @@ class ArbeidsgiverVarselServiceTest :
                         tittel = "Dialogmøte",
                         lenke = hendelse.ressursUrl,
                         initiellStatus = SakStatus.FERDIG,
-                        hardDeleteDate = LocalDateTime.now().plusDays(1),
+                        hardDeleteDate = existingHardDeleteDate(),
                         ressursId = hendelse.ressursId,
                     )
                 embeddedDatabase.storeArbeidsgivernotifikasjonerSak(avsluttetSak, eksternSakId = "sak-avsluttet")
@@ -376,6 +376,8 @@ private fun arbeidsgiverHendelse(
 )
 
 private fun hendelseMotetidspunkt(): LocalDateTime = LocalDateTime.of(2030, 1, 15, 10, 0)
+
+private fun existingHardDeleteDate(): LocalDateTime = LocalDate.now().plusDays(1).atStartOfDay()
 
 private fun arbeidsgiverVarselFeilet(
     eksternReferanseId: String = UUID.randomUUID().toString(),

--- a/src/test/kotlin/no/nav/syfo/service/ArbeidsgiverVarselServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/service/ArbeidsgiverVarselServiceTest.kt
@@ -1,5 +1,7 @@
 package no.nav.syfo.service
 
+import com.apollo.graphql.NySakMutation
+import com.apollographql.apollo.api.Optional
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
@@ -49,8 +51,9 @@ class ArbeidsgiverVarselServiceTest :
                 val hendelse = arbeidsgiverHendelse()
                 val eksternSakId = UUID.randomUUID().toString()
                 val inputSlot = mutableListOf<ArbeidsgiverNotifikasjonAltinnRessursInput>()
+                val mutationSlot = slot<NySakMutation>()
 
-                coEvery { arbeidsgiverNotifikasjonService.createNewSak(any()) } returns eksternSakId
+                coEvery { arbeidsgiverNotifikasjonService.createNewSak(capture(mutationSlot)) } returns eksternSakId
                 coEvery { arbeidsgiverNotifikasjonService.sendNotifikasjon(capture(inputSlot)) } returns "notifikasjon-id"
 
                 service.sendVarselTilArbeidsgiver(hendelse)
@@ -69,6 +72,8 @@ class ArbeidsgiverVarselServiceTest :
                     )
                 sak?.eksternSakId shouldBe eksternSakId
                 sak?.ressursId shouldBe hendelse.ressursId
+                sak?.lenke shouldBe hendelse.ressursUrl
+                mutationSlot.captured.lenke shouldBe Optional.Absent
                 inputSlot.single().uuid shouldBe UUID.fromString(hendelse.eksternReferanseId)
                 inputSlot.single().grupperingsid shouldBe sak?.grupperingsid
                 sak?.hardDeleteDate shouldBe inputSlot.single().hardDeleteDate
@@ -89,10 +94,10 @@ class ArbeidsgiverVarselServiceTest :
                         virksomhetsnummer = hendelse.orgnummer,
                         ansattFnr = hendelse.arbeidstakerFnr,
                         tittel = "Dialogmøte",
-                        lenke = hendelse.ressursUrl,
                         initiellStatus = SakStatus.MOTTATT,
                         hardDeleteDate = existingHardDeleteDate(),
                         ressursId = hendelse.ressursId,
+                        ressursUrl = hendelse.ressursUrl,
                     )
                 embeddedDatabase.storeArbeidsgivernotifikasjonerSak(eksisterendeSak, eksternSakId = "sak-1")
                 val inputSlot = mutableListOf<ArbeidsgiverNotifikasjonAltinnRessursInput>()
@@ -127,10 +132,10 @@ class ArbeidsgiverVarselServiceTest :
                         virksomhetsnummer = hendelse.orgnummer,
                         ansattFnr = hendelse.arbeidstakerFnr,
                         tittel = "Dialogmøte",
-                        lenke = hendelse.ressursUrl,
                         initiellStatus = SakStatus.MOTTATT,
                         hardDeleteDate = existingHardDeleteDate(),
                         ressursId = hendelse.ressursId,
+                        ressursUrl = hendelse.ressursUrl,
                     )
                 embeddedDatabase.storeArbeidsgivernotifikasjonerSak(eksisterendeSak, eksternSakId = "sak-1")
 
@@ -166,10 +171,10 @@ class ArbeidsgiverVarselServiceTest :
                         virksomhetsnummer = hendelse.orgnummer,
                         ansattFnr = hendelse.arbeidstakerFnr,
                         tittel = "Dialogmøte",
-                        lenke = hendelse.ressursUrl,
                         initiellStatus = SakStatus.FERDIG,
                         hardDeleteDate = existingHardDeleteDate(),
                         ressursId = hendelse.ressursId,
+                        ressursUrl = hendelse.ressursUrl,
                     )
                 embeddedDatabase.storeArbeidsgivernotifikasjonerSak(avsluttetSak, eksternSakId = "sak-avsluttet")
                 val inputSlot = mutableListOf<ArbeidsgiverNotifikasjonAltinnRessursInput>()

--- a/src/test/kotlin/no/nav/syfo/service/ArbeidsgiverVarselServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/service/ArbeidsgiverVarselServiceTest.kt
@@ -9,6 +9,7 @@ import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
+import io.mockk.slot
 import no.nav.syfo.ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_MERKELAPP
 import no.nav.syfo.db.ARBEIDSTAKER_FNR_1
 import no.nav.syfo.db.ORGNUMMER_1
@@ -70,6 +71,7 @@ class ArbeidsgiverVarselServiceTest :
                 sak?.ressursId shouldBe hendelse.ressursId
                 inputSlot.single().uuid shouldBe UUID.fromString(hendelse.eksternReferanseId)
                 inputSlot.single().grupperingsid shouldBe sak?.grupperingsid
+                sak?.hardDeleteDate shouldBe inputSlot.single().hardDeleteDate
                 inputSlot.single().hardDeleteDate shouldBe
                     LocalDate
                         .now()
@@ -94,13 +96,65 @@ class ArbeidsgiverVarselServiceTest :
                     )
                 embeddedDatabase.storeArbeidsgivernotifikasjonerSak(eksisterendeSak, eksternSakId = "sak-1")
                 val inputSlot = mutableListOf<ArbeidsgiverNotifikasjonAltinnRessursInput>()
+                val nyStatusSakInputSlot = slot<no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NyStatusSakInput>()
 
+                coEvery { arbeidsgiverNotifikasjonService.nyStatusSak(capture(nyStatusSakInputSlot)) } returns "sak-1"
                 coEvery { arbeidsgiverNotifikasjonService.sendNotifikasjon(capture(inputSlot)) } returns "notifikasjon-id"
 
                 service.sendVarselTilArbeidsgiver(hendelse)
 
                 coVerify(exactly = 0) { arbeidsgiverNotifikasjonService.createNewSak(any()) }
+                nyStatusSakInputSlot.captured.grupperingsId shouldBe eksisterendeSak.grupperingsid
+                nyStatusSakInputSlot.captured.merkelapp shouldBe eksisterendeSak.merkelapp
+                nyStatusSakInputSlot.captured.sakStatus shouldBe eksisterendeSak.initiellStatus.let { SakStatus.valueOf(it.name) }
+                nyStatusSakInputSlot.captured.oppdatertHardDeleteDateTime shouldBe inputSlot.single().hardDeleteDate
                 inputSlot.single().grupperingsid shouldBe eksisterendeSak.grupperingsid
+                val oppdatertSak =
+                    embeddedDatabase.getPaagaaendeArbeidsgivernotifikasjonerSakByType(
+                        ansattFnr = hendelse.arbeidstakerFnr,
+                        virksomhetsnummer = hendelse.orgnummer,
+                        type = SAK_TYPE_DIALOGMOTE_UTEN_LEDER,
+                    )
+                oppdatertSak?.hardDeleteDate shouldBe inputSlot.single().hardDeleteDate
+            }
+
+            it("lagrer feilet utsending og avbryter sending når oppdatering av eksisterende sak returnerer null") {
+                val hendelse = arbeidsgiverHendelse()
+                val eksisterendeSak =
+                    NySakAltinnInput(
+                        grupperingsid = UUID.randomUUID().toString(),
+                        merkelapp = ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_MERKELAPP,
+                        virksomhetsnummer = hendelse.orgnummer,
+                        ansattFnr = hendelse.arbeidstakerFnr,
+                        tittel = "Dialogmøte",
+                        lenke = hendelse.ressursUrl,
+                        initiellStatus = SakStatus.MOTTATT,
+                        hardDeleteDate = LocalDateTime.now().plusDays(1),
+                        ressursId = hendelse.ressursId,
+                    )
+                embeddedDatabase.storeArbeidsgivernotifikasjonerSak(eksisterendeSak, eksternSakId = "sak-1")
+
+                coEvery { arbeidsgiverNotifikasjonService.nyStatusSak(any()) } returns null
+
+                service.sendVarselTilArbeidsgiver(hendelse)
+
+                val feiledeVarsler = embeddedDatabase.fetchUtsendtVarselFeiletByFnr(ARBEIDSTAKER_FNR_1)
+                feiledeVarsler shouldHaveSize 1
+                feiledeVarsler.single().feilmelding shouldBe
+                    "ArbeidsgiverNotifikasjonService returnerte null ID ved oppdatering av hardDeleteDate på sak"
+                embeddedDatabase.fetchUtsendtVarselByFnr(ARBEIDSTAKER_FNR_1) shouldHaveSize 0
+                coVerify(exactly = 0) {
+                    arbeidsgiverNotifikasjonService.sendNotifikasjon(
+                        any<ArbeidsgiverNotifikasjonAltinnRessursInput>(),
+                    )
+                }
+                val sakEtterFeil =
+                    embeddedDatabase.getPaagaaendeArbeidsgivernotifikasjonerSakByType(
+                        ansattFnr = hendelse.arbeidstakerFnr,
+                        virksomhetsnummer = hendelse.orgnummer,
+                        type = SAK_TYPE_DIALOGMOTE_UTEN_LEDER,
+                    )
+                sakEtterFeil?.hardDeleteDate shouldBe eksisterendeSak.hardDeleteDate
             }
 
             it("gjenbruker ikke ferdigstilte saker") {

--- a/src/test/kotlin/no/nav/syfo/service/ArbeidsgiverVarselServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/service/ArbeidsgiverVarselServiceTest.kt
@@ -71,6 +71,7 @@ class ArbeidsgiverVarselServiceTest :
                         virksomhetsnummer = hendelse.orgnummer,
                         type = SAK_TYPE_DIALOGMOTE_UTEN_LEDER,
                         mottakerType = MottakerType.ALTINN,
+                        ressursId = hendelse.ressursId,
                     )
                 sak?.eksternSakId shouldBe eksternSakId
                 sak?.ressursId shouldBe hendelse.ressursId
@@ -79,6 +80,7 @@ class ArbeidsgiverVarselServiceTest :
                 mutationSlot.captured.lenke shouldBe Optional.Absent
                 inputSlot.single().uuid shouldBe UUID.fromString(hendelse.eksternReferanseId)
                 inputSlot.single().grupperingsid shouldBe sak?.grupperingsid
+                UUID.fromString(inputSlot.single().grupperingsid) shouldNotBe null
                 inputSlot.single().link shouldBe hendelse.ressursUrl
                 sak?.hardDeleteDate shouldBe inputSlot.single().hardDeleteDate
                 inputSlot.single().hardDeleteDate shouldBe
@@ -123,8 +125,49 @@ class ArbeidsgiverVarselServiceTest :
                         virksomhetsnummer = hendelse.orgnummer,
                         type = SAK_TYPE_DIALOGMOTE_UTEN_LEDER,
                         mottakerType = MottakerType.ALTINN,
+                        ressursId = hendelse.ressursId,
                     )
                 oppdatertSak?.hardDeleteDate shouldBe inputSlot.single().hardDeleteDate
+            }
+
+            it("gjenbruker ikke eksisterende pågående sak med annen ressursId") {
+                val hendelse = arbeidsgiverHendelse()
+                val eksisterendeSakForAnnenRessurs =
+                    NySakAltinnInput(
+                        grupperingsid = UUID.randomUUID().toString(),
+                        merkelapp = ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_MERKELAPP,
+                        virksomhetsnummer = hendelse.orgnummer,
+                        ansattFnr = hendelse.arbeidstakerFnr,
+                        tittel = "Dialogmøte",
+                        initiellStatus = SakStatus.MOTTATT,
+                        hardDeleteDate = existingHardDeleteDate(),
+                        ressursId = "annen_altinn_ressurs",
+                    )
+                embeddedDatabase.storeArbeidsgivernotifikasjonerSak(
+                    eksisterendeSakForAnnenRessurs,
+                    eksternSakId = "sak-annen-ressurs",
+                )
+                val inputSlot = mutableListOf<ArbeidsgiverNotifikasjonAltinnRessursInput>()
+
+                coEvery { arbeidsgiverNotifikasjonService.createNewSak(any()) } returns "sak-ny"
+                coEvery { arbeidsgiverNotifikasjonService.sendNotifikasjon(capture(inputSlot)) } returns "notifikasjon-id"
+
+                service.sendVarselTilArbeidsgiver(hendelse)
+
+                val nySak =
+                    embeddedDatabase.getPaagaaendeArbeidsgivernotifikasjonerSakByType(
+                        ansattFnr = hendelse.arbeidstakerFnr,
+                        virksomhetsnummer = hendelse.orgnummer,
+                        type = SAK_TYPE_DIALOGMOTE_UTEN_LEDER,
+                        mottakerType = MottakerType.ALTINN,
+                        ressursId = hendelse.ressursId,
+                    )
+                coVerify(exactly = 1) { arbeidsgiverNotifikasjonService.createNewSak(any()) }
+                coVerify(exactly = 0) { arbeidsgiverNotifikasjonService.nyStatusSak(any()) }
+                nySak?.ressursId shouldBe hendelse.ressursId
+                nySak?.grupperingsid shouldBe inputSlot.single().grupperingsid
+                nySak?.grupperingsid shouldNotBe eksisterendeSakForAnnenRessurs.grupperingsid
+                UUID.fromString(inputSlot.single().grupperingsid) shouldNotBe null
             }
 
             it("gjenbruker ikke sak med feil mottakertype") {
@@ -163,6 +206,7 @@ class ArbeidsgiverVarselServiceTest :
                         virksomhetsnummer = hendelse.orgnummer,
                         type = SAK_TYPE_DIALOGMOTE_UTEN_LEDER,
                         mottakerType = MottakerType.ALTINN,
+                        ressursId = hendelse.ressursId,
                     )
                 coVerify(exactly = 1) { arbeidsgiverNotifikasjonService.createNewSak(any()) }
                 nySak?.grupperingsid shouldBe inputSlot.single().grupperingsid
@@ -204,6 +248,7 @@ class ArbeidsgiverVarselServiceTest :
                         virksomhetsnummer = hendelse.orgnummer,
                         type = SAK_TYPE_DIALOGMOTE_UTEN_LEDER,
                         mottakerType = MottakerType.ALTINN,
+                        ressursId = hendelse.ressursId,
                     )
                 sakEtterFeil?.hardDeleteDate shouldBe eksisterendeSak.hardDeleteDate
             }
@@ -235,6 +280,7 @@ class ArbeidsgiverVarselServiceTest :
                         virksomhetsnummer = hendelse.orgnummer,
                         type = SAK_TYPE_DIALOGMOTE_UTEN_LEDER,
                         mottakerType = MottakerType.ALTINN,
+                        ressursId = hendelse.ressursId,
                     )
                 coVerify(exactly = 1) { arbeidsgiverNotifikasjonService.createNewSak(any()) }
                 nySak?.grupperingsid shouldBe inputSlot.single().grupperingsid

--- a/src/test/kotlin/no/nav/syfo/service/ArbeidsgiverVarselServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/service/ArbeidsgiverVarselServiceTest.kt
@@ -70,6 +70,7 @@ class ArbeidsgiverVarselServiceTest :
                         ansattFnr = hendelse.arbeidstakerFnr,
                         virksomhetsnummer = hendelse.orgnummer,
                         type = SAK_TYPE_DIALOGMOTE_UTEN_LEDER,
+                        mottakerType = MottakerType.ALTINN,
                     )
                 sak?.eksternSakId shouldBe eksternSakId
                 sak?.ressursId shouldBe hendelse.ressursId
@@ -121,8 +122,51 @@ class ArbeidsgiverVarselServiceTest :
                         ansattFnr = hendelse.arbeidstakerFnr,
                         virksomhetsnummer = hendelse.orgnummer,
                         type = SAK_TYPE_DIALOGMOTE_UTEN_LEDER,
+                        mottakerType = MottakerType.ALTINN,
                     )
                 oppdatertSak?.hardDeleteDate shouldBe inputSlot.single().hardDeleteDate
+            }
+
+            it("gjenbruker ikke sak med feil mottakertype") {
+                val hendelse = arbeidsgiverHendelse()
+                val sakMedFeilMottakertype =
+                    NySakAltinnInput(
+                        grupperingsid = UUID.randomUUID().toString(),
+                        merkelapp = ARBEIDSGIVERNOTIFIKASJON_DIALOGMOTE_MERKELAPP,
+                        virksomhetsnummer = hendelse.orgnummer,
+                        ansattFnr = hendelse.arbeidstakerFnr,
+                        tittel = "Dialogmøte",
+                        initiellStatus = SakStatus.MOTTATT,
+                        hardDeleteDate = existingHardDeleteDate(),
+                        ressursId = hendelse.ressursId,
+                    )
+                val lagretSakId =
+                    embeddedDatabase.storeArbeidsgivernotifikasjonerSak(
+                        sakMedFeilMottakertype,
+                        eksternSakId = "sak-feil-mottaker",
+                    )
+                embeddedDatabase.updateArbeidsgivernotifikasjonerSakMottakerType(
+                    sakId = lagretSakId,
+                    mottakerType = MottakerType.NAERMESTE_LEDER,
+                )
+
+                val inputSlot = mutableListOf<ArbeidsgiverNotifikasjonAltinnRessursInput>()
+
+                coEvery { arbeidsgiverNotifikasjonService.createNewSak(any()) } returns "sak-ny"
+                coEvery { arbeidsgiverNotifikasjonService.sendNotifikasjon(capture(inputSlot)) } returns "notifikasjon-id"
+
+                service.sendVarselTilArbeidsgiver(hendelse)
+
+                val nySak =
+                    embeddedDatabase.getPaagaaendeArbeidsgivernotifikasjonerSakByType(
+                        ansattFnr = hendelse.arbeidstakerFnr,
+                        virksomhetsnummer = hendelse.orgnummer,
+                        type = SAK_TYPE_DIALOGMOTE_UTEN_LEDER,
+                        mottakerType = MottakerType.ALTINN,
+                    )
+                coVerify(exactly = 1) { arbeidsgiverNotifikasjonService.createNewSak(any()) }
+                nySak?.grupperingsid shouldBe inputSlot.single().grupperingsid
+                nySak?.grupperingsid shouldNotBe sakMedFeilMottakertype.grupperingsid
             }
 
             it("lagrer feilet utsending og avbryter sending når oppdatering av eksisterende sak returnerer null") {
@@ -159,6 +203,7 @@ class ArbeidsgiverVarselServiceTest :
                         ansattFnr = hendelse.arbeidstakerFnr,
                         virksomhetsnummer = hendelse.orgnummer,
                         type = SAK_TYPE_DIALOGMOTE_UTEN_LEDER,
+                        mottakerType = MottakerType.ALTINN,
                     )
                 sakEtterFeil?.hardDeleteDate shouldBe eksisterendeSak.hardDeleteDate
             }
@@ -189,6 +234,7 @@ class ArbeidsgiverVarselServiceTest :
                         ansattFnr = hendelse.arbeidstakerFnr,
                         virksomhetsnummer = hendelse.orgnummer,
                         type = SAK_TYPE_DIALOGMOTE_UTEN_LEDER,
+                        mottakerType = MottakerType.ALTINN,
                     )
                 coVerify(exactly = 1) { arbeidsgiverNotifikasjonService.createNewSak(any()) }
                 nySak?.grupperingsid shouldBe inputSlot.single().grupperingsid
@@ -402,3 +448,24 @@ private fun arbeidsgiverVarselFeilet(
     utsendtForsokTidspunkt = LocalDateTime.now(),
     hendelseJson = hendelseJson,
 )
+
+private fun EmbeddedDatabase.updateArbeidsgivernotifikasjonerSakMottakerType(
+    sakId: String,
+    mottakerType: MottakerType,
+) {
+    connection.use { connection ->
+        connection
+            .prepareStatement(
+                """
+                UPDATE ARBEIDSGIVERNOTIFIKASJONER_SAK
+                SET mottaker_type = ?
+                WHERE id = ?
+                """.trimIndent(),
+            ).use { preparedStatement ->
+                preparedStatement.setString(1, mottakerType.name)
+                preparedStatement.setObject(2, UUID.fromString(sakId))
+                preparedStatement.executeUpdate()
+            }
+        connection.commit()
+    }
+}

--- a/src/test/kotlin/no/nav/syfo/service/SenderFacadeSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/service/SenderFacadeSpek.kt
@@ -25,6 +25,7 @@ import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType
 import no.nav.syfo.kafka.producers.dinesykmeldte.DineSykmeldteHendelseKafkaProducer
 import no.nav.syfo.kafka.producers.dittsykefravaer.DittSykefravaerMeldingKafkaProducer
 import no.nav.syfo.planner.ARBEIDSTAKER_FNR_1
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.MottakerType
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NySakAltinnInput
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NySakNarmesteLederInput
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.SAK_TYPE_DIALOGMOTE_UTEN_LEDER
@@ -216,6 +217,7 @@ class SenderFacadeSpek :
                 storedSak?.id shouldBe storedId
                 storedSak?.eksternSakId shouldBe createdSakId
                 storedSak?.type shouldBe SAK_TYPE_OPPFOLGING_MED_LEDER
+                storedSak?.mottakerType shouldBe MottakerType.NAERMESTE_LEDER
             }
 
             it("Stores NySakAltinnInput with ressursId and correct type") {
@@ -233,7 +235,6 @@ class SenderFacadeSpek :
                         initiellStatus = SakStatus.MOTTATT,
                         hardDeleteDate = LocalDateTime.now().plusDays(1),
                         ressursId = "nav_sykefravarsoppfolging_arbeidsgiver",
-                        ressursUrl = "https://www.nav.no",
                     )
 
                 val storedId = senderFacade.createNewSak(sakInput)
@@ -248,7 +249,8 @@ class SenderFacadeSpek :
                 storedSak?.eksternSakId shouldBe createdSakId
                 storedSak?.type shouldBe SAK_TYPE_DIALOGMOTE_UTEN_LEDER
                 storedSak?.ressursId shouldBe "nav_sykefravarsoppfolging_arbeidsgiver"
-                storedSak?.lenke shouldBe "https://www.nav.no"
+                storedSak?.lenke shouldBe null
+                storedSak?.mottakerType shouldBe MottakerType.ALTINN
                 storedSak?.narmestelederId shouldBe null
                 storedSak?.narmesteLederFnr shouldBe null
                 mutationSlot.captured.lenke shouldBe Optional.Absent

--- a/src/test/kotlin/no/nav/syfo/service/SenderFacadeSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/service/SenderFacadeSpek.kt
@@ -1,11 +1,14 @@
 package no.nav.syfo.service
 
+import com.apollo.graphql.NySakMutation
+import com.apollographql.apollo.api.Optional
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import no.nav.syfo.ARBEIDSGIVERNOTIFIKASJON_OPPFOLGING_MERKELAPP
 import no.nav.syfo.db.ARBEIDSTAKER_AKTOR_ID_1
@@ -217,7 +220,8 @@ class SenderFacadeSpek :
 
             it("Stores NySakAltinnInput with ressursId and correct type") {
                 val createdSakId = UUID.randomUUID().toString()
-                coEvery { arbeidsgiverNotifikasjonService.createNewSak(any()) } returns createdSakId
+                val mutationSlot = slot<NySakMutation>()
+                coEvery { arbeidsgiverNotifikasjonService.createNewSak(capture(mutationSlot)) } returns createdSakId
 
                 val sakInput =
                     NySakAltinnInput(
@@ -226,10 +230,10 @@ class SenderFacadeSpek :
                         virksomhetsnummer = "999999999",
                         ansattFnr = ARBEIDSTAKER_FNR_1,
                         tittel = "Dialogmøte",
-                        lenke = "https://www.nav.no",
                         initiellStatus = SakStatus.MOTTATT,
                         hardDeleteDate = LocalDateTime.now().plusDays(1),
                         ressursId = "nav_sykefravarsoppfolging_arbeidsgiver",
+                        ressursUrl = "https://www.nav.no",
                     )
 
                 val storedId = senderFacade.createNewSak(sakInput)
@@ -244,8 +248,10 @@ class SenderFacadeSpek :
                 storedSak?.eksternSakId shouldBe createdSakId
                 storedSak?.type shouldBe SAK_TYPE_DIALOGMOTE_UTEN_LEDER
                 storedSak?.ressursId shouldBe "nav_sykefravarsoppfolging_arbeidsgiver"
+                storedSak?.lenke shouldBe "https://www.nav.no"
                 storedSak?.narmestelederId shouldBe null
                 storedSak?.narmesteLederFnr shouldBe null
+                mutationSlot.captured.lenke shouldBe Optional.Absent
             }
         }
     })

--- a/src/test/kotlin/no/nav/syfo/service/SenderFacadeSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/service/SenderFacadeSpek.kt
@@ -212,6 +212,7 @@ class SenderFacadeSpek :
                         ansattFnr = sakInput.ansattFnr,
                         virksomhetsnummer = sakInput.virksomhetsnummer,
                         type = SAK_TYPE_OPPFOLGING_MED_LEDER,
+                        mottakerType = MottakerType.NAERMESTE_LEDER,
                     )
 
                 storedSak?.id shouldBe storedId
@@ -243,6 +244,14 @@ class SenderFacadeSpek :
                         ansattFnr = sakInput.ansattFnr,
                         virksomhetsnummer = sakInput.virksomhetsnummer,
                         type = SAK_TYPE_DIALOGMOTE_UTEN_LEDER,
+                        mottakerType = MottakerType.ALTINN,
+                    )
+                val storedSakWithWrongMottakerType =
+                    senderFacade.getPaagaaendeSakByType(
+                        ansattFnr = sakInput.ansattFnr,
+                        virksomhetsnummer = sakInput.virksomhetsnummer,
+                        type = SAK_TYPE_DIALOGMOTE_UTEN_LEDER,
+                        mottakerType = MottakerType.NAERMESTE_LEDER,
                     )
 
                 storedSak?.id shouldBe storedId
@@ -253,6 +262,7 @@ class SenderFacadeSpek :
                 storedSak?.mottakerType shouldBe MottakerType.ALTINN
                 storedSak?.narmestelederId shouldBe null
                 storedSak?.narmesteLederFnr shouldBe null
+                storedSakWithWrongMottakerType shouldBe null
                 mutationSlot.captured.lenke shouldBe Optional.Absent
             }
         }


### PR DESCRIPTION
## Beskrivelse

Implementerer støtte for arbeidsgivervarsel for dialogmøter uten nærmeste leder. Varsel sendes mot Altinn3-ressurs, sak opprettes eller gjenbrukes, feilede utsendinger lagres med retry-kontekst, og retry håndterer idempotens basert på unik ekstern referanse per varsel. Nye saker får UUID-basert `grupperingsid`.

I tillegg oppdateres sakslagringen for arbeidsgivernotifikasjoner: `lenke` på sak kan nå være `NULL`, og ny `mottaker_type` skiller mellom saker opprettet for nærmeste leder og saker opprettet for Altinn-mottaker. Ved gjenbruk av eksisterende sak filtrerer vi på både `mottaker_type` og `ressursId`, fordi arbeidsgivernotifikasjon-api ikke tillater å legge beskjed/oppgave på en sak med annen mottakertype enn saken ble opprettet med, og Altinn-varsler ikke skal gjenbruke sak for en annen ressurs.

## Endringer

- `ArbeidsgiverVarselService`: behandler `AG_VARSEL_ALTINN_RESSURS`, oppretter/gjenbruker sak, sender varsel og lagrer utsending/feil
- `ResendFailedVarslerJob`: retry av feilede arbeidsgivervarsler mot Altinn-ressurs
- `ArbeidsgivernotifikasjonerDAO`: støtte for oppdatering av `hardDeleteDate`, nullable `lenke`, `mottaker_type`, og saksgjenbruk filtrert på mottakertype og `ressursId`
- `ARBEIDSGIVERNOTIFIKASJONER_SAK`: `lenke` gjøres nullable, og `mottaker_type` legges til med default `NAERMESTE_LEDER` og CHECK constraint for gyldige verdier
- `NySakAltinnInput`: sender ikke lenger `lenke` på `nySak`, Altinn-saker lagres med `mottaker_type = ALTINN`, og nye saker får UUID-basert `grupperingsid`
- `NySakNarmesteLederInput`: beholder lenke og lagres med `mottaker_type = NAERMESTE_LEDER`
- `UtsendtVarselFeiletDAO`: henter feilede AG-varsler for retry og filtrerer bort allerede utsendte varsler
- Tester for happy path, saksgjenbruk, mottakertype-/ressursId-filtrering, feilregistrering, retry og hardDeleteDate-oppdatering

## Issue

Closes #977

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet automatisk med `./gradlew build`
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
