### PR TITLE
Fix/is 3999 ekstern ref index

### DIFF
--- a/src/main/kotlin/no/nav/syfo/consumer/dkif/DkifConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/consumer/dkif/DkifConsumer.kt
@@ -1,7 +1,6 @@
 package no.nav.syfo.consumer.dkif
 
 import io.ktor.client.call.body
-import io.ktor.client.plugins.ClientRequestException
 import io.ktor.client.request.headers
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody

--- a/src/main/kotlin/no/nav/syfo/db/Database.kt
+++ b/src/main/kotlin/no/nav/syfo/db/Database.kt
@@ -4,6 +4,7 @@ import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import no.nav.syfo.DbEnv
 import org.flywaydb.core.Flyway
+import org.flywaydb.database.postgresql.PostgreSQLConfigurationExtension
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.sql.Connection
@@ -33,7 +34,7 @@ class Database(
         )
 
     init {
-        runFlywayMigrations(hikariDataSource)
+        runFlywayMigrations()
     }
 
     override val connection: Connection
@@ -41,9 +42,18 @@ class Database(
 
     override val log: Logger = LoggerFactory.getLogger(Database::class.qualifiedName)
 
-    private fun runFlywayMigrations(hikariDataSource: HikariDataSource) =
+    // Flyway runs on its own driver-based connection with autoCommit=true (Flyway's default) so that
+    // migrations using CREATE INDEX CONCURRENTLY (which cannot run inside a transaction block) work
+    // correctly. The application pool uses autoCommit=false, which would otherwise wrap each statement
+    // in an implicit transaction and cause CONCURRENTLY to hang.
+    //
+    // transactionalLock=false makes Flyway take a session-level advisory lock instead of a
+    // transactional one. A transactional lock keeps a connection idle-in-transaction for the whole
+    // migration run, and that open snapshot blocks CREATE INDEX CONCURRENTLY indefinitely.
+    private fun runFlywayMigrations() =
         Flyway.configure().run {
-            dataSource(hikariDataSource)
+            dataSource(generateJdbcUrlFromEnv(env), env.dbUsername, env.dbPassword)
+            getConfigurationExtension(PostgreSQLConfigurationExtension::class.java).isTransactionalLock = false
             load().migrate().migrationsExecuted
         }
 }

--- a/src/main/resources/db/migration/V45__add_index_utsendt_varsel_ekstern_ref.sql
+++ b/src/main/resources/db/migration/V45__add_index_utsendt_varsel_ekstern_ref.sql
@@ -1,0 +1,2 @@
+-- flyway:executeInTransaction=false
+CREATE INDEX CONCURRENTLY IF NOT EXISTS utsendt_varsel_ekstern_ref_index ON UTSENDT_VARSEL (ekstern_ref);

--- a/src/main/resources/db/migration/V45__add_index_utsendt_varsel_ekstern_ref.sql
+++ b/src/main/resources/db/migration/V45__add_index_utsendt_varsel_ekstern_ref.sql
@@ -1,2 +1,1 @@
--- flyway:executeInTransaction=false
-CREATE INDEX CONCURRENTLY IF NOT EXISTS utsendt_varsel_ekstern_ref_index ON UTSENDT_VARSEL (ekstern_ref);
+CREATE INDEX IF NOT EXISTS utsendt_varsel_ekstern_ref_index ON UTSENDT_VARSEL (ekstern_ref);

--- a/src/main/resources/db/migration/V45__add_index_utsendt_varsel_ekstern_ref.sql
+++ b/src/main/resources/db/migration/V45__add_index_utsendt_varsel_ekstern_ref.sql
@@ -1,1 +1,2 @@
-CREATE INDEX IF NOT EXISTS utsendt_varsel_ekstern_ref_index ON UTSENDT_VARSEL (ekstern_ref);
+-- flyway:executeInTransaction=false
+CREATE INDEX CONCURRENTLY IF NOT EXISTS utsendt_varsel_ekstern_ref_index ON UTSENDT_VARSEL (ekstern_ref);

--- a/src/test/kotlin/no/nav/syfo/testutil/EmbeddedDatabase.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/EmbeddedDatabase.kt
@@ -4,6 +4,7 @@ import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import no.nav.syfo.db.DatabaseInterface
 import org.flywaydb.core.Flyway
+import org.flywaydb.database.postgresql.PostgreSQLConfigurationExtension
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.testcontainers.containers.PostgreSQLContainer
@@ -44,12 +45,21 @@ class EmbeddedDatabase : DatabaseInterface {
                 transactionIsolation = "TRANSACTION_REPEATABLE_READ"
             }
 
-        HikariDataSource(config).also { ds ->
+        HikariDataSource(config).also {
+            // Flyway runs on its own driver-based connection with autoCommit=true (Flyway's default)
+            // so that migrations using CREATE INDEX CONCURRENTLY (which cannot run inside a
+            // transaction block) work correctly. The application pool uses autoCommit=false.
+            //
+            // transactionalLock=false makes Flyway take a session-level advisory lock instead of a
+            // transactional one. A transactional lock keeps a connection idle-in-transaction for the
+            // whole migration run, and that open snapshot blocks CREATE INDEX CONCURRENTLY indefinitely.
             Flyway
                 .configure()
-                .dataSource(ds)
+                .dataSource(postgresContainer.jdbcUrl, postgresContainer.username, postgresContainer.password)
                 .cleanDisabled(false)
-                .load()
+                .apply {
+                    getConfigurationExtension(PostgreSQLConfigurationExtension::class.java).isTransactionalLock = false
+                }.load()
                 .apply {
                     clean()
                     migrate()


### PR DESCRIPTION
## Beskrivelse

Opplever at det er noe etterslep på prossesering av hendelser i esyfovarsel. Har spesifikt sett på ferdigstilling av varsler for kartleggingsspørsmål. Personer som har svart, men som mangler ferdigstilling. Sjekker man opp samme varsel senere på dagen, er plutselig varselet ferdigstilt.

Query Insights i GCP peker på `UPDATE UTSENDT_VARSEL SET ferdigstilt_tidspunkt = $1 WHERE EKSTERN_REF = $2` som en spørring som har høy "load by total time". Legger derfor på en indeks i et forsøk på å få fart på ting.

Draft for å foreløpig unngå deploy til dev.

## Issue

Relatert til https://trello.com/c/IvCY3nze/3999-meldt-feil-p%C3%A5-innloggede-sider-om-oppgave-som-ikke-forsvinner

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
