### PR TITLE
Send Optional.Absent i nybeskjed.metadata når hardDelete er null

### DIFF
--- a/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/domain/ArbeidsgiverNotifikasjon.kt
+++ b/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/domain/ArbeidsgiverNotifikasjon.kt
@@ -89,11 +89,9 @@ sealed class ArbeidsgiverNotifikasjon {
             eksternId = varselId,
             grupperingsid = Optional.present(grupperingsid),
             hardDelete =
-                Optional.present(
-                    FutureTemporalInput(
-                        den = Optional.present(hardDeleteDate?.formatAsISO8601DateTime()),
-                    ),
-                ),
+                hardDeleteDate?.let {
+                    Optional.present(FutureTemporalInput(den = Optional.present(it.formatAsISO8601DateTime())))
+                } ?: Optional.Absent,
         )
 
     protected enum class MutationType {


### PR DESCRIPTION
## Pull request overview

Endrer GraphQL-mapping for arbeidsgivernotifikasjoner slik at `NyBeskjedInput.metadata.hardDelete` sendes som `Optional.Absent` når `hardDeleteDate` er `null`, i stedet for å sende en `Present`-wrapper med `den = null`. Dette gir mer korrekt Optional-semantikk mot GraphQL/Apollo-typene.

**Changes:**
- Oppdaterer `createMetadata()` til å returnere `Optional.Absent` for `hardDelete` når `hardDeleteDate` er `null`.
- Forenkler konstruksjonen av `FutureTemporalInput` når `hardDeleteDate` er satt (bruker `let`).




