### PR TITLE
Legger til mer logging i ArbeidsgiverNotifikasjonProdusent

### DIFF
--- a/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonProdusent.kt
+++ b/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonProdusent.kt
@@ -92,7 +92,9 @@ class ArbeidsgiverNotifikasjonProdusent(
             log.info("Created new beskjed with id ${result.onNyBeskjedVellykket.id}")
             return result.onNyBeskjedVellykket.id
         } else {
-            log.error("Could not create new beskjed")
+            log.error(
+                "Could not create new beskjed for grupperingsid ${arbeidsgiverNotifikasjonInput.grupperingsid} and merkelapp ${arbeidsgiverNotifikasjonInput.merkelapp}",
+            )
             response.errors?.forEach {
                 log.error("createNewBeskjed response error: ${it.message}")
             }
@@ -161,7 +163,7 @@ class ArbeidsgiverNotifikasjonProdusent(
         val result = response.data?.nyStatusSakByGrupperingsid
 
         if (result?.onNyStatusSakVellykket != null) {
-            log.info("Updated sak with id ${result.onNyStatusSakVellykket.id}")
+            log.info("Updated sak with id ${result.onNyStatusSakVellykket.id} and grupperingsid: ${nyStatusSakInput.grupperingsId}")
             return result.onNyStatusSakVellykket.id
         } else {
             log.error("Could not update sak")


### PR DESCRIPTION
# Pull request overview
Denne PR-en forbedrer feilsøking/observability for integrasjonen mot arbeidsgivernotifikasjon-produsent ved å legge til mer kontekst i eksisterende logger i ArbeidsgiverNotifikasjonProdusent.

## Changes:

Utvider feillogg ved createNewBeskjedForArbeidsgiver med grupperingsid og merkelapp.
Utvider infologg ved nyStatusSak med grupperingsId i tillegg til sak-id.