### PR TITLE
feat(oppfolgingsplan): støtt varselbestilling til nærmeste leder

### DIFF
--- a/scripts/messages/narmeste-leder-oppfolgingsplan-foresporsel.json
+++ b/scripts/messages/narmeste-leder-oppfolgingsplan-foresporsel.json
@@ -1,0 +1,8 @@
+{
+  "@type": "NarmesteLederHendelse",
+  "type": "NL_OPPFOLGINGSPLAN_FORESPORSEL",
+  "ferdigstill": false,
+  "narmesteLederFnr": "01987654322",
+  "arbeidstakerFnr": "22345678910",
+  "orgnummer": "999999999"
+}

--- a/scripts/messages/narmeste-leder-oppfolgingsplan-paaminnelse.json
+++ b/scripts/messages/narmeste-leder-oppfolgingsplan-paaminnelse.json
@@ -1,0 +1,17 @@
+{
+  "@type": "NarmesteLederHendelse",
+  "type": "NL_OPPFOLGINGSPLAN_VARSELBESTILLING",
+  "ferdigstill": false,
+  "data": {
+    "arbeidsgiverMeldingType": "BESKJED",
+    "dineSykmeldteHendelseType": "OPPFOLGINGSPLAN_PAAMINNELSE",
+    "notifikasjonInnhold": {
+      "epostTittel": "Påminnelse om oppfølgingsplan til Forsiktig Dronning",
+      "epostBody": "Du har bedt oss minne deg på at du skal lage en oppfølgingsplan for Forsiktig Dronning. Du kan lage oppfølgingsplanen ved å logge inn på Dine sykmeldte på navn.no.",
+      "varselTekst": "Lag oppfølgingsplan"
+    }
+  },
+  "narmesteLederFnr": "01987654322",
+  "arbeidstakerFnr": "22345678910",
+  "orgnummer": "999999999"
+}

--- a/scripts/messages/narmeste-leder-oppfolgingsplan-paaminnelse.json
+++ b/scripts/messages/narmeste-leder-oppfolgingsplan-paaminnelse.json
@@ -8,7 +8,6 @@
     "ressursUrl": "https://www.ekstern.dev.nav.no/syk/oppfolgingsplan/NARMESTE_LEDER_ID",
     "notifikasjonInnhold": {
       "epostTittel": "Påminnelse om oppfølgingsplan til Forsiktig Dronning",
-      "epostBody": "Du har bedt oss minne deg på at du skal lage en oppfølgingsplan for Forsiktig Dronning. Du kan lage oppfølgingsplanen ved å logge inn på Dine sykmeldte på navn.no.",
       "varselTekst": "Lag oppfølgingsplan"
     }
   },

--- a/scripts/messages/narmeste-leder-oppfolgingsplan-paaminnelse.json
+++ b/scripts/messages/narmeste-leder-oppfolgingsplan-paaminnelse.json
@@ -5,6 +5,7 @@
   "data": {
     "arbeidsgiverMeldingType": "BESKJED",
     "dineSykmeldteHendelseType": "OPPFOLGINGSPLAN_PAAMINNELSE",
+    "ressursUrl": "https://www.ekstern.dev.nav.no/syk/oppfolgingsplan/NARMESTE_LEDER_ID",
     "notifikasjonInnhold": {
       "epostTittel": "Påminnelse om oppfølgingsplan til Forsiktig Dronning",
       "epostBody": "Du har bedt oss minne deg på at du skal lage en oppfølgingsplan for Forsiktig Dronning. Du kan lage oppfølgingsplanen ved å logge inn på Dine sykmeldte på navn.no.",

--- a/scripts/publish-varselbus-message.sh
+++ b/scripts/publish-varselbus-message.sh
@@ -33,7 +33,7 @@ fi
 json_payload="$(tr -d '\r\n' < "$json_file")"
 
 printf '%s%s%s\n' "$message_key" "$key_separator" "$json_payload" | \
-  docker exec -i "$docker_container" kafka-console-producer \
+  podman exec -i "$docker_container" kafka-console-producer \
     --bootstrap-server "$bootstrap_server" \
     --topic "$topic" \
     --property parse.key=true \

--- a/src/main/kotlin/no/nav/syfo/BootstrapApplication.kt
+++ b/src/main/kotlin/no/nav/syfo/BootstrapApplication.kt
@@ -261,6 +261,7 @@ fun setModule(env: Environment): Application.() -> Unit =
                 kartleggingVarselService = kartleggingssporsmalVarselService,
                 senderFacade = senderFacade,
                 arbeidsgiverVarselService = arbeidsgiverVarselService,
+                oppfolgingsplanVarselService = oppfolgingsplanVarselService,
             )
 
         val varselBusService =

--- a/src/main/kotlin/no/nav/syfo/db/UtsendtVarselFeiletDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/db/UtsendtVarselFeiletDAO.kt
@@ -43,7 +43,7 @@ fun DatabaseInterface.fetchUtsendtArbeidsgivernotifikasjonVarselFeilet(): List<P
         AND feilet.is_resendt = FALSE
         AND feilet.resend_exhausted IS NOT TRUE
         AND feilet.hendelsetype_navn in 
-        ('NL_DIALOGMOTE_SVAR_MOTEBEHOV', 'AG_VARSEL_ALTINN_RESSURS')
+        ('NL_DIALOGMOTE_SVAR_MOTEBEHOV', 'AG_VARSEL_ALTINN_RESSURS', 'NL_OPPFOLGINGSPLAN_VARSELBESTILLING')
         AND NOT EXISTS (
             SELECT 1
             FROM UTSENDT_VARSEL UV

--- a/src/main/kotlin/no/nav/syfo/db/domain/PUtsendtVarselFeilet.kt
+++ b/src/main/kotlin/no/nav/syfo/db/domain/PUtsendtVarselFeilet.kt
@@ -5,6 +5,7 @@ import no.nav.syfo.kafka.common.createObjectMapper
 import no.nav.syfo.kafka.consumers.varselbus.domain.ArbeidsgiverNotifikasjonTilAltinnRessursHendelse
 import no.nav.syfo.kafka.consumers.varselbus.domain.ArbeidstakerHendelse
 import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType
+import no.nav.syfo.kafka.consumers.varselbus.domain.NarmesteLederHendelse
 import java.time.LocalDateTime
 
 private val objectMapper = createObjectMapper()
@@ -43,4 +44,15 @@ fun PUtsendtVarselFeilet.toArbeidsgiverNotifikasjonTilAltinnRessursHendelse(): A
             "Mangler hendelseJson for feilet arbeidsgiverhendelse"
         }
     return objectMapper.readValue(hendelseJson)
+}
+
+fun PUtsendtVarselFeilet.toNarmesteLederHendelse(): NarmesteLederHendelse {
+    val hendelseJson =
+        requireNotNull(hendelseJson) {
+            "Mangler hendelseJson for feilet nærmeste-leder-hendelse"
+        }
+    val rootNode = objectMapper.readTree(hendelseJson)
+    return objectMapper.readValue<NarmesteLederHendelse>(hendelseJson).also {
+        it.data = rootNode["data"]
+    }
 }

--- a/src/main/kotlin/no/nav/syfo/job/ResendFailedVarslerJob.kt
+++ b/src/main/kotlin/no/nav/syfo/job/ResendFailedVarslerJob.kt
@@ -20,6 +20,7 @@ import no.nav.syfo.service.DialogmoteInnkallingSykmeldtVarselService
 import no.nav.syfo.service.KartleggingssporsmalVarselService
 import no.nav.syfo.service.MerVeiledningVarselService
 import no.nav.syfo.service.MotebehovVarselService
+import no.nav.syfo.service.OppfolgingsplanVarselService
 import no.nav.syfo.service.SenderFacade
 import org.slf4j.LoggerFactory
 import java.util.UUID
@@ -32,6 +33,7 @@ class ResendFailedVarslerJob(
     private val kartleggingVarselService: KartleggingssporsmalVarselService,
     private val senderFacade: SenderFacade,
     private val arbeidsgiverVarselService: ArbeidsgiverVarselService,
+    private val oppfolgingsplanVarselService: OppfolgingsplanVarselService,
 ) {
     private val log = LoggerFactory.getLogger(ResendFailedVarslerJob::class.java)
 
@@ -132,6 +134,7 @@ class ResendFailedVarslerJob(
                     when (failedVarsel.hendelsetypeNavn) {
                         "AG_VARSEL_ALTINN_RESSURS" -> tryResendArbeidsgiverAltinnRessursVarsel(failedVarsel)
                         "NL_DIALOGMOTE_SVAR_MOTEBEHOV" -> tryResendArbeidsgivernotifikasjonMoteBehov(failedVarsel)
+                        "NL_OPPFOLGINGSPLAN_VARSELBESTILLING" -> tryResendOppfolgingsplanVarselbestilling(failedVarsel)
                         else -> {
                             log.warn("Not resending varsel for hendelsetypeNavn: ${failedVarsel.hendelsetypeNavn}")
                             return@map 0
@@ -271,6 +274,21 @@ class ResendFailedVarslerJob(
         }
         return 0
     }
+
+    private suspend fun tryResendOppfolgingsplanVarselbestilling(failedVarsel: PUtsendtVarselFeilet): Int =
+        when (oppfolgingsplanVarselService.resendVarselbestillingTilArbeidsgiverNotifikasjon(failedVarsel)) {
+            ArbeidsgiverVarselResendResult.RESENT -> {
+                db.updateUtsendtVarselFeiletToResendt(failedVarsel.uuid, nullstillHendelseJson = true)
+                1
+            }
+
+            ArbeidsgiverVarselResendResult.PERMANENT_FAILURE -> {
+                db.updateUtsendtVarselFeiletToResendExhausted(failedVarsel.uuid)
+                0
+            }
+
+            ArbeidsgiverVarselResendResult.RETRYABLE_FAILURE -> 0
+        }
 }
 
 private fun HendelseType.toDistribusjonsType() =

--- a/src/main/kotlin/no/nav/syfo/kafka/consumers/varselbus/domain/DineSykmeldteHendelseType.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/consumers/varselbus/domain/DineSykmeldteHendelseType.kt
@@ -7,7 +7,7 @@ enum class DineSykmeldteHendelseType {
     DIALOGMOTE_AVLYSNING,
     DIALOGMOTE_ENDRING,
     DIALOGMOTE_REFERAT,
-    OPPFOLGINGSPLAN_PAAMINNELSE
+    OPPFOLGINGSPLAN_PAAMINNELSE,
 }
 
 fun HendelseType.toDineSykmeldteHendelseType(): DineSykmeldteHendelseType =

--- a/src/main/kotlin/no/nav/syfo/kafka/consumers/varselbus/domain/DineSykmeldteHendelseType.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/consumers/varselbus/domain/DineSykmeldteHendelseType.kt
@@ -7,10 +7,12 @@ enum class DineSykmeldteHendelseType {
     DIALOGMOTE_AVLYSNING,
     DIALOGMOTE_ENDRING,
     DIALOGMOTE_REFERAT,
+    OPPFOLGINGSPLAN_PAAMINNELSE
 }
 
 fun HendelseType.toDineSykmeldteHendelseType(): DineSykmeldteHendelseType =
     when (this) {
+        HendelseType.NL_OPPFOLGINGSPLAN_VARSELBESTILLING -> DineSykmeldteHendelseType.OPPFOLGINGSPLAN_PAAMINNELSE
         HendelseType.NL_OPPFOLGINGSPLAN_SENDT_TIL_GODKJENNING -> DineSykmeldteHendelseType.OPPFOLGINGSPLAN_TIL_GODKJENNING
         HendelseType.NL_DIALOGMOTE_SVAR_MOTEBEHOV -> DineSykmeldteHendelseType.DIALOGMOTE_SVAR_BEHOV
         HendelseType.NL_DIALOGMOTE_INNKALT -> DineSykmeldteHendelseType.DIALOGMOTE_INNKALLING

--- a/src/main/kotlin/no/nav/syfo/kafka/consumers/varselbus/domain/EsyfovarselHendelse.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/consumers/varselbus/domain/EsyfovarselHendelse.kt
@@ -60,6 +60,18 @@ data class VarselData(
     val notifikasjonInnhold: VarselDataNotifikasjonInnhold? = null,
 )
 
+data class OppfolgingsplanVarselbestillingData(
+    val arbeidsgiverMeldingType: String?,
+    val dineSykmeldteHendelseType: String?,
+    val notifikasjonInnhold: OppfolgingsplanNotifikasjonInnhold? = null,
+)
+
+data class OppfolgingsplanNotifikasjonInnhold(
+    val epostTittel: String,
+    val epostBody: String,
+    val varselTekst: String? = null,
+)
+
 data class VarselDataNotifikasjonInnhold(
     val epostTittel: String,
     val epostBody: String,
@@ -108,6 +120,7 @@ data class VarselDataDialogmoteSvar(
  */
 enum class HendelseType {
     AG_VARSEL_ALTINN_RESSURS,
+    NL_OPPFOLGINGSPLAN_VARSELBESTILLING,
     NL_OPPFOLGINGSPLAN_SENDT_TIL_GODKJENNING,
     SM_OPPFOLGINGSPLAN_SENDT_TIL_GODKJENNING,
     NL_DIALOGMOTE_SVAR_MOTEBEHOV,
@@ -164,6 +177,12 @@ fun Any.toVarselData(): VarselData =
     objectMapper.readValue(
         this.toString(),
         VarselData::class.java,
+    )
+
+fun Any.toOppfolgingsplanVarselbestillingData(): OppfolgingsplanVarselbestillingData =
+    objectMapper.readValue(
+        this.toString(),
+        OppfolgingsplanVarselbestillingData::class.java,
     )
 
 fun EsyfovarselHendelse.isArbeidstakerHendelse(): Boolean = this is ArbeidstakerHendelse

--- a/src/main/kotlin/no/nav/syfo/kafka/consumers/varselbus/domain/EsyfovarselHendelse.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/consumers/varselbus/domain/EsyfovarselHendelse.kt
@@ -63,6 +63,7 @@ data class VarselData(
 data class OppfolgingsplanVarselbestillingData(
     val arbeidsgiverMeldingType: String?,
     val dineSykmeldteHendelseType: String?,
+    val ressursUrl: String?,
     val notifikasjonInnhold: OppfolgingsplanNotifikasjonInnhold? = null,
 )
 

--- a/src/main/kotlin/no/nav/syfo/metrics/AppMetrics.kt
+++ b/src/main/kotlin/no/nav/syfo/metrics/AppMetrics.kt
@@ -18,6 +18,7 @@ const val KARTLEGGINGSSPORSMAL_NOTICE_SENT = "${METRICS_NS}_kartleggingssporsmal
 const val NOTICE_SENT = "${METRICS_NS}_notice_sent"
 const val CALL_PDL_SUCCESS = "${METRICS_NS}_call_pdl_success_count"
 const val CALL_PDL_FAIL = "${METRICS_NS}_call_pdl_fail_count"
+const val OPPFOLGINGSPLAN_VARSEL_UGYLDIG = "${METRICS_NS}_oppfolgingsplan_varsel_ugyldig_count"
 const val ARBEIDSGIVER_NOTIFIKASJON_MESSAGE_TEXT_TRUNCATED =
     "${METRICS_NS}_arbeidsgiver_notifikasjon_message_text_truncated"
 
@@ -60,6 +61,12 @@ val COUNT_CALL_PDL_FAIL: Counter =
         .description("Counts the number of failed calls to pdl")
         .register(METRICS_REGISTRY)
 
+val COUNT_OPPFOLGINGSPLAN_VARSEL_UGYLDIG: Counter =
+    Counter
+        .builder(OPPFOLGINGSPLAN_VARSEL_UGYLDIG)
+        .description("Counts the number of invalid oppfolgingsplan varsel payloads")
+        .register(METRICS_REGISTRY)
+
 val COUNT_ARBEIDSGIVER_NOTIFIKASJON_MESSAGE_TEXT_TRUNCATED: Counter =
     Counter
         .builder(ARBEIDSGIVER_NOTIFIKASJON_MESSAGE_TEXT_TRUNCATED)
@@ -83,6 +90,10 @@ fun tellSvarMotebehovVarselSendt(varslerSendt: Int) {
 
 fun countArbeidsgiverNotifikasjonMessageTextTruncated() {
     COUNT_ARBEIDSGIVER_NOTIFIKASJON_MESSAGE_TEXT_TRUNCATED.increment()
+}
+
+fun countOppfolgingsplanVarselUgyldig() {
+    COUNT_OPPFOLGINGSPLAN_VARSEL_UGYLDIG.increment()
 }
 
 fun Routing.registerPrometheusApi() {

--- a/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/FakeArbeidsgiverNotifikasjonProdusent.kt
+++ b/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/FakeArbeidsgiverNotifikasjonProdusent.kt
@@ -22,7 +22,7 @@ class FakeArbeidsgiverNotifikasjonProdusent : IArbeidsgiverNotifikasjonProdusent
     override suspend fun createNewBeskjedForArbeidsgiver(arbeidsgiverNotifikasjonInput: ArbeidsgiverNotifikasjon): String =
         UUID.randomUUID().toString().also { id ->
             log.info(
-                "Lokal arbeidsgivernotifikasjon beskjed opprettet: merkelapp=${arbeidsgiverNotifikasjonInput.merkelapp}, virksomhetsnummer=${arbeidsgiverNotifikasjonInput.virksomhetsnummer}, id=$id",
+                "Lokal arbeidsgivernotifikasjon beskjed opprettet: merkelapp=${arbeidsgiverNotifikasjonInput.merkelapp}, virksomhetsnummer=${arbeidsgiverNotifikasjonInput.virksomhetsnummer}, id=$id, messageText=${arbeidsgiverNotifikasjonInput.messageText}, epostTitle=${arbeidsgiverNotifikasjonInput.emailTitle}, epostBody=${arbeidsgiverNotifikasjonInput.emailBody}, url=${arbeidsgiverNotifikasjonInput.url}",
             )
         }
 

--- a/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/FakeArbeidsgiverNotifikasjonProdusent.kt
+++ b/src/main/kotlin/no/nav/syfo/producer/arbeidsgivernotifikasjon/FakeArbeidsgiverNotifikasjonProdusent.kt
@@ -22,7 +22,7 @@ class FakeArbeidsgiverNotifikasjonProdusent : IArbeidsgiverNotifikasjonProdusent
     override suspend fun createNewBeskjedForArbeidsgiver(arbeidsgiverNotifikasjonInput: ArbeidsgiverNotifikasjon): String =
         UUID.randomUUID().toString().also { id ->
             log.info(
-                "Lokal arbeidsgivernotifikasjon beskjed opprettet: merkelapp=${arbeidsgiverNotifikasjonInput.merkelapp}, virksomhetsnummer=${arbeidsgiverNotifikasjonInput.virksomhetsnummer}, id=$id, messageText=${arbeidsgiverNotifikasjonInput.messageText}, epostTitle=${arbeidsgiverNotifikasjonInput.emailTitle}, epostBody=${arbeidsgiverNotifikasjonInput.emailBody}, url=${arbeidsgiverNotifikasjonInput.url}",
+                "Lokal arbeidsgivernotifikasjon beskjed opprettet: merkelapp=${arbeidsgiverNotifikasjonInput.merkelapp}, virksomhetsnummer=${arbeidsgiverNotifikasjonInput.virksomhetsnummer}, id=$id",
             )
         }
 

--- a/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverNotifikasjonService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverNotifikasjonService.kt
@@ -1,8 +1,6 @@
 package no.nav.syfo.service
 
 import com.apollo.graphql.NySakMutation
-import com.fasterxml.jackson.annotation.JsonEnumDefaultValue
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import no.nav.syfo.consumer.narmesteLeder.NarmesteLederService
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.IArbeidsgiverNotifikasjonProdusent
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.ArbeidsgiverDeleteNotifikasjon

--- a/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverNotifikasjonService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/ArbeidsgiverNotifikasjonService.kt
@@ -1,6 +1,8 @@
 package no.nav.syfo.service
 
 import com.apollo.graphql.NySakMutation
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import no.nav.syfo.consumer.narmesteLeder.NarmesteLederService
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.IArbeidsgiverNotifikasjonProdusent
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.ArbeidsgiverDeleteNotifikasjon
@@ -21,7 +23,7 @@ class ArbeidsgiverNotifikasjonService(
 ) {
     private val log: Logger = LoggerFactory.getLogger(ArbeidsgiverNotifikasjonService::class.qualifiedName)
 
-    suspend fun sendNotifikasjon(arbeidsgiverNotifikasjon: ArbeidsgiverNotifikasjonNarmestelederInput) {
+    suspend fun sendNotifikasjon(arbeidsgiverNotifikasjon: ArbeidsgiverNotifikasjonNarmestelederInput): Boolean {
         val narmesteLederRelasjon =
             narmesteLederService.getNarmesteLederRelasjon(
                 arbeidsgiverNotifikasjon.ansattFnr,
@@ -29,17 +31,17 @@ class ArbeidsgiverNotifikasjonService(
             )
 
         if (narmesteLederRelasjon == null || !narmesteLederService.hasNarmesteLederInfo(narmesteLederRelasjon)) {
-            log.warn("Sender ikke varsel til ag-notifikasjon: narmesteLederRelasjon er null eller har ikke kontaktinfo")
-            return
+            log.warn("Sender ikke varsel til ag-notifikasjon: narmesteLederRelasjon er null eller mangler nødvendig kontaktinfo")
+            return false
         }
 
-        if (arbeidsgiverNotifikasjon.narmesteLederFnr !== null &&
+        if (arbeidsgiverNotifikasjon.narmesteLederFnr != null &&
             arbeidsgiverNotifikasjon.narmesteLederFnr != narmesteLederRelasjon.narmesteLederFnr
         ) {
             log.warn(
                 "Sender ikke varsel til ag-notifikasjon: den ansatte har nærmeste leder med annet fnr enn mottaker i varselHendelse",
             )
-            return
+            return false
         }
 
         val url = arbeidsgiverNotifikasjon.link ?: "$dineSykmeldteUrl/${narmesteLederRelasjon.narmesteLederId}"
@@ -60,17 +62,24 @@ class ArbeidsgiverNotifikasjonService(
                 grupperingsid = arbeidsgiverNotifikasjon.grupperingsid,
             )
 
-        when (arbeidsgiverNotifikasjon.meldingstype) {
-            BESKJED ->
-                arbeidsgiverNotifikasjonProdusent.createNewBeskjedForArbeidsgiver(
-                    arbeidsgiverNotifikasjonNarmesteLeder,
-                )
+        val notifikasjonId =
+            when (arbeidsgiverNotifikasjon.meldingstype) {
+                BESKJED ->
+                    arbeidsgiverNotifikasjonProdusent.createNewBeskjedForArbeidsgiver(
+                        arbeidsgiverNotifikasjonNarmesteLeder,
+                    )
 
-            OPPGAVE ->
-                arbeidsgiverNotifikasjonProdusent.createNewOppgaveForArbeidsgiver(
-                    arbeidsgiverNotifikasjonNarmesteLeder,
-                )
+                OPPGAVE ->
+                    arbeidsgiverNotifikasjonProdusent.createNewOppgaveForArbeidsgiver(
+                        arbeidsgiverNotifikasjonNarmesteLeder,
+                    )
+            }
+        if (notifikasjonId == null) {
+            throw IllegalStateException(
+                "ArbeidsgiverNotifikasjonProdusent returnerte null ID ved utsending til nærmeste leder",
+            )
         }
+        return true
     }
 
     suspend fun sendNotifikasjon(arbeidsgiverNotifikasjon: ArbeidsgiverNotifikasjonAltinnRessursInput): String? {

--- a/src/main/kotlin/no/nav/syfo/service/MotebehovVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/MotebehovVarselService.kt
@@ -76,17 +76,17 @@ class MotebehovVarselService(
         senderFacade.sendTilArbeidsgiverNotifikasjon(
             varselHendelse,
             ArbeidsgiverNotifikasjonNarmestelederInput(
-                UUID.randomUUID(),
-                varselHendelse.orgnummer,
-                varselHendelse.narmesteLederFnr,
-                varselHendelse.arbeidstakerFnr,
-                ARBEIDSGIVERNOTIFIKASJON_OPPFOLGING_MERKELAPP,
-                ARBEIDSGIVERNOTIFIKASJON_SVAR_MOTEBEHOV_MESSAGE_TEXT,
-                ARBEIDSGIVERNOTIFIKASJON_SVAR_MOTEBEHOV_EMAIL_TITLE,
-                ARBEIDSGIVERNOTIFIKASJON_SVAR_MOTEBEHOV_EMAIL_BODY,
-                LocalDateTime.now().plusWeeks(weeksBeforeDelete),
-                Meldingstype.OPPGAVE,
-                UUID.randomUUID().toString(),
+                uuid = UUID.randomUUID(),
+                virksomhetsnummer = varselHendelse.orgnummer,
+                narmesteLederFnr = varselHendelse.narmesteLederFnr,
+                ansattFnr = varselHendelse.arbeidstakerFnr,
+                merkelapp = ARBEIDSGIVERNOTIFIKASJON_OPPFOLGING_MERKELAPP,
+                messageText = ARBEIDSGIVERNOTIFIKASJON_SVAR_MOTEBEHOV_MESSAGE_TEXT,
+                epostTittel = ARBEIDSGIVERNOTIFIKASJON_SVAR_MOTEBEHOV_EMAIL_TITLE,
+                epostHtmlBody = ARBEIDSGIVERNOTIFIKASJON_SVAR_MOTEBEHOV_EMAIL_BODY,
+                hardDeleteDate = LocalDateTime.now().plusWeeks(weeksBeforeDelete),
+                meldingstype = Meldingstype.OPPGAVE,
+                grupperingsid = UUID.randomUUID().toString(),
             ),
         )
     }
@@ -148,21 +148,20 @@ class MotebehovVarselService(
         }
         val notifikasjon =
             ArbeidsgiverNotifikasjonNarmestelederInput(
-                UUID.randomUUID(),
-                utsendtvarselFeilet.orgnummer,
-                utsendtvarselFeilet.narmesteLederFnr,
-                utsendtvarselFeilet.arbeidstakerFnr,
-                ARBEIDSGIVERNOTIFIKASJON_OPPFOLGING_MERKELAPP,
-                ARBEIDSGIVERNOTIFIKASJON_SVAR_MOTEBEHOV_MESSAGE_TEXT,
-                ARBEIDSGIVERNOTIFIKASJON_SVAR_MOTEBEHOV_EMAIL_TITLE,
-                ARBEIDSGIVERNOTIFIKASJON_SVAR_MOTEBEHOV_EMAIL_BODY,
-                LocalDateTime.now().plusWeeks(weeksBeforeDelete),
-                Meldingstype.OPPGAVE,
-                UUID.randomUUID().toString(),
+                uuid = UUID.randomUUID(),
+                virksomhetsnummer = utsendtvarselFeilet.orgnummer,
+                narmesteLederFnr = utsendtvarselFeilet.narmesteLederFnr,
+                ansattFnr = utsendtvarselFeilet.arbeidstakerFnr,
+                merkelapp = ARBEIDSGIVERNOTIFIKASJON_OPPFOLGING_MERKELAPP,
+                messageText = ARBEIDSGIVERNOTIFIKASJON_SVAR_MOTEBEHOV_MESSAGE_TEXT,
+                epostTittel = ARBEIDSGIVERNOTIFIKASJON_SVAR_MOTEBEHOV_EMAIL_TITLE,
+                epostHtmlBody = ARBEIDSGIVERNOTIFIKASJON_SVAR_MOTEBEHOV_EMAIL_BODY,
+                hardDeleteDate = LocalDateTime.now().plusWeeks(weeksBeforeDelete),
+                meldingstype = Meldingstype.OPPGAVE,
+                grupperingsid = UUID.randomUUID().toString(),
             )
         try {
-            senderFacade.sendTilArbeidsgiverNotifikasjon(utsendtvarselFeilet, notifikasjon)
-            return true
+            return senderFacade.sendTilArbeidsgiverNotifikasjon(utsendtvarselFeilet, notifikasjon) == ArbeidsgiverVarselResendResult.RESENT
         } catch (e: Exception) {
             log.error(
                 "Could not resend arbeidsgiver notifikasjon for feiletVarsel: ${utsendtvarselFeilet.uuid}",

--- a/src/main/kotlin/no/nav/syfo/service/OppfolgingsplanVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/OppfolgingsplanVarselService.kt
@@ -26,6 +26,7 @@ import no.nav.syfo.kafka.consumers.varselbus.domain.OppfolgingsplanVarselbestill
 import no.nav.syfo.kafka.consumers.varselbus.domain.toDineSykmeldteHendelseType
 import no.nav.syfo.kafka.consumers.varselbus.domain.toOppfolgingsplanVarselbestillingData
 import no.nav.syfo.kafka.producers.dinesykmeldte.domain.DineSykmeldteVarsel
+import no.nav.syfo.metrics.countOppfolgingsplanVarselUgyldig
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NySakNarmesteLederInput
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.SakStatus
 import no.nav.syfo.service.SenderFacade.InternalBrukernotifikasjonType.BESKJED
@@ -88,9 +89,16 @@ class OppfolgingsplanVarselService(
     }
 
     suspend fun sendVarselbestillingTilNarmesteLeder(varselHendelse: NarmesteLederHendelse) {
-        val varselbestilling = varselHendelse.requireOppfolgingsplanVarselbestillingData()
-        val notifikasjonInnhold = requireNotNull(varselbestilling.notifikasjonInnhold)
-        val varselTekst = requireNotNull(notifikasjonInnhold.varselTekst)
+        val validatedVarselbestilling =
+            try {
+                varselHendelse.requireValidOppfolgingsplanVarselbestilling()
+            } catch (exception: OppfolgingsplanVarselPermanentException) {
+                handleInvalidOppfolgingsplanVarselbestilling(varselHendelse, exception)
+                return
+            }
+        val varselbestilling = validatedVarselbestilling.varselbestilling
+        val notifikasjonInnhold = validatedVarselbestilling.notifikasjonInnhold
+        val varselTekst = validatedVarselbestilling.varselTekst
 
         if (varselbestilling.dineSykmeldteHendelseType != null) {
             senderFacade.sendTilDineSykmeldte(
@@ -106,7 +114,7 @@ class OppfolgingsplanVarselService(
             )
         }
         if (varselbestilling.arbeidsgiverMeldingType != null) {
-            val meldingstype = varselbestilling.requireMeldingstype()
+            val meldingstype = requireNotNull(validatedVarselbestilling.meldingstype)
             val hendelseJson = objectMapper.writeValueAsString(varselHendelse)
             val hardDeleteDate = LocalDateTime.now().plusWeeks(WEEKS_BEFORE_DELETE)
             val eksternReferanseUuid = UUID.randomUUID()
@@ -155,8 +163,8 @@ class OppfolgingsplanVarselService(
                     log.error("Kunne ikke deserialisere feilet oppfølgingsplanvarsel for retry: {}", it.message)
                     return ArbeidsgiverVarselResendResult.PERMANENT_FAILURE
                 }
-        val varselbestilling =
-            runCatching { varselHendelse.requireOppfolgingsplanVarselbestillingData() }
+        val validatedVarselbestilling =
+            runCatching { varselHendelse.requireValidOppfolgingsplanVarselbestilling() }
                 .getOrElse {
                     log.error("Kunne ikke validere feilet oppfølgingsplanvarsel for retry: {}", it.message)
                     return ArbeidsgiverVarselResendResult.PERMANENT_FAILURE
@@ -171,9 +179,10 @@ class OppfolgingsplanVarselService(
                 log.error("Kunne ikke parse uuidEksternReferanse for feilet oppfølgingsplanvarsel: {}", it.message)
                 return ArbeidsgiverVarselResendResult.PERMANENT_FAILURE
             }
-        val notifikasjonInnhold = requireNotNull(varselbestilling.notifikasjonInnhold)
-        val varselTekst = requireNotNull(notifikasjonInnhold.varselTekst)
-        val meldingstype = varselbestilling.requireMeldingstype()
+        val varselbestilling = validatedVarselbestilling.varselbestilling
+        val notifikasjonInnhold = validatedVarselbestilling.notifikasjonInnhold
+        val varselTekst = validatedVarselbestilling.varselTekst
+        val meldingstype = requireNotNull(validatedVarselbestilling.meldingstype)
         val hardDeleteDate = LocalDateTime.now().plusWeeks(WEEKS_BEFORE_DELETE)
         val arbeidsgiverSak =
             try {
@@ -437,6 +446,30 @@ class OppfolgingsplanVarselService(
         link = link,
     )
 
+    private fun NarmesteLederHendelse.requireValidOppfolgingsplanVarselbestilling(): ValidatedOppfolgingsplanVarselbestilling {
+        val varselbestilling = requireOppfolgingsplanVarselbestillingData()
+        val notifikasjonInnhold =
+            varselbestilling.notifikasjonInnhold
+                ?: throw OppfolgingsplanVarselPermanentException(
+                    "Oppfølgingsplanvarsel mangler feltet: data.notifikasjonInnhold",
+                )
+        val varselTekst =
+            notifikasjonInnhold.varselTekst
+                ?: throw OppfolgingsplanVarselPermanentException(
+                    "Oppfølgingsplanvarsel mangler feltet: data.notifikasjonInnhold.varselTekst",
+                )
+        val meldingstype =
+            varselbestilling.arbeidsgiverMeldingType
+                ?.let { varselbestilling.requireMeldingstype() }
+
+        return ValidatedOppfolgingsplanVarselbestilling(
+            varselbestilling = varselbestilling,
+            notifikasjonInnhold = notifikasjonInnhold,
+            varselTekst = varselTekst,
+            meldingstype = meldingstype,
+        )
+    }
+
     private fun NarmesteLederHendelse.requireOppfolgingsplanVarselbestillingData(): OppfolgingsplanVarselbestillingData {
         val payloadDataNode =
             data?.let {
@@ -445,17 +478,17 @@ class OppfolgingsplanVarselService(
                 } else {
                     objectMapper.valueToTree(it)
                 }
-            } ?: throw IllegalArgumentException("Oppfølgingsplanvarsel mangler feltet: data")
+            } ?: throw OppfolgingsplanVarselPermanentException("Oppfølgingsplanvarsel mangler feltet: data")
 
         val payload =
             runCatching { payloadDataNode.toOppfolgingsplanVarselbestillingData() }
-                .getOrElse { throw IllegalArgumentException("Oppfølgingsplanvarsel har ugyldig format i data-feltet") }
+                .getOrElse { throw OppfolgingsplanVarselPermanentException("Oppfølgingsplanvarsel har ugyldig format i data-feltet") }
 
         if (payload.notifikasjonInnhold == null) {
-            throw IllegalArgumentException("Oppfølgingsplanvarsel mangler feltet: data.notifikasjonInnhold")
+            throw OppfolgingsplanVarselPermanentException("Oppfølgingsplanvarsel mangler feltet: data.notifikasjonInnhold")
         }
         if (!payloadDataNode.path("notifikasjonInnhold").hasNonNull("varselTekst")) {
-            throw IllegalArgumentException("Oppfølgingsplanvarsel mangler feltet: data.notifikasjonInnhold.varselTekst")
+            throw OppfolgingsplanVarselPermanentException("Oppfølgingsplanvarsel mangler feltet: data.notifikasjonInnhold.varselTekst")
         }
 
         return payload
@@ -465,9 +498,42 @@ class OppfolgingsplanVarselService(
         when (arbeidsgiverMeldingType) {
             Meldingstype.BESKJED.name -> Meldingstype.BESKJED
             Meldingstype.OPPGAVE.name -> Meldingstype.OPPGAVE
-            null -> throw IllegalArgumentException("Oppfølgingsplanvarsel mangler feltet: data.arbeidsgiverMeldingType")
-            else -> throw IllegalArgumentException("Oppfølgingsplanvarsel har ugyldig data.arbeidsgiverMeldingType=$arbeidsgiverMeldingType")
+            null -> throw OppfolgingsplanVarselPermanentException("Oppfølgingsplanvarsel mangler feltet: data.arbeidsgiverMeldingType")
+            else ->
+                throw OppfolgingsplanVarselPermanentException(
+                    "Oppfølgingsplanvarsel har ugyldig data.arbeidsgiverMeldingType=$arbeidsgiverMeldingType",
+                )
         }
+
+    private fun handleInvalidOppfolgingsplanVarselbestilling(
+        varselHendelse: NarmesteLederHendelse,
+        exception: OppfolgingsplanVarselPermanentException,
+    ) {
+        countOppfolgingsplanVarselUgyldig()
+        log.warn(
+            "Avviser ugyldig oppfølgingsplanvarselbestilling: type={}, feil={}",
+            varselHendelse.type,
+            exception.message,
+        )
+        senderFacade.lagreIkkeUtsendtArbeidsgiverNotifikasjonForNarmesteLeder(
+            varselHendelse = varselHendelse,
+            eksternReferanse = UUID.randomUUID().toString(),
+            feilmelding = exception.message,
+            merkelapp = ARBEIDSGIVERNOTIFIKASJON_OPPFOLGING_MERKELAPP,
+            hendelseJson = varselHendelse.serializeSafely(),
+            resendExhausted = true,
+        )
+    }
+
+    private fun NarmesteLederHendelse.serializeSafely(): String? =
+        runCatching { objectMapper.writeValueAsString(this) }
+            .onFailure { exception ->
+                log.error(
+                    "Kunne ikke serialisere oppfølgingsplanvarselbestilling for feillagring: type={}, feil={}",
+                    type,
+                    exception::class.simpleName ?: "UnknownException",
+                )
+            }.getOrNull()
 
     private data class OppfolgingsplanArbeidsgiverSak(
         val grupperingsid: String,
@@ -475,8 +541,19 @@ class OppfolgingsplanVarselService(
         val narmesteLederRelasjon: NarmesteLederRelasjon,
     )
 
+    private data class ValidatedOppfolgingsplanVarselbestilling(
+        val varselbestilling: OppfolgingsplanVarselbestillingData,
+        val notifikasjonInnhold: OppfolgingsplanNotifikasjonInnhold,
+        val varselTekst: String,
+        val meldingstype: Meldingstype?,
+    )
+
     private class OppfolgingsplanVarselRetryableException(
         override val message: String,
         cause: Throwable? = null,
     ) : RuntimeException(message, cause)
+
+    private class OppfolgingsplanVarselPermanentException(
+        override val message: String,
+    ) : RuntimeException(message)
 }

--- a/src/main/kotlin/no/nav/syfo/service/OppfolgingsplanVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/OppfolgingsplanVarselService.kt
@@ -11,6 +11,7 @@ import no.nav.syfo.ARBEIDSGIVERNOTIFIKASJON_OPPFOLGING_MERKELAPP
 import no.nav.syfo.BRUKERNOTIFIKASJONER_OPPFOLGINGSPLANER_SYKMELDT_URL
 import no.nav.syfo.BRUKERNOTIFIKASJON_OPPFOLGINGSPLAN_GODKJENNING_MESSAGE_TEXT
 import no.nav.syfo.DINE_SYKMELDTE_OPPFOLGINGSPLAN_SENDT_TIL_GODKJENNING_TEKST
+import no.nav.syfo.consumer.narmesteLeder.NarmesteLederRelasjon
 import no.nav.syfo.consumer.narmesteLeder.NarmesteLederService
 import no.nav.syfo.consumer.pdl.PdlClient
 import no.nav.syfo.consumer.pdl.fullName
@@ -87,7 +88,7 @@ class OppfolgingsplanVarselService(
 
     suspend fun sendVarselbestillingTilNarmesteLeder(varselHendelse: NarmesteLederHendelse) {
         val varselbestilling = varselHendelse.requireOppfolgingsplanVarselbestillingData()
-        val notifikasjonInnhold = varselbestilling.notifikasjonInnhold!!
+        val notifikasjonInnhold = requireNotNull(varselbestilling.notifikasjonInnhold)
         val varselTekst = requireNotNull(notifikasjonInnhold.varselTekst)
 
         if (varselbestilling.dineSykmeldteHendelseType != null) {
@@ -97,18 +98,39 @@ class OppfolgingsplanVarselService(
                     ansattFnr = varselHendelse.arbeidstakerFnr,
                     orgnr = varselHendelse.orgnummer,
                     oppgavetype = varselbestilling.dineSykmeldteHendelseType,
-                    lenke = null
+                    lenke = null,
                     tekst = varselTekst,
                     utlopstidspunkt = OffsetDateTime.now().plusWeeks(WEEKS_BEFORE_DELETE),
                 ),
             )
         }
         if (varselbestilling.arbeidsgiverMeldingType != null) {
-            senderFacade.sendTilArbeidsgiverNotifikasjon(
+            val meldingstype = varselbestilling.requireMeldingstype()
+            val hendelseJson = objectMapper.writeValueAsString(varselHendelse)
+            val hardDeleteDate = LocalDateTime.now().plusWeeks(WEEKS_BEFORE_DELETE)
+            val eksternReferanseUuid = UUID.randomUUID()
+            val arbeidsgiverSak =
+                try {
+                    getOrCreateOppfolgingsplanSak(
+                        varselHendelse = varselHendelse,
+                        hardDeleteDate = hardDeleteDate,
+                    )
+                } catch (exception: OppfolgingsplanVarselRetryableException) {
+                    log.warn("Kunne ikke klargjøre arbeidsgiversak for oppfølgingsplanvarselbestilling: {}", exception.message)
+                    senderFacade.lagreIkkeUtsendtArbeidsgiverNotifikasjonForNarmesteLeder(
+                        varselHendelse = varselHendelse,
+                        eksternReferanse = eksternReferanseUuid.toString(),
+                        feilmelding = exception.message,
+                        merkelapp = ARBEIDSGIVERNOTIFIKASJON_OPPFOLGING_MERKELAPP,
+                        hendelseJson = hendelseJson,
+                    )
+                    return
+                }
+            senderFacade.sendTilArbeidsgiverNotifikasjonMedRetrylagring(
                 varselHendelse = varselHendelse,
                 notifikasjon =
                     ArbeidsgiverNotifikasjonNarmestelederInput(
-                        uuid = UUID.randomUUID(),
+                        uuid = eksternReferanseUuid,
                         virksomhetsnummer = varselHendelse.orgnummer,
                         narmesteLederFnr = varselHendelse.narmesteLederFnr,
                         ansattFnr = varselHendelse.arbeidstakerFnr,
@@ -116,11 +138,12 @@ class OppfolgingsplanVarselService(
                         messageText = varselTekst,
                         epostTittel = notifikasjonInnhold.epostTittel,
                         epostHtmlBody = notifikasjonInnhold.epostBody,
-                        hardDeleteDate = LocalDateTime.now().plusWeeks(WEEKS_BEFORE_DELETE),
-                        meldingstype = varselbestilling.requireMeldingstype(),
-                        grupperingsid = UUID.randomUUID().toString(),
+                        hardDeleteDate = hardDeleteDate,
+                        meldingstype = meldingstype,
+                        grupperingsid = arbeidsgiverSak.grupperingsid,
+                        link = arbeidsgiverSak.link,
                     ),
-                hendelseJson = objectMapper.writeValueAsString(varselHendelse),
+                hendelseJson = hendelseJson,
             )
         }
     }
@@ -148,8 +171,20 @@ class OppfolgingsplanVarselService(
                 log.error("Kunne ikke parse uuidEksternReferanse for feilet oppfølgingsplanvarsel: {}", it.message)
                 return ArbeidsgiverVarselResendResult.PERMANENT_FAILURE
             }
-        val notifikasjonInnhold = varselbestilling.notifikasjonInnhold!!
+        val notifikasjonInnhold = requireNotNull(varselbestilling.notifikasjonInnhold)
         val varselTekst = requireNotNull(notifikasjonInnhold.varselTekst)
+        val meldingstype = varselbestilling.requireMeldingstype()
+        val hardDeleteDate = LocalDateTime.now().plusWeeks(WEEKS_BEFORE_DELETE)
+        val arbeidsgiverSak =
+            try {
+                getOrCreateOppfolgingsplanSak(
+                    varselHendelse = varselHendelse,
+                    hardDeleteDate = hardDeleteDate,
+                )
+            } catch (exception: OppfolgingsplanVarselRetryableException) {
+                log.warn("Kunne ikke klargjøre arbeidsgiversak for retry av oppfølgingsplanvarselbestilling: {}", exception.message)
+                return ArbeidsgiverVarselResendResult.RETRYABLE_FAILURE
+            }
         return senderFacade.sendTilArbeidsgiverNotifikasjon(
             varselFeilet = varselFeilet,
             notifikasjon =
@@ -162,9 +197,10 @@ class OppfolgingsplanVarselService(
                     messageText = varselTekst,
                     epostTittel = notifikasjonInnhold.epostTittel,
                     epostHtmlBody = notifikasjonInnhold.epostBody,
-                    hardDeleteDate = LocalDateTime.now().plusWeeks(WEEKS_BEFORE_DELETE),
-                    meldingstype = varselbestilling.requireMeldingstype(),
-                    grupperingsid = UUID.randomUUID().toString(),
+                    hardDeleteDate = hardDeleteDate,
+                    meldingstype = meldingstype,
+                    grupperingsid = arbeidsgiverSak.grupperingsid,
+                    link = arbeidsgiverSak.link,
                 ),
         )
     }
@@ -187,25 +223,13 @@ class OppfolgingsplanVarselService(
             return
         }
 
-        val url = "$dinesykmeldteUrl/${narmesteLederRelasjon.narmesteLederId}"
-        val personData = pdlClient.hentPerson(personIdent = varselHendelse.arbeidstakerFnr)
-        val grupperingsid = UUID.randomUUID().toString()
-
-        val sakInput =
-            NySakNarmesteLederInput(
-                grupperingsid = grupperingsid,
-                narmestelederId = narmesteLederRelasjon.narmesteLederId,
-                merkelapp = ARBEIDSGIVERNOTIFIKASJON_OPPFOLGING_MERKELAPP,
-                virksomhetsnummer = varselHendelse.orgnummer,
-                narmesteLederFnr = varselHendelse.narmesteLederFnr,
-                ansattFnr = varselHendelse.arbeidstakerFnr,
-                tittel = personData?.fullName()?.let { "Oppfølging av $it" } ?: "Oppfølging av sykmeldt",
-                lenke = url,
-                initiellStatus = SakStatus.MOTTATT,
-                hardDeleteDate = LocalDateTime.now().plusWeeks(WEEKS_BEFORE_DELETE),
+        val hardDeleteDate = LocalDateTime.now().plusWeeks(WEEKS_BEFORE_DELETE)
+        val arbeidsgiverSak =
+            getOrCreateOppfolgingsplanSak(
+                varselHendelse = varselHendelse,
+                hardDeleteDate = hardDeleteDate,
+                narmesteLederRelasjon = narmesteLederRelasjon,
             )
-
-        senderFacade.createNewSak(sakInput)
         senderFacade.sendTilArbeidsgiverNotifikasjon(
             varselHendelse,
             ArbeidsgiverNotifikasjonNarmestelederInput(
@@ -217,10 +241,10 @@ class OppfolgingsplanVarselService(
                 messageText = ARBEIDSGIVERNOTIFIKASJON_OPPFOLGINGSPLAN_FORESPORSEL_MESSAGE_TEXT,
                 epostTittel = ARBEIDSGIVERNOTIFIKASJON_OPPFOLGINGSPLAN_FORESPORSEL_EMAIL_TITLE,
                 epostHtmlBody = ARBEIDSGIVERNOTIFIKASJON_OPPFOLGINGSPLAN_FORESPORSEL_EMAIL_BODY,
-                hardDeleteDate = LocalDateTime.now().plusWeeks(WEEKS_BEFORE_DELETE),
+                hardDeleteDate = hardDeleteDate,
                 meldingstype = Meldingstype.BESKJED,
-                grupperingsid = grupperingsid,
-                link = url,
+                grupperingsid = arbeidsgiverSak.grupperingsid,
+                link = arbeidsgiverSak.link,
             ),
         )
     }
@@ -254,6 +278,127 @@ class OppfolgingsplanVarselService(
             }
         }
 
+    private suspend fun getOrCreateOppfolgingsplanSak(
+        varselHendelse: NarmesteLederHendelse,
+        hardDeleteDate: LocalDateTime,
+        narmesteLederRelasjon: NarmesteLederRelasjon? = null,
+    ): OppfolgingsplanArbeidsgiverSak {
+        val resolvedNarmesteLederRelasjon =
+            narmesteLederRelasjon
+                ?: try {
+                    narmesteLederService.getNarmesteLederRelasjon(
+                        varselHendelse.arbeidstakerFnr,
+                        varselHendelse.orgnummer,
+                    )
+                } catch (exception: RuntimeException) {
+                    throw OppfolgingsplanVarselRetryableException(
+                        "Kunne ikke hente nærmeste-lederrelasjon for oppfølgingsplansak",
+                        exception,
+                    )
+                }
+        val narmesteLederId =
+            resolvedNarmesteLederRelasjon?.narmesteLederId
+                ?: throw OppfolgingsplanVarselRetryableException(
+                    "Mangler nærmeste-lederrelasjon med narmesteLederId for oppfølgingsplansak",
+                )
+        val link = getDineSykmeldteNarmesteLederLink(narmesteLederId)
+        val eksisterendeSak =
+            try {
+                senderFacade.getPaagaaendeSak(
+                    narmesteLederId = narmesteLederId,
+                    merkelapp = ARBEIDSGIVERNOTIFIKASJON_OPPFOLGING_MERKELAPP,
+                )
+            } catch (exception: RuntimeException) {
+                throw OppfolgingsplanVarselRetryableException(
+                    "Kunne ikke hente pågående oppfølgingsplansak",
+                    exception,
+                )
+            }
+
+        if (eksisterendeSak != null) {
+            bumpHardDeleteDateForEksisterendeSak(
+                eksisterendeSak = eksisterendeSak,
+                hardDeleteDate = hardDeleteDate,
+            )
+            return OppfolgingsplanArbeidsgiverSak(
+                grupperingsid = eksisterendeSak.grupperingsid,
+                link = eksisterendeSak.lenke ?: link,
+            )
+        }
+
+        val personData =
+            try {
+                pdlClient.hentPerson(personIdent = varselHendelse.arbeidstakerFnr)
+            } catch (exception: RuntimeException) {
+                throw OppfolgingsplanVarselRetryableException(
+                    "Kunne ikke hente persondata for oppfølgingsplansak",
+                    exception,
+                )
+            }
+        val sakInput =
+            NySakNarmesteLederInput(
+                grupperingsid = UUID.randomUUID().toString(),
+                narmestelederId = narmesteLederId,
+                merkelapp = ARBEIDSGIVERNOTIFIKASJON_OPPFOLGING_MERKELAPP,
+                virksomhetsnummer = varselHendelse.orgnummer,
+                narmesteLederFnr = varselHendelse.narmesteLederFnr,
+                ansattFnr = varselHendelse.arbeidstakerFnr,
+                tittel = personData?.fullName()?.let { "Oppfølging av $it" } ?: "Oppfølging av sykmeldt",
+                lenke = link,
+                initiellStatus = SakStatus.MOTTATT,
+                hardDeleteDate = hardDeleteDate,
+            )
+
+        try {
+            senderFacade.createNewSak(sakInput)
+        } catch (exception: RuntimeException) {
+            throw OppfolgingsplanVarselRetryableException(
+                "Kunne ikke opprette oppfølgingsplansak",
+                exception,
+            )
+        }
+
+        return OppfolgingsplanArbeidsgiverSak(
+            grupperingsid = sakInput.grupperingsid,
+            link = sakInput.lenke,
+        )
+    }
+
+    private suspend fun bumpHardDeleteDateForEksisterendeSak(
+        eksisterendeSak: no.nav.syfo.db.domain.PSakInput,
+        hardDeleteDate: LocalDateTime,
+    ) {
+        val sakStatus =
+            try {
+                SakStatus.valueOf(eksisterendeSak.initiellStatus.name)
+            } catch (exception: IllegalArgumentException) {
+                throw OppfolgingsplanVarselRetryableException(
+                    "Kunne ikke tolke saksstatus for eksisterende oppfølgingsplansak",
+                    exception,
+                )
+            }
+
+        try {
+            senderFacade.nyStatusSak(
+                sakId = eksisterendeSak.id,
+                nyStatusSakInput =
+                    no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NyStatusSakInput(
+                        grupperingsId = eksisterendeSak.grupperingsid,
+                        merkelapp = eksisterendeSak.merkelapp,
+                        sakStatus = sakStatus,
+                        oppdatertHardDeleteDateTime = hardDeleteDate,
+                    ),
+            )
+        } catch (exception: RuntimeException) {
+            throw OppfolgingsplanVarselRetryableException(
+                "Kunne ikke oppdatere hardDeleteDate for eksisterende oppfølgingsplansak",
+                exception,
+            )
+        }
+    }
+
+    private fun getDineSykmeldteNarmesteLederLink(narmesteLederId: String): String = "$dinesykmeldteUrl/$narmesteLederId"
+
     private fun NarmesteLederHendelse.requireOppfolgingsplanVarselbestillingData(): OppfolgingsplanVarselbestillingData {
         val payloadDataNode =
             data?.let {
@@ -285,4 +430,14 @@ class OppfolgingsplanVarselService(
             null -> throw IllegalArgumentException("Oppfølgingsplanvarsel mangler feltet: data.varselType")
             else -> throw IllegalArgumentException("Oppfølgingsplanvarsel har ugyldig data.varselType=$arbeidsgiverMeldingType")
         }
+
+    private data class OppfolgingsplanArbeidsgiverSak(
+        val grupperingsid: String,
+        val link: String,
+    )
+
+    private class OppfolgingsplanVarselRetryableException(
+        override val message: String,
+        cause: Throwable? = null,
+    ) : RuntimeException(message, cause)
 }

--- a/src/main/kotlin/no/nav/syfo/service/OppfolgingsplanVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/OppfolgingsplanVarselService.kt
@@ -465,8 +465,8 @@ class OppfolgingsplanVarselService(
         when (arbeidsgiverMeldingType) {
             Meldingstype.BESKJED.name -> Meldingstype.BESKJED
             Meldingstype.OPPGAVE.name -> Meldingstype.OPPGAVE
-            null -> throw IllegalArgumentException("Oppfølgingsplanvarsel mangler feltet: data.varselType")
-            else -> throw IllegalArgumentException("Oppfølgingsplanvarsel har ugyldig data.varselType=$arbeidsgiverMeldingType")
+            null -> throw IllegalArgumentException("Oppfølgingsplanvarsel mangler feltet: data.arbeidsgiverMeldingType")
+            else -> throw IllegalArgumentException("Oppfølgingsplanvarsel har ugyldig data.arbeidsgiverMeldingType=$arbeidsgiverMeldingType")
         }
 
     private data class OppfolgingsplanArbeidsgiverSak(

--- a/src/main/kotlin/no/nav/syfo/service/OppfolgingsplanVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/OppfolgingsplanVarselService.kt
@@ -116,7 +116,10 @@ class OppfolgingsplanVarselService(
                         hardDeleteDate = hardDeleteDate,
                     )
                 } catch (exception: OppfolgingsplanVarselRetryableException) {
-                    log.warn("Kunne ikke klargjøre arbeidsgiversak for oppfølgingsplanvarselbestilling: {}", exception.message)
+                    log.warn(
+                        "Kunne ikke klargjøre arbeidsgiversak for oppfølgingsplanvarselbestilling: {}",
+                        exception.message
+                    )
                     senderFacade.lagreIkkeUtsendtArbeidsgiverNotifikasjonForNarmesteLeder(
                         varselHendelse = varselHendelse,
                         eksternReferanse = eksternReferanseUuid.toString(),
@@ -126,6 +129,13 @@ class OppfolgingsplanVarselService(
                     )
                     return
                 }
+            val link =
+                if (varselbestilling.ressursUrl != null && arbeidsgiverSak.narmesteLederRelasjon.narmesteLederId != null) {
+                    varselbestilling.ressursUrl.replace(
+                        "NARMESTE_LEDER_ID",
+                        arbeidsgiverSak.narmesteLederRelasjon.narmesteLederId
+                    )
+                } else arbeidsgiverSak.link
             senderFacade.sendTilArbeidsgiverNotifikasjonMedRetrylagring(
                 varselHendelse = varselHendelse,
                 notifikasjon =
@@ -141,7 +151,7 @@ class OppfolgingsplanVarselService(
                         hardDeleteDate = hardDeleteDate,
                         meldingstype = meldingstype,
                         grupperingsid = arbeidsgiverSak.grupperingsid,
-                        link = arbeidsgiverSak.link,
+                        link = link,
                     ),
                 hendelseJson = hendelseJson,
             )
@@ -182,9 +192,19 @@ class OppfolgingsplanVarselService(
                     hardDeleteDate = hardDeleteDate,
                 )
             } catch (exception: OppfolgingsplanVarselRetryableException) {
-                log.warn("Kunne ikke klargjøre arbeidsgiversak for retry av oppfølgingsplanvarselbestilling: {}", exception.message)
+                log.warn(
+                    "Kunne ikke klargjøre arbeidsgiversak for retry av oppfølgingsplanvarselbestilling: {}",
+                    exception.message
+                )
                 return ArbeidsgiverVarselResendResult.RETRYABLE_FAILURE
             }
+        val link =
+            if (varselbestilling.ressursUrl != null && arbeidsgiverSak.narmesteLederRelasjon.narmesteLederId != null) {
+                varselbestilling.ressursUrl.replace(
+                    "NARMESTE_LEDER_ID",
+                    arbeidsgiverSak.narmesteLederRelasjon.narmesteLederId
+                )
+            } else arbeidsgiverSak.link
         return senderFacade.sendTilArbeidsgiverNotifikasjon(
             varselFeilet = varselFeilet,
             notifikasjon =
@@ -200,7 +220,7 @@ class OppfolgingsplanVarselService(
                     hardDeleteDate = hardDeleteDate,
                     meldingstype = meldingstype,
                     grupperingsid = arbeidsgiverSak.grupperingsid,
-                    link = arbeidsgiverSak.link,
+                    link = link,
                 ),
         )
     }
@@ -323,6 +343,7 @@ class OppfolgingsplanVarselService(
             return OppfolgingsplanArbeidsgiverSak(
                 grupperingsid = eksisterendeSak.grupperingsid,
                 link = eksisterendeSak.lenke ?: link,
+                narmesteLederRelasjon = resolvedNarmesteLederRelasjon
             )
         }
 
@@ -361,6 +382,7 @@ class OppfolgingsplanVarselService(
         return OppfolgingsplanArbeidsgiverSak(
             grupperingsid = sakInput.grupperingsid,
             link = sakInput.lenke,
+            narmesteLederRelasjon = resolvedNarmesteLederRelasjon
         )
     }
 
@@ -397,7 +419,8 @@ class OppfolgingsplanVarselService(
         }
     }
 
-    private fun getDineSykmeldteNarmesteLederLink(narmesteLederId: String): String = "$dinesykmeldteUrl/$narmesteLederId"
+    private fun getDineSykmeldteNarmesteLederLink(narmesteLederId: String): String =
+        "$dinesykmeldteUrl/$narmesteLederId"
 
     private fun NarmesteLederHendelse.requireOppfolgingsplanVarselbestillingData(): OppfolgingsplanVarselbestillingData {
         val payloadDataNode =
@@ -434,6 +457,7 @@ class OppfolgingsplanVarselService(
     private data class OppfolgingsplanArbeidsgiverSak(
         val grupperingsid: String,
         val link: String,
+        val narmesteLederRelasjon: NarmesteLederRelasjon
     )
 
     private class OppfolgingsplanVarselRetryableException(

--- a/src/main/kotlin/no/nav/syfo/service/OppfolgingsplanVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/OppfolgingsplanVarselService.kt
@@ -21,6 +21,7 @@ import no.nav.syfo.kafka.common.createObjectMapper
 import no.nav.syfo.kafka.consumers.varselbus.domain.ArbeidstakerHendelse
 import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType.SM_OPPFOLGINGSPLAN_SENDT_TIL_GODKJENNING
 import no.nav.syfo.kafka.consumers.varselbus.domain.NarmesteLederHendelse
+import no.nav.syfo.kafka.consumers.varselbus.domain.OppfolgingsplanNotifikasjonInnhold
 import no.nav.syfo.kafka.consumers.varselbus.domain.OppfolgingsplanVarselbestillingData
 import no.nav.syfo.kafka.consumers.varselbus.domain.toDineSykmeldteHendelseType
 import no.nav.syfo.kafka.consumers.varselbus.domain.toOppfolgingsplanVarselbestillingData
@@ -118,7 +119,7 @@ class OppfolgingsplanVarselService(
                 } catch (exception: OppfolgingsplanVarselRetryableException) {
                     log.warn(
                         "Kunne ikke klargjøre arbeidsgiversak for oppfølgingsplanvarselbestilling: {}",
-                        exception.message
+                        exception.message,
                     )
                     senderFacade.lagreIkkeUtsendtArbeidsgiverNotifikasjonForNarmesteLeder(
                         varselHendelse = varselHendelse,
@@ -129,29 +130,18 @@ class OppfolgingsplanVarselService(
                     )
                     return
                 }
-            val link =
-                if (varselbestilling.ressursUrl != null && arbeidsgiverSak.narmesteLederRelasjon.narmesteLederId != null) {
-                    varselbestilling.ressursUrl.replace(
-                        "NARMESTE_LEDER_ID",
-                        arbeidsgiverSak.narmesteLederRelasjon.narmesteLederId
-                    )
-                } else arbeidsgiverSak.link
             senderFacade.sendTilArbeidsgiverNotifikasjonMedRetrylagring(
                 varselHendelse = varselHendelse,
                 notifikasjon =
-                    ArbeidsgiverNotifikasjonNarmestelederInput(
-                        uuid = eksternReferanseUuid,
-                        virksomhetsnummer = varselHendelse.orgnummer,
-                        narmesteLederFnr = varselHendelse.narmesteLederFnr,
-                        ansattFnr = varselHendelse.arbeidstakerFnr,
-                        merkelapp = ARBEIDSGIVERNOTIFIKASJON_OPPFOLGING_MERKELAPP,
-                        messageText = varselTekst,
-                        epostTittel = notifikasjonInnhold.epostTittel,
-                        epostHtmlBody = notifikasjonInnhold.epostBody,
-                        hardDeleteDate = hardDeleteDate,
+                    createOppfolgingsplanVarselbestillingNotifikasjonInput(
+                        eksternReferanseUuid = eksternReferanseUuid,
+                        varselHendelse = varselHendelse,
+                        notifikasjonInnhold = notifikasjonInnhold,
+                        varselTekst = varselTekst,
                         meldingstype = meldingstype,
-                        grupperingsid = arbeidsgiverSak.grupperingsid,
-                        link = link,
+                        hardDeleteDate = hardDeleteDate,
+                        arbeidsgiverSak = arbeidsgiverSak,
+                        link = resolveOppfolgingsplanVarselbestillingLink(varselbestilling, arbeidsgiverSak),
                     ),
                 hendelseJson = hendelseJson,
             )
@@ -194,33 +184,22 @@ class OppfolgingsplanVarselService(
             } catch (exception: OppfolgingsplanVarselRetryableException) {
                 log.warn(
                     "Kunne ikke klargjøre arbeidsgiversak for retry av oppfølgingsplanvarselbestilling: {}",
-                    exception.message
+                    exception.message,
                 )
                 return ArbeidsgiverVarselResendResult.RETRYABLE_FAILURE
             }
-        val link =
-            if (varselbestilling.ressursUrl != null && arbeidsgiverSak.narmesteLederRelasjon.narmesteLederId != null) {
-                varselbestilling.ressursUrl.replace(
-                    "NARMESTE_LEDER_ID",
-                    arbeidsgiverSak.narmesteLederRelasjon.narmesteLederId
-                )
-            } else arbeidsgiverSak.link
         return senderFacade.sendTilArbeidsgiverNotifikasjon(
             varselFeilet = varselFeilet,
             notifikasjon =
-                ArbeidsgiverNotifikasjonNarmestelederInput(
-                    uuid = eksternReferanseUuid,
-                    virksomhetsnummer = varselHendelse.orgnummer,
-                    narmesteLederFnr = varselHendelse.narmesteLederFnr,
-                    ansattFnr = varselHendelse.arbeidstakerFnr,
-                    merkelapp = ARBEIDSGIVERNOTIFIKASJON_OPPFOLGING_MERKELAPP,
-                    messageText = varselTekst,
-                    epostTittel = notifikasjonInnhold.epostTittel,
-                    epostHtmlBody = notifikasjonInnhold.epostBody,
-                    hardDeleteDate = hardDeleteDate,
+                createOppfolgingsplanVarselbestillingNotifikasjonInput(
+                    eksternReferanseUuid = eksternReferanseUuid,
+                    varselHendelse = varselHendelse,
+                    notifikasjonInnhold = notifikasjonInnhold,
+                    varselTekst = varselTekst,
                     meldingstype = meldingstype,
-                    grupperingsid = arbeidsgiverSak.grupperingsid,
-                    link = link,
+                    hardDeleteDate = hardDeleteDate,
+                    arbeidsgiverSak = arbeidsgiverSak,
+                    link = resolveOppfolgingsplanVarselbestillingLink(varselbestilling, arbeidsgiverSak),
                 ),
         )
     }
@@ -343,7 +322,7 @@ class OppfolgingsplanVarselService(
             return OppfolgingsplanArbeidsgiverSak(
                 grupperingsid = eksisterendeSak.grupperingsid,
                 link = eksisterendeSak.lenke ?: link,
-                narmesteLederRelasjon = resolvedNarmesteLederRelasjon
+                narmesteLederRelasjon = resolvedNarmesteLederRelasjon,
             )
         }
 
@@ -382,7 +361,7 @@ class OppfolgingsplanVarselService(
         return OppfolgingsplanArbeidsgiverSak(
             grupperingsid = sakInput.grupperingsid,
             link = sakInput.lenke,
-            narmesteLederRelasjon = resolvedNarmesteLederRelasjon
+            narmesteLederRelasjon = resolvedNarmesteLederRelasjon,
         )
     }
 
@@ -419,8 +398,44 @@ class OppfolgingsplanVarselService(
         }
     }
 
-    private fun getDineSykmeldteNarmesteLederLink(narmesteLederId: String): String =
-        "$dinesykmeldteUrl/$narmesteLederId"
+    private fun getDineSykmeldteNarmesteLederLink(narmesteLederId: String): String = "$dinesykmeldteUrl/$narmesteLederId"
+
+    private fun resolveOppfolgingsplanVarselbestillingLink(
+        varselbestilling: OppfolgingsplanVarselbestillingData,
+        arbeidsgiverSak: OppfolgingsplanArbeidsgiverSak,
+    ): String =
+        if (varselbestilling.ressursUrl != null && arbeidsgiverSak.narmesteLederRelasjon.narmesteLederId != null) {
+            varselbestilling.ressursUrl.replace(
+                "NARMESTE_LEDER_ID",
+                arbeidsgiverSak.narmesteLederRelasjon.narmesteLederId,
+            )
+        } else {
+            arbeidsgiverSak.link
+        }
+
+    private fun createOppfolgingsplanVarselbestillingNotifikasjonInput(
+        eksternReferanseUuid: UUID,
+        varselHendelse: NarmesteLederHendelse,
+        notifikasjonInnhold: OppfolgingsplanNotifikasjonInnhold,
+        varselTekst: String,
+        meldingstype: Meldingstype,
+        hardDeleteDate: LocalDateTime,
+        arbeidsgiverSak: OppfolgingsplanArbeidsgiverSak,
+        link: String,
+    ) = ArbeidsgiverNotifikasjonNarmestelederInput(
+        uuid = eksternReferanseUuid,
+        virksomhetsnummer = varselHendelse.orgnummer,
+        narmesteLederFnr = varselHendelse.narmesteLederFnr,
+        ansattFnr = varselHendelse.arbeidstakerFnr,
+        merkelapp = ARBEIDSGIVERNOTIFIKASJON_OPPFOLGING_MERKELAPP,
+        messageText = varselTekst,
+        epostTittel = notifikasjonInnhold.epostTittel,
+        epostHtmlBody = notifikasjonInnhold.epostBody,
+        hardDeleteDate = hardDeleteDate,
+        meldingstype = meldingstype,
+        grupperingsid = arbeidsgiverSak.grupperingsid,
+        link = link,
+    )
 
     private fun NarmesteLederHendelse.requireOppfolgingsplanVarselbestillingData(): OppfolgingsplanVarselbestillingData {
         val payloadDataNode =
@@ -457,7 +472,7 @@ class OppfolgingsplanVarselService(
     private data class OppfolgingsplanArbeidsgiverSak(
         val grupperingsid: String,
         val link: String,
-        val narmesteLederRelasjon: NarmesteLederRelasjon
+        val narmesteLederRelasjon: NarmesteLederRelasjon,
     )
 
     private class OppfolgingsplanVarselRetryableException(

--- a/src/main/kotlin/no/nav/syfo/service/OppfolgingsplanVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/OppfolgingsplanVarselService.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.service
 
+import com.fasterxml.jackson.databind.JsonNode
 import no.nav.syfo.ARBEIDSGIVERNOTIFIKASJON_OPPFOLGINGSPLAN_FORESPORSEL_EMAIL_BODY
 import no.nav.syfo.ARBEIDSGIVERNOTIFIKASJON_OPPFOLGINGSPLAN_FORESPORSEL_EMAIL_TITLE
 import no.nav.syfo.ARBEIDSGIVERNOTIFIKASJON_OPPFOLGINGSPLAN_FORESPORSEL_MESSAGE_TEXT
@@ -13,10 +14,15 @@ import no.nav.syfo.DINE_SYKMELDTE_OPPFOLGINGSPLAN_SENDT_TIL_GODKJENNING_TEKST
 import no.nav.syfo.consumer.narmesteLeder.NarmesteLederService
 import no.nav.syfo.consumer.pdl.PdlClient
 import no.nav.syfo.consumer.pdl.fullName
+import no.nav.syfo.db.domain.PUtsendtVarselFeilet
+import no.nav.syfo.db.domain.toNarmesteLederHendelse
+import no.nav.syfo.kafka.common.createObjectMapper
 import no.nav.syfo.kafka.consumers.varselbus.domain.ArbeidstakerHendelse
 import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType.SM_OPPFOLGINGSPLAN_SENDT_TIL_GODKJENNING
 import no.nav.syfo.kafka.consumers.varselbus.domain.NarmesteLederHendelse
+import no.nav.syfo.kafka.consumers.varselbus.domain.OppfolgingsplanVarselbestillingData
 import no.nav.syfo.kafka.consumers.varselbus.domain.toDineSykmeldteHendelseType
+import no.nav.syfo.kafka.consumers.varselbus.domain.toOppfolgingsplanVarselbestillingData
 import no.nav.syfo.kafka.producers.dinesykmeldte.domain.DineSykmeldteVarsel
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NySakNarmesteLederInput
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.SakStatus
@@ -38,6 +44,7 @@ class OppfolgingsplanVarselService(
     companion object {
         private const val WEEKS_BEFORE_DELETE = 4L
         private val log = LoggerFactory.getLogger(OppfolgingsplanVarselService::class.qualifiedName)
+        private val objectMapper = createObjectMapper()
     }
 
     suspend fun sendVarselTilArbeidstaker(varselHendelse: ArbeidstakerHendelse) {
@@ -63,18 +70,102 @@ class OppfolgingsplanVarselService(
         senderFacade.sendTilArbeidsgiverNotifikasjon(
             varselHendelse,
             ArbeidsgiverNotifikasjonNarmestelederInput(
-                UUID.randomUUID(),
-                varselHendelse.orgnummer,
-                varselHendelse.narmesteLederFnr,
-                varselHendelse.arbeidstakerFnr,
-                ARBEIDSGIVERNOTIFIKASJON_OPPFOLGING_MERKELAPP,
-                ARBEIDSGIVERNOTIFIKASJON_OPPFOLGINGSPLAN_GODKJENNING_MESSAGE_TEXT,
-                ARBEIDSGIVERNOTIFIKASJON_OPPFOLGINGSPLAN_GODKJENNING_EMAIL_TITLE,
-                ARBEIDSGIVERNOTIFIKASJON_OPPFOLGINGSPLAN_GODKJENNING_EMAIL_BODY,
-                LocalDateTime.now().plusWeeks(WEEKS_BEFORE_DELETE),
+                uuid = UUID.randomUUID(),
+                virksomhetsnummer = varselHendelse.orgnummer,
+                narmesteLederFnr = varselHendelse.narmesteLederFnr,
+                ansattFnr = varselHendelse.arbeidstakerFnr,
+                merkelapp = ARBEIDSGIVERNOTIFIKASJON_OPPFOLGING_MERKELAPP,
+                messageText = ARBEIDSGIVERNOTIFIKASJON_OPPFOLGINGSPLAN_GODKJENNING_MESSAGE_TEXT,
+                epostTittel = ARBEIDSGIVERNOTIFIKASJON_OPPFOLGINGSPLAN_GODKJENNING_EMAIL_TITLE,
+                epostHtmlBody = ARBEIDSGIVERNOTIFIKASJON_OPPFOLGINGSPLAN_GODKJENNING_EMAIL_BODY,
+                hardDeleteDate = LocalDateTime.now().plusWeeks(WEEKS_BEFORE_DELETE),
                 meldingstype = Meldingstype.BESKJED,
                 grupperingsid = UUID.randomUUID().toString(),
             ),
+        )
+    }
+
+    suspend fun sendVarselbestillingTilNarmesteLeder(varselHendelse: NarmesteLederHendelse) {
+        val varselbestilling = varselHendelse.requireOppfolgingsplanVarselbestillingData()
+        val notifikasjonInnhold = varselbestilling.notifikasjonInnhold!!
+        val varselTekst = requireNotNull(notifikasjonInnhold.varselTekst)
+
+        if (varselbestilling.dineSykmeldteHendelseType != null) {
+            senderFacade.sendTilDineSykmeldte(
+                varselHendelse,
+                DineSykmeldteVarsel(
+                    ansattFnr = varselHendelse.arbeidstakerFnr,
+                    orgnr = varselHendelse.orgnummer,
+                    oppgavetype = varselbestilling.dineSykmeldteHendelseType,
+                    lenke = null
+                    tekst = varselTekst,
+                    utlopstidspunkt = OffsetDateTime.now().plusWeeks(WEEKS_BEFORE_DELETE),
+                ),
+            )
+        }
+        if (varselbestilling.arbeidsgiverMeldingType != null) {
+            senderFacade.sendTilArbeidsgiverNotifikasjon(
+                varselHendelse = varselHendelse,
+                notifikasjon =
+                    ArbeidsgiverNotifikasjonNarmestelederInput(
+                        uuid = UUID.randomUUID(),
+                        virksomhetsnummer = varselHendelse.orgnummer,
+                        narmesteLederFnr = varselHendelse.narmesteLederFnr,
+                        ansattFnr = varselHendelse.arbeidstakerFnr,
+                        merkelapp = ARBEIDSGIVERNOTIFIKASJON_OPPFOLGING_MERKELAPP,
+                        messageText = varselTekst,
+                        epostTittel = notifikasjonInnhold.epostTittel,
+                        epostHtmlBody = notifikasjonInnhold.epostBody,
+                        hardDeleteDate = LocalDateTime.now().plusWeeks(WEEKS_BEFORE_DELETE),
+                        meldingstype = varselbestilling.requireMeldingstype(),
+                        grupperingsid = UUID.randomUUID().toString(),
+                    ),
+                hendelseJson = objectMapper.writeValueAsString(varselHendelse),
+            )
+        }
+    }
+
+    suspend fun resendVarselbestillingTilArbeidsgiverNotifikasjon(varselFeilet: PUtsendtVarselFeilet): ArbeidsgiverVarselResendResult {
+        val varselHendelse =
+            runCatching { varselFeilet.toNarmesteLederHendelse() }
+                .getOrElse {
+                    log.error("Kunne ikke deserialisere feilet oppfølgingsplanvarsel for retry: {}", it.message)
+                    return ArbeidsgiverVarselResendResult.PERMANENT_FAILURE
+                }
+        val varselbestilling =
+            runCatching { varselHendelse.requireOppfolgingsplanVarselbestillingData() }
+                .getOrElse {
+                    log.error("Kunne ikke validere feilet oppfølgingsplanvarsel for retry: {}", it.message)
+                    return ArbeidsgiverVarselResendResult.PERMANENT_FAILURE
+                }
+        val eksternReferanseUuid =
+            runCatching {
+                UUID.fromString(
+                    varselFeilet.uuidEksternReferanse
+                        ?: throw IllegalArgumentException("Mangler uuidEksternReferanse for feilet oppfølgingsplanvarsel"),
+                )
+            }.getOrElse {
+                log.error("Kunne ikke parse uuidEksternReferanse for feilet oppfølgingsplanvarsel: {}", it.message)
+                return ArbeidsgiverVarselResendResult.PERMANENT_FAILURE
+            }
+        val notifikasjonInnhold = varselbestilling.notifikasjonInnhold!!
+        val varselTekst = requireNotNull(notifikasjonInnhold.varselTekst)
+        return senderFacade.sendTilArbeidsgiverNotifikasjon(
+            varselFeilet = varselFeilet,
+            notifikasjon =
+                ArbeidsgiverNotifikasjonNarmestelederInput(
+                    uuid = eksternReferanseUuid,
+                    virksomhetsnummer = varselHendelse.orgnummer,
+                    narmesteLederFnr = varselHendelse.narmesteLederFnr,
+                    ansattFnr = varselHendelse.arbeidstakerFnr,
+                    merkelapp = ARBEIDSGIVERNOTIFIKASJON_OPPFOLGING_MERKELAPP,
+                    messageText = varselTekst,
+                    epostTittel = notifikasjonInnhold.epostTittel,
+                    epostHtmlBody = notifikasjonInnhold.epostBody,
+                    hardDeleteDate = LocalDateTime.now().plusWeeks(WEEKS_BEFORE_DELETE),
+                    meldingstype = varselbestilling.requireMeldingstype(),
+                    grupperingsid = UUID.randomUUID().toString(),
+                ),
         )
     }
 
@@ -118,18 +209,18 @@ class OppfolgingsplanVarselService(
         senderFacade.sendTilArbeidsgiverNotifikasjon(
             varselHendelse,
             ArbeidsgiverNotifikasjonNarmestelederInput(
-                UUID.randomUUID(),
-                varselHendelse.orgnummer,
-                varselHendelse.narmesteLederFnr,
-                varselHendelse.arbeidstakerFnr,
-                ARBEIDSGIVERNOTIFIKASJON_OPPFOLGING_MERKELAPP,
-                ARBEIDSGIVERNOTIFIKASJON_OPPFOLGINGSPLAN_FORESPORSEL_MESSAGE_TEXT,
-                ARBEIDSGIVERNOTIFIKASJON_OPPFOLGINGSPLAN_FORESPORSEL_EMAIL_TITLE,
-                ARBEIDSGIVERNOTIFIKASJON_OPPFOLGINGSPLAN_FORESPORSEL_EMAIL_BODY,
-                LocalDateTime.now().plusWeeks(WEEKS_BEFORE_DELETE),
-                Meldingstype.BESKJED,
-                grupperingsid,
-                url,
+                uuid = UUID.randomUUID(),
+                virksomhetsnummer = varselHendelse.orgnummer,
+                narmesteLederFnr = varselHendelse.narmesteLederFnr,
+                ansattFnr = varselHendelse.arbeidstakerFnr,
+                merkelapp = ARBEIDSGIVERNOTIFIKASJON_OPPFOLGING_MERKELAPP,
+                messageText = ARBEIDSGIVERNOTIFIKASJON_OPPFOLGINGSPLAN_FORESPORSEL_MESSAGE_TEXT,
+                epostTittel = ARBEIDSGIVERNOTIFIKASJON_OPPFOLGINGSPLAN_FORESPORSEL_EMAIL_TITLE,
+                epostHtmlBody = ARBEIDSGIVERNOTIFIKASJON_OPPFOLGINGSPLAN_FORESPORSEL_EMAIL_BODY,
+                hardDeleteDate = LocalDateTime.now().plusWeeks(WEEKS_BEFORE_DELETE),
+                meldingstype = Meldingstype.BESKJED,
+                grupperingsid = grupperingsid,
+                link = url,
             ),
         )
     }
@@ -161,5 +252,37 @@ class OppfolgingsplanVarselService(
                 )
                 null
             }
+        }
+
+    private fun NarmesteLederHendelse.requireOppfolgingsplanVarselbestillingData(): OppfolgingsplanVarselbestillingData {
+        val payloadDataNode =
+            data?.let {
+                if (it is JsonNode) {
+                    it
+                } else {
+                    objectMapper.valueToTree(it)
+                }
+            } ?: throw IllegalArgumentException("Oppfølgingsplanvarsel mangler feltet: data")
+
+        val payload =
+            runCatching { payloadDataNode.toOppfolgingsplanVarselbestillingData() }
+                .getOrElse { throw IllegalArgumentException("Oppfølgingsplanvarsel har ugyldig format i data-feltet") }
+
+        if (payload.notifikasjonInnhold == null) {
+            throw IllegalArgumentException("Oppfølgingsplanvarsel mangler feltet: data.notifikasjonInnhold")
+        }
+        if (!payloadDataNode.path("notifikasjonInnhold").hasNonNull("varselTekst")) {
+            throw IllegalArgumentException("Oppfølgingsplanvarsel mangler feltet: data.notifikasjonInnhold.varselTekst")
+        }
+
+        return payload
+    }
+
+    private fun OppfolgingsplanVarselbestillingData.requireMeldingstype(): Meldingstype =
+        when (arbeidsgiverMeldingType) {
+            Meldingstype.BESKJED.name -> Meldingstype.BESKJED
+            Meldingstype.OPPGAVE.name -> Meldingstype.OPPGAVE
+            null -> throw IllegalArgumentException("Oppfølgingsplanvarsel mangler feltet: data.varselType")
+            else -> throw IllegalArgumentException("Oppfølgingsplanvarsel har ugyldig data.varselType=$arbeidsgiverMeldingType")
         }
 }

--- a/src/main/kotlin/no/nav/syfo/service/SenderFacade.kt
+++ b/src/main/kotlin/no/nav/syfo/service/SenderFacade.kt
@@ -24,6 +24,7 @@ import no.nav.syfo.db.storeArbeidsgivernotifikasjonerSak
 import no.nav.syfo.db.storeUtsendtVarsel
 import no.nav.syfo.db.storeUtsendtVarselFeilet
 import no.nav.syfo.db.updateArbeidsgivernotifikasjonerSakStatus
+import no.nav.syfo.db.updateArbeidsgivernotifikasjonerSakStatusAndHardDeleteDate
 import no.nav.syfo.db.updateUtsendtVarselFeiletToResendExhausted
 import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.exceptions.JournalpostDistribusjonGoneException
@@ -164,10 +165,44 @@ class SenderFacade(
         varselHendelse: NarmesteLederHendelse,
         notifikasjon: ArbeidsgiverNotifikasjonNarmestelederInput,
         hendelseJson: String? = null,
+    ): Boolean =
+        sendTilArbeidsgiverNotifikasjon(
+            varselHendelse = varselHendelse,
+            notifikasjon = notifikasjon,
+            hendelseJson = hendelseJson,
+            lagreFeilVedIkkeSendt = false,
+        )
+
+    suspend fun sendTilArbeidsgiverNotifikasjonMedRetrylagring(
+        varselHendelse: NarmesteLederHendelse,
+        notifikasjon: ArbeidsgiverNotifikasjonNarmestelederInput,
+        hendelseJson: String,
+    ): Boolean =
+        sendTilArbeidsgiverNotifikasjon(
+            varselHendelse = varselHendelse,
+            notifikasjon = notifikasjon,
+            hendelseJson = hendelseJson,
+            lagreFeilVedIkkeSendt = true,
+        )
+
+    private suspend fun sendTilArbeidsgiverNotifikasjon(
+        varselHendelse: NarmesteLederHendelse,
+        notifikasjon: ArbeidsgiverNotifikasjonNarmestelederInput,
+        hendelseJson: String?,
+        lagreFeilVedIkkeSendt: Boolean,
     ): Boolean {
         try {
             val isSent = arbeidsgiverNotifikasjonService.sendNotifikasjon(notifikasjon)
             if (!isSent) {
+                if (lagreFeilVedIkkeSendt) {
+                    lagreIkkeUtsendtArbeidsgiverNotifikasjonForNarmesteLeder(
+                        varselHendelse = varselHendelse,
+                        eksternReferanse = notifikasjon.uuid.toString(),
+                        feilmelding = "ArbeidsgiverNotifikasjonService sendte ikke varsel til nærmeste leder",
+                        merkelapp = notifikasjon.merkelapp,
+                        hendelseJson = hendelseJson,
+                    )
+                }
                 return false
             }
             lagreUtsendtNarmesteLederVarsel(
@@ -263,7 +298,13 @@ class SenderFacade(
     ) {
         val oppdatertSak = arbeidsgiverNotifikasjonService.nyStatusSak(nyStatusSakInput)
         require(oppdatertSak != null) { "Failed to update sak" }
-        database.updateArbeidsgivernotifikasjonerSakStatus(sakId, nyStatusSakInput.sakStatus)
+        nyStatusSakInput.oppdatertHardDeleteDateTime?.let {
+            database.updateArbeidsgivernotifikasjonerSakStatusAndHardDeleteDate(
+                sakId = sakId,
+                sakStatus = nyStatusSakInput.sakStatus,
+                hardDeleteDate = it,
+            )
+        } ?: database.updateArbeidsgivernotifikasjonerSakStatus(sakId, nyStatusSakInput.sakStatus)
     }
 
     suspend fun updateKalenderavtale(
@@ -613,6 +654,23 @@ class SenderFacade(
             ),
         )
         return uuid
+    }
+
+    fun lagreIkkeUtsendtArbeidsgiverNotifikasjonForNarmesteLeder(
+        varselHendelse: NarmesteLederHendelse,
+        eksternReferanse: String,
+        feilmelding: String?,
+        merkelapp: String,
+        hendelseJson: String? = null,
+    ) {
+        lagreIkkeUtsendtNarmesteLederVarsel(
+            kanal = ARBEIDSGIVERNOTIFIKASJON,
+            varselHendelse = varselHendelse,
+            eksternReferanse = eksternReferanse,
+            feilmelding = feilmelding,
+            merkelapp = merkelapp,
+            hendelseJson = hendelseJson,
+        )
     }
 
     private fun lagreIkkeUtsendtNarmesteLederVarsel(

--- a/src/main/kotlin/no/nav/syfo/service/SenderFacade.kt
+++ b/src/main/kotlin/no/nav/syfo/service/SenderFacade.kt
@@ -163,15 +163,20 @@ class SenderFacade(
     suspend fun sendTilArbeidsgiverNotifikasjon(
         varselHendelse: NarmesteLederHendelse,
         notifikasjon: ArbeidsgiverNotifikasjonNarmestelederInput,
-    ) {
+        hendelseJson: String? = null,
+    ): Boolean {
         try {
-            arbeidsgiverNotifikasjonService.sendNotifikasjon(notifikasjon)
+            val isSent = arbeidsgiverNotifikasjonService.sendNotifikasjon(notifikasjon)
+            if (!isSent) {
+                return false
+            }
             lagreUtsendtNarmesteLederVarsel(
                 ARBEIDSGIVERNOTIFIKASJON,
                 varselHendelse,
                 notifikasjon.uuid.toString(),
                 notifikasjon.merkelapp,
             )
+            return true
         } catch (e: Exception) {
             log.error("Error while sending varsel to ARBEIDSGIVERNOTIFIKASJON: ${e.message}")
             lagreIkkeUtsendtNarmesteLederVarsel(
@@ -180,21 +185,27 @@ class SenderFacade(
                 eksternReferanse = notifikasjon.uuid.toString(),
                 feilmelding = e.message,
                 merkelapp = notifikasjon.merkelapp,
+                hendelseJson = hendelseJson,
             )
+            return false
         }
     }
 
     suspend fun sendTilArbeidsgiverNotifikasjon(
         varselFeilet: PUtsendtVarselFeilet,
         notifikasjon: ArbeidsgiverNotifikasjonNarmestelederInput,
-    ) {
+    ): ArbeidsgiverVarselResendResult {
         try {
-            arbeidsgiverNotifikasjonService.sendNotifikasjon(notifikasjon)
+            val isSent = arbeidsgiverNotifikasjonService.sendNotifikasjon(notifikasjon)
+            if (!isSent) {
+                return ArbeidsgiverVarselResendResult.RETRYABLE_FAILURE
+            }
             lagreUtsendtNarmesteLederVarsel(
                 varselFeilet,
                 notifikasjon.uuid.toString(),
                 notifikasjon.merkelapp,
             )
+            return ArbeidsgiverVarselResendResult.RESENT
         } catch (e: Exception) {
             log.error(
                 "Error while resending varsel with id {} to ARBEIDSGIVERNOTIFIKASJON: {}",
@@ -610,6 +621,7 @@ class SenderFacade(
         eksternReferanse: String,
         feilmelding: String?,
         merkelapp: String?,
+        hendelseJson: String? = null,
     ): UUID {
         val uuid = UUID.randomUUID()
         database.storeUtsendtVarselFeilet(
@@ -627,6 +639,7 @@ class SenderFacade(
                 feilmelding = feilmelding,
                 utsendtForsokTidspunkt = LocalDateTime.now(),
                 isForcedLetter = false,
+                hendelseJson = hendelseJson,
             ),
         )
         return uuid

--- a/src/main/kotlin/no/nav/syfo/service/SenderFacade.kt
+++ b/src/main/kotlin/no/nav/syfo/service/SenderFacade.kt
@@ -247,6 +247,7 @@ class SenderFacade(
                 varselFeilet.uuid,
                 e.message,
             )
+            return ArbeidsgiverVarselResendResult.RETRYABLE_FAILURE
         }
     }
 

--- a/src/main/kotlin/no/nav/syfo/service/SenderFacade.kt
+++ b/src/main/kotlin/no/nav/syfo/service/SenderFacade.kt
@@ -663,6 +663,7 @@ class SenderFacade(
         feilmelding: String?,
         merkelapp: String,
         hendelseJson: String? = null,
+        resendExhausted: Boolean = false,
     ) {
         lagreIkkeUtsendtNarmesteLederVarsel(
             kanal = ARBEIDSGIVERNOTIFIKASJON,
@@ -671,6 +672,7 @@ class SenderFacade(
             feilmelding = feilmelding,
             merkelapp = merkelapp,
             hendelseJson = hendelseJson,
+            resendExhausted = resendExhausted,
         )
     }
 
@@ -681,6 +683,7 @@ class SenderFacade(
         feilmelding: String?,
         merkelapp: String?,
         hendelseJson: String? = null,
+        resendExhausted: Boolean = false,
     ): UUID {
         val uuid = UUID.randomUUID()
         database.storeUtsendtVarselFeilet(
@@ -698,6 +701,7 @@ class SenderFacade(
                 feilmelding = feilmelding,
                 utsendtForsokTidspunkt = LocalDateTime.now(),
                 isForcedLetter = false,
+                resendExhausted = resendExhausted,
                 hendelseJson = hendelseJson,
             ),
         )

--- a/src/main/kotlin/no/nav/syfo/service/VarselBusService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/VarselBusService.kt
@@ -12,6 +12,7 @@ import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType.NL_DIALOGMOTE_S
 import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType.NL_DIALOGMOTE_SVAR_MOTEBEHOV
 import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType.NL_OPPFOLGINGSPLAN_FORESPORSEL
 import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType.NL_OPPFOLGINGSPLAN_SENDT_TIL_GODKJENNING
+import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType.NL_OPPFOLGINGSPLAN_VARSELBESTILLING
 import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType.SM_AKTIVITETSPLIKT
 import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType.SM_ARBEIDSUFORHET_FORHANDSVARSEL
 import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType.SM_DIALOGMOTE_AVLYST
@@ -72,6 +73,11 @@ class VarselBusService(
 
                 NL_OPPFOLGINGSPLAN_SENDT_TIL_GODKJENNING ->
                     oppfolgingsplanVarselService.sendVarselTilNarmesteLeder(
+                        varselHendelse.toNarmestelederHendelse(),
+                    )
+
+                NL_OPPFOLGINGSPLAN_VARSELBESTILLING ->
+                    oppfolgingsplanVarselService.sendVarselbestillingTilNarmesteLeder(
                         varselHendelse.toNarmestelederHendelse(),
                     )
 

--- a/src/test/kotlin/no/nav/syfo/db/UtsendtVarselFeiletDAOSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/db/UtsendtVarselFeiletDAOSpek.kt
@@ -98,7 +98,7 @@ class UtsendtVarselFeiletDAOSpek :
                 val varsel =
                     ikkeUtsendtVarsel(
                         fnr = fnr,
-                        hendelseJson = """{"type":"NL_OPPFOLGINGSPLAN_VARSELBESTILLING","data":{"varselType":"BESKJED"}}""",
+                        hendelseJson = """{"type":"NL_OPPFOLGINGSPLAN_VARSELBESTILLING","data":{"arbeidsgiverMeldingType":"BESKJED"}}""",
                     ).copy(
                         uuidEksternReferanse = UUID.randomUUID().toString(),
                         orgnummer = "999888777",

--- a/src/test/kotlin/no/nav/syfo/db/UtsendtVarselFeiletDAOSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/db/UtsendtVarselFeiletDAOSpek.kt
@@ -92,6 +92,24 @@ class UtsendtVarselFeiletDAOSpek :
 
                 embeddedDatabase.fetchUtsendtArbeidsgivernotifikasjonVarselFeilet().size shouldBe 0
             }
+
+            it("Henter AG-feiletvarsel for NL_OPPFOLGINGSPLAN_VARSELBESTILLING") {
+                val fnr = "12121212121"
+                val varsel =
+                    ikkeUtsendtVarsel(
+                        fnr = fnr,
+                        hendelseJson = """{"type":"NL_OPPFOLGINGSPLAN_VARSELBESTILLING","data":{"varselType":"BESKJED"}}""",
+                    ).copy(
+                        uuidEksternReferanse = UUID.randomUUID().toString(),
+                        orgnummer = "999888777",
+                        kanal = Kanal.ARBEIDSGIVERNOTIFIKASJON.name,
+                        hendelsetypeNavn = HendelseType.NL_OPPFOLGINGSPLAN_VARSELBESTILLING.name,
+                    )
+
+                embeddedDatabase.storeUtsendtVarselFeilet(varsel)
+
+                embeddedDatabase.fetchUtsendtArbeidsgivernotifikasjonVarselFeilet().size shouldBe 1
+            }
         }
     })
 

--- a/src/test/kotlin/no/nav/syfo/job/ResendFailedVarslerJobTest.kt
+++ b/src/test/kotlin/no/nav/syfo/job/ResendFailedVarslerJobTest.kt
@@ -26,6 +26,7 @@ import no.nav.syfo.service.DialogmoteInnkallingSykmeldtVarselService
 import no.nav.syfo.service.KartleggingssporsmalVarselService
 import no.nav.syfo.service.MerVeiledningVarselService
 import no.nav.syfo.service.MotebehovVarselService
+import no.nav.syfo.service.OppfolgingsplanVarselService
 import no.nav.syfo.service.SenderFacade
 import no.nav.syfo.testutil.EmbeddedDatabase
 import org.amshove.kluent.shouldBeEqualTo
@@ -41,6 +42,7 @@ class ResendFailedVarslerJobTest :
         val kartleggingVarselService = mockk<KartleggingssporsmalVarselService>(relaxed = true)
         val senderFacade = mockk<SenderFacade>(relaxed = true)
         val arbeidsgiverVarselService = mockk<ArbeidsgiverVarselService>(relaxed = true)
+        val oppfolgingsplanVarselService = mockk<OppfolgingsplanVarselService>(relaxed = true)
 
         beforeTest {
             embeddedDatabase.dropData()
@@ -64,6 +66,7 @@ class ResendFailedVarslerJobTest :
                 kartleggingVarselService = kartleggingVarselService,
                 senderFacade = senderFacade,
                 arbeidsgiverVarselService = arbeidsgiverVarselService,
+                oppfolgingsplanVarselService = oppfolgingsplanVarselService,
             )
 
         describe("Resend brukernotifikasjon varsler") {
@@ -557,6 +560,54 @@ class ResendFailedVarslerJobTest :
                 storedFailedVarsel.hendelseJson shouldBeEqualTo failedVarsel.hendelseJson
                 coVerify(exactly = 0) { arbeidsgiverVarselService.resendVarselTilArbeidsgiver(any()) }
             }
+
+            it("Resends failed NL_OPPFOLGINGSPLAN_VARSELBESTILLING and clears hendelseJson after success") {
+                val failedVarsel =
+                    failedArbeidsgiverNotifikasjonForNarmesteLeder(
+                        hendelsetypeNavn = HendelseType.NL_OPPFOLGINGSPLAN_VARSELBESTILLING.name,
+                    )
+                coEvery {
+                    oppfolgingsplanVarselService.resendVarselbestillingTilArbeidsgiverNotifikasjon(failedVarsel)
+                } returns ArbeidsgiverVarselResendResult.RESENT
+
+                embeddedDatabase.storeUtsendtVarselFeilet(failedVarsel)
+
+                val result = runBlocking { job.resendFailedArbeidsgivernotifikasjonVarsler() }
+
+                result shouldBeEqualTo 1
+                val storedFailedVarsel =
+                    embeddedDatabase
+                        .fetchUtsendtVarselFeiletByFnr(failedVarsel.arbeidstakerFnr)
+                        .first { it.uuid == failedVarsel.uuid }
+                storedFailedVarsel.isResendt shouldBeEqualTo true
+                storedFailedVarsel.hendelseJson shouldBeEqualTo null
+                coVerify(exactly = 1) {
+                    oppfolgingsplanVarselService.resendVarselbestillingTilArbeidsgiverNotifikasjon(any())
+                }
+            }
+
+            it("Keeps NL_OPPFOLGINGSPLAN_VARSELBESTILLING retryable when resend still mangler NL-info") {
+                val failedVarsel =
+                    failedArbeidsgiverNotifikasjonForNarmesteLeder(
+                        hendelsetypeNavn = HendelseType.NL_OPPFOLGINGSPLAN_VARSELBESTILLING.name,
+                    )
+                coEvery {
+                    oppfolgingsplanVarselService.resendVarselbestillingTilArbeidsgiverNotifikasjon(any())
+                } returns ArbeidsgiverVarselResendResult.RETRYABLE_FAILURE
+
+                embeddedDatabase.storeUtsendtVarselFeilet(failedVarsel)
+
+                val result = runBlocking { job.resendFailedArbeidsgivernotifikasjonVarsler() }
+
+                result shouldBeEqualTo 0
+                val storedFailedVarsel =
+                    embeddedDatabase
+                        .fetchUtsendtVarselFeiletByFnr(failedVarsel.arbeidstakerFnr)
+                        .first { it.uuid == failedVarsel.uuid }
+                storedFailedVarsel.isResendt shouldBeEqualTo false
+                storedFailedVarsel.resendExhausted shouldBeEqualTo false
+                storedFailedVarsel.hendelseJson shouldBeEqualTo failedVarsel.hendelseJson
+            }
         }
     })
 
@@ -604,3 +655,41 @@ private fun failedArbeidsgiverAltinnVarsel(
         hendelseJson = hendelseJson ?: createObjectMapper().writeValueAsString(hendelse),
     )
 }
+
+private fun failedArbeidsgiverNotifikasjonForNarmesteLeder(
+    hendelsetypeNavn: String,
+    eksternReferanseId: String = UUID.randomUUID().toString(),
+    hendelseJson: String =
+        """
+        {
+          "@type": "NarmesteLederHendelse",
+          "type": "$hendelsetypeNavn",
+          "ferdigstill": false,
+          "narmesteLederFnr": "32121212121",
+          "arbeidstakerFnr": "12121212121",
+          "orgnummer": "999888777",
+          "data": {
+            "varselType": "BESKJED",
+            "notifikasjonInnhold": {
+              "epostTittel": "Tittel",
+              "epostBody": "<p>Body</p>",
+              "varselTekst": "Varsel"
+            }
+          }
+        }
+        """.trimIndent(),
+) = PUtsendtVarselFeilet(
+    uuid = UUID.randomUUID().toString(),
+    uuidEksternReferanse = eksternReferanseId,
+    arbeidstakerFnr = "12121212121",
+    narmesteLederFnr = "32121212121",
+    orgnummer = "999888777",
+    hendelsetypeNavn = hendelsetypeNavn,
+    arbeidsgivernotifikasjonMerkelapp = "Oppfølging",
+    brukernotifikasjonerMeldingType = null,
+    journalpostId = null,
+    kanal = "ARBEIDSGIVERNOTIFIKASJON",
+    feilmelding = "noe gikk galt",
+    utsendtForsokTidspunkt = LocalDateTime.now().minusHours(2),
+    hendelseJson = hendelseJson,
+)

--- a/src/test/kotlin/no/nav/syfo/job/ResendFailedVarslerJobTest.kt
+++ b/src/test/kotlin/no/nav/syfo/job/ResendFailedVarslerJobTest.kt
@@ -669,7 +669,7 @@ private fun failedArbeidsgiverNotifikasjonForNarmesteLeder(
           "arbeidstakerFnr": "12121212121",
           "orgnummer": "999888777",
           "data": {
-            "varselType": "BESKJED",
+            "arbeidsgiverMeldingType": "BESKJED",
             "notifikasjonInnhold": {
               "epostTittel": "Tittel",
               "epostBody": "<p>Body</p>",

--- a/src/test/kotlin/no/nav/syfo/kafka/consumers/varselbus/domain/EsyfovarselHendelseTest.kt
+++ b/src/test/kotlin/no/nav/syfo/kafka/consumers/varselbus/domain/EsyfovarselHendelseTest.kt
@@ -54,6 +54,47 @@ class EsyfovarselHendelseTest :
             }
             """.trimIndent()
 
+        val oppfolgingsplanHendelseJson =
+            """
+            {
+              "@type": "NarmesteLederHendelse",
+              "type": "NL_OPPFOLGINGSPLAN_VARSELBESTILLING",
+              "ferdigstill": false,
+              "data": {
+                "varselType": "BESKJED",
+                "notifikasjonInnhold": {
+                  "epostTittel": "Du har fått en ny melding",
+                  "epostBody": "Les meldingen i Dine sykmeldte",
+                  "varselTekst": "Du har fått en ny notifikasjon."
+                }
+              },
+              "narmesteLederFnr": "12345678910",
+              "arbeidstakerFnr": "012345678901",
+              "orgnummer": "999888777"
+            }
+            """.trimIndent()
+
+        val oppfolgingsplanHendelseJsonMedEkstraSmsTekst =
+            """
+            {
+              "@type": "NarmesteLederHendelse",
+              "type": "NL_OPPFOLGINGSPLAN_VARSELBESTILLING",
+              "ferdigstill": false,
+              "data": {
+                "varselType": "BESKJED",
+                "notifikasjonInnhold": {
+                  "epostTittel": "Du har fått en ny melding",
+                  "epostBody": "Les meldingen i Dine sykmeldte",
+                  "smsTekst": "Gammel sms-tekst",
+                  "varselTekst": "Du har fått en ny notifikasjon."
+                }
+              },
+              "narmesteLederFnr": "12345678910",
+              "arbeidstakerFnr": "012345678901",
+              "orgnummer": "999888777"
+            }
+            """.trimIndent()
+
         describe("EsyfovarselHendelse") {
             it("deserialiserer arbeidsgiverhendelse med AG_VARSEL_ALTINN_RESSURS til korrekt type") {
                 val hendelse: EsyfovarselHendelse = objectMapper.readValue(arbeidsgiverHendelseJson)
@@ -72,6 +113,26 @@ class EsyfovarselHendelseTest :
                 val hendelse: EsyfovarselHendelse = objectMapper.readValue(arbeidsgiverHendelseJson)
 
                 hendelse.isArbeidstakerHendelse() shouldBe false
+            }
+
+            it("deserialiserer oppfølgingsplanvarselbestilling uten smsTekst") {
+                val hendelse: EsyfovarselHendelse = objectMapper.readValue(oppfolgingsplanHendelseJson)
+                hendelse.data = objectMapper.readTree(oppfolgingsplanHendelseJson)["data"]
+                val varselData = requireNotNull(hendelse.data).toOppfolgingsplanVarselbestillingData()
+
+                (hendelse is NarmesteLederHendelse) shouldBe true
+                hendelse.type shouldBe HendelseType.NL_OPPFOLGINGSPLAN_VARSELBESTILLING
+                varselData.notifikasjonInnhold?.epostTittel shouldBe "Du har fått en ny melding"
+                varselData.notifikasjonInnhold?.epostBody shouldBe "Les meldingen i Dine sykmeldte"
+                varselData.notifikasjonInnhold?.varselTekst shouldBe "Du har fått en ny notifikasjon."
+            }
+
+            it("ignorerer ekstra smsTekst ved deserialisering av oppfølgingsplanvarselbestilling") {
+                val hendelse: EsyfovarselHendelse = objectMapper.readValue(oppfolgingsplanHendelseJsonMedEkstraSmsTekst)
+                hendelse.data = objectMapper.readTree(oppfolgingsplanHendelseJsonMedEkstraSmsTekst)["data"]
+                val varselData = requireNotNull(hendelse.data).toOppfolgingsplanVarselbestillingData()
+
+                varselData.notifikasjonInnhold?.varselTekst shouldBe "Du har fått en ny notifikasjon."
             }
 
             it("faller tilbake til smsTekst når varselTekst mangler i arbeidsgiverhendelse") {

--- a/src/test/kotlin/no/nav/syfo/kafka/consumers/varselbus/domain/EsyfovarselHendelseTest.kt
+++ b/src/test/kotlin/no/nav/syfo/kafka/consumers/varselbus/domain/EsyfovarselHendelseTest.kt
@@ -61,31 +61,10 @@ class EsyfovarselHendelseTest :
               "type": "NL_OPPFOLGINGSPLAN_VARSELBESTILLING",
               "ferdigstill": false,
               "data": {
-                "varselType": "BESKJED",
+                "arbeidsgiverMeldingType": "BESKJED",
                 "notifikasjonInnhold": {
                   "epostTittel": "Du har fått en ny melding",
                   "epostBody": "Les meldingen i Dine sykmeldte",
-                  "varselTekst": "Du har fått en ny notifikasjon."
-                }
-              },
-              "narmesteLederFnr": "12345678910",
-              "arbeidstakerFnr": "012345678901",
-              "orgnummer": "999888777"
-            }
-            """.trimIndent()
-
-        val oppfolgingsplanHendelseJsonMedEkstraSmsTekst =
-            """
-            {
-              "@type": "NarmesteLederHendelse",
-              "type": "NL_OPPFOLGINGSPLAN_VARSELBESTILLING",
-              "ferdigstill": false,
-              "data": {
-                "varselType": "BESKJED",
-                "notifikasjonInnhold": {
-                  "epostTittel": "Du har fått en ny melding",
-                  "epostBody": "Les meldingen i Dine sykmeldte",
-                  "smsTekst": "Gammel sms-tekst",
                   "varselTekst": "Du har fått en ny notifikasjon."
                 }
               },
@@ -124,14 +103,6 @@ class EsyfovarselHendelseTest :
                 hendelse.type shouldBe HendelseType.NL_OPPFOLGINGSPLAN_VARSELBESTILLING
                 varselData.notifikasjonInnhold?.epostTittel shouldBe "Du har fått en ny melding"
                 varselData.notifikasjonInnhold?.epostBody shouldBe "Les meldingen i Dine sykmeldte"
-                varselData.notifikasjonInnhold?.varselTekst shouldBe "Du har fått en ny notifikasjon."
-            }
-
-            it("ignorerer ekstra smsTekst ved deserialisering av oppfølgingsplanvarselbestilling") {
-                val hendelse: EsyfovarselHendelse = objectMapper.readValue(oppfolgingsplanHendelseJsonMedEkstraSmsTekst)
-                hendelse.data = objectMapper.readTree(oppfolgingsplanHendelseJsonMedEkstraSmsTekst)["data"]
-                val varselData = requireNotNull(hendelse.data).toOppfolgingsplanVarselbestillingData()
-
                 varselData.notifikasjonInnhold?.varselTekst shouldBe "Du har fått en ny notifikasjon."
             }
 

--- a/src/test/kotlin/no/nav/syfo/service/ArbeidsgiverNotifikasjonServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/service/ArbeidsgiverNotifikasjonServiceTest.kt
@@ -1,12 +1,16 @@
 package no.nav.syfo.service
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
+import no.nav.syfo.consumer.narmesteLeder.NarmesteLederRelasjon
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.IArbeidsgiverNotifikasjonProdusent
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.ArbeidsgiverNotifikasjon
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.ArbeidsgiverNotifikasjonAltinnRessurs
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.ArbeidsgiverNotifikasjonNarmesteLeder
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -48,6 +52,108 @@ class ArbeidsgiverNotifikasjonServiceTest :
                 val actual = capturedNotifikasjoner.single() as ArbeidsgiverNotifikasjonAltinnRessurs
                 actual.messageText shouldBe input.messageText
                 actual.smsTekst shouldBe input.smsTekst
+            }
+        }
+
+        describe("sendNotifikasjon for nærmeste leder") {
+            it("videresender e-postvarsel for nærmeste leder") {
+                val input =
+                    ArbeidsgiverNotifikasjonNarmestelederInput(
+                        uuid = UUID.randomUUID(),
+                        virksomhetsnummer = "999888777",
+                        narmesteLederFnr = "12345678910",
+                        ansattFnr = "10987654321",
+                        merkelapp = "merkelapp",
+                        messageText = "Varseltekst",
+                        epostTittel = "Tittel",
+                        epostHtmlBody = "<p>Body</p>",
+                        hardDeleteDate = LocalDateTime.of(2030, 1, 1, 0, 0),
+                        grupperingsid = UUID.randomUUID().toString(),
+                    )
+                val capturedNotifikasjoner = mutableListOf<ArbeidsgiverNotifikasjon>()
+                coEvery { narmesteLederService.getNarmesteLederRelasjon(input.ansattFnr, input.virksomhetsnummer) } returns
+                    NarmesteLederRelasjon(
+                        narmesteLederFnr = input.narmesteLederFnr,
+                        narmesteLederEpost = "leder@test.no",
+                        narmesteLederTelefonnummer = "99999999",
+                        tilganger = emptyList(),
+                        navn = "Leder",
+                    )
+                every { narmesteLederService.hasNarmesteLederInfo(any()) } returns true
+                coEvery {
+                    arbeidsgiverNotifikasjonProdusent.createNewBeskjedForArbeidsgiver(capture(capturedNotifikasjoner))
+                } returns "notifikasjon-id"
+
+                val result = service.sendNotifikasjon(input)
+
+                result shouldBe true
+                val actual = capturedNotifikasjoner.single() as ArbeidsgiverNotifikasjonNarmesteLeder
+                actual.messageText shouldBe input.messageText
+            }
+
+            it("returnerer true når telefonnummer mangler for nærmeste leder") {
+                val input =
+                    ArbeidsgiverNotifikasjonNarmestelederInput(
+                        uuid = UUID.randomUUID(),
+                        virksomhetsnummer = "999888777",
+                        narmesteLederFnr = "12345678910",
+                        ansattFnr = "10987654321",
+                        merkelapp = "merkelapp",
+                        messageText = "Varseltekst",
+                        epostTittel = "Tittel",
+                        epostHtmlBody = "<p>Body</p>",
+                        hardDeleteDate = LocalDateTime.of(2030, 1, 1, 0, 0),
+                        grupperingsid = UUID.randomUUID().toString(),
+                    )
+                coEvery { narmesteLederService.getNarmesteLederRelasjon(input.ansattFnr, input.virksomhetsnummer) } returns
+                    NarmesteLederRelasjon(
+                        narmesteLederFnr = input.narmesteLederFnr,
+                        narmesteLederEpost = "leder@test.no",
+                        narmesteLederTelefonnummer = null,
+                        tilganger = emptyList(),
+                        navn = "Leder",
+                    )
+                every { narmesteLederService.hasNarmesteLederInfo(any()) } returns true
+                coEvery {
+                    arbeidsgiverNotifikasjonProdusent.createNewBeskjedForArbeidsgiver(any())
+                } returns "notifikasjon-id"
+
+                val result = service.sendNotifikasjon(input)
+
+                result shouldBe true
+            }
+
+            it("kaster exception når produsent returnerer null ID") {
+                val input =
+                    ArbeidsgiverNotifikasjonNarmestelederInput(
+                        uuid = UUID.randomUUID(),
+                        virksomhetsnummer = "999888777",
+                        narmesteLederFnr = "12345678910",
+                        ansattFnr = "10987654321",
+                        merkelapp = "merkelapp",
+                        messageText = "Varseltekst",
+                        epostTittel = "Tittel",
+                        epostHtmlBody = "<p>Body</p>",
+                        hardDeleteDate = LocalDateTime.of(2030, 1, 1, 0, 0),
+                        grupperingsid = UUID.randomUUID().toString(),
+                    )
+                coEvery { narmesteLederService.getNarmesteLederRelasjon(input.ansattFnr, input.virksomhetsnummer) } returns
+                    NarmesteLederRelasjon(
+                        narmesteLederFnr = input.narmesteLederFnr,
+                        narmesteLederEpost = "leder@test.no",
+                        narmesteLederTelefonnummer = "99999999",
+                        tilganger = emptyList(),
+                        navn = "Leder",
+                    )
+                every { narmesteLederService.hasNarmesteLederInfo(any()) } returns true
+                coEvery {
+                    arbeidsgiverNotifikasjonProdusent.createNewBeskjedForArbeidsgiver(any())
+                } returns null
+
+                shouldThrow<IllegalStateException> {
+                    service.sendNotifikasjon(input)
+                }.message shouldBe
+                    "ArbeidsgiverNotifikasjonProdusent returnerte null ID ved utsending til nærmeste leder"
             }
         }
     })

--- a/src/test/kotlin/no/nav/syfo/service/DialogmoteInnkallingNarmesteLederVarselServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/service/DialogmoteInnkallingNarmesteLederVarselServiceSpek.kt
@@ -83,6 +83,7 @@ class DialogmoteInnkallingNarmesteLederVarselServiceSpek :
                             ),
                     )
                 coEvery { arbeidsgiverNotifikasjonService.createNewSak(any()) } returns UUID.randomUUID().toString()
+                coEvery { arbeidsgiverNotifikasjonService.sendNotifikasjon(any<ArbeidsgiverNotifikasjonNarmestelederInput>()) } returns true
             }
 
             it("Should create sak and kalenderavtale for innkalling, but not send notifikasjon") {

--- a/src/test/kotlin/no/nav/syfo/service/OppfolgingsplanVarselServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/service/OppfolgingsplanVarselServiceSpek.kt
@@ -302,9 +302,10 @@ class OppfolgingsplanVarselServiceSpek :
                 coVerify(exactly = 0) { pdlClient.hentPerson(any()) }
             }
 
-            it("Oppfolgingsplan varselbestilling should create new sak, set link and map payload texts") {
+            it("Oppfolgingsplan varselbestilling should substitute NARMESTE_LEDER_ID in ressursUrl for AG-notifikasjon") {
                 val narmesteLederId = "1234"
-                val expectedUrl = "$fakeDinesykmeldteUrl/$narmesteLederId"
+                val expectedSakUrl = "$fakeDinesykmeldteUrl/$narmesteLederId"
+                val expectedNotifikasjonLink = "https://example.com/oppfolgingsplan/$narmesteLederId/detaljer"
                 val dineSykmeldteVarselSlot = slot<DineSykmeldteVarsel>()
                 val notifikasjonInputSlot = slot<ArbeidsgiverNotifikasjonNarmestelederInput>()
                 justRun { dineSykmeldteHendelseKafkaProducer.sendVarsel(capture(dineSykmeldteVarselSlot)) }
@@ -313,7 +314,11 @@ class OppfolgingsplanVarselServiceSpek :
                 coEvery { arbeidsgiverNotifikasjonService.createNewSak(any()) } returns UUID.randomUUID().toString()
                 coEvery { arbeidsgiverNotifikasjonService.sendNotifikasjon(capture(notifikasjonInputSlot)) } returns true
 
-                oppfolgingsplanVarselService.sendVarselbestillingTilNarmesteLeder(oppfolgingsplanVarselbestillingHendelse())
+                oppfolgingsplanVarselService.sendVarselbestillingTilNarmesteLeder(
+                    oppfolgingsplanVarselbestillingHendelse(
+                        ressursUrl = "https://example.com/oppfolgingsplan/NARMESTE_LEDER_ID/detaljer",
+                    ),
+                )
 
                 val storedSak =
                     senderFacade.getPaagaaendeSak(
@@ -326,9 +331,9 @@ class OppfolgingsplanVarselServiceSpek :
                 notifikasjonInputSlot.captured.epostTittel shouldBeEqualTo "E-posttittel"
                 notifikasjonInputSlot.captured.epostHtmlBody shouldBeEqualTo "<p>E-postbody</p>"
                 notifikasjonInputSlot.captured.meldingstype shouldBeEqualTo Meldingstype.BESKJED
-                notifikasjonInputSlot.captured.link shouldBeEqualTo expectedUrl
+                notifikasjonInputSlot.captured.link shouldBeEqualTo expectedNotifikasjonLink
                 notifikasjonInputSlot.captured.grupperingsid shouldBeEqualTo storedSak?.grupperingsid
-                storedSak?.lenke shouldBeEqualTo expectedUrl
+                storedSak?.lenke shouldBeEqualTo expectedSakUrl
                 storedSak?.hardDeleteDate shouldBeEqualTo notifikasjonInputSlot.captured.hardDeleteDate
                 coVerify(exactly = 1) { arbeidsgiverNotifikasjonService.createNewSak(any()) }
                 coVerify(exactly = 0) { arbeidsgiverNotifikasjonService.nyStatusSak(any()) }
@@ -652,13 +657,14 @@ class OppfolgingsplanVarselServiceSpek :
 private fun oppfolgingsplanVarselbestillingHendelse(
     arbeidsgiverMeldingType: String? = Meldingstype.BESKJED.name,
     dineSykmeldteHendelseType: String? = DineSykmeldteHendelseType.OPPFOLGINGSPLAN_PAAMINNELSE.name,
+    ressursUrl: String? = null,
     rawData: String? = null,
 ) = NarmesteLederHendelse(
     type = HendelseType.NL_OPPFOLGINGSPLAN_VARSELBESTILLING,
     ferdigstill = false,
     data =
         createObjectMapper().readTree(
-            rawData ?: defaultOppfolgingsplanVarselbestillingData(arbeidsgiverMeldingType, dineSykmeldteHendelseType),
+            rawData ?: defaultOppfolgingsplanVarselbestillingData(arbeidsgiverMeldingType, dineSykmeldteHendelseType, ressursUrl),
         ),
     narmesteLederFnr = FNR_2,
     arbeidstakerFnr = FNR_1,
@@ -678,10 +684,12 @@ private fun oppfolgingsplanForesporselHendelse() =
 private fun defaultOppfolgingsplanVarselbestillingData(
     arbeidsgiverMeldingType: String?,
     dineSykmeldteHendelseType: String?,
+    ressursUrl: String?,
 ) = """
     {
      "arbeidsgiverMeldingType": ${arbeidsgiverMeldingType?.let { "\"$it\"" } ?: "null"},
      "dineSykmeldteHendelseType": ${dineSykmeldteHendelseType?.let { "\"$it\"" } ?: "null"},
+     "ressursUrl": ${ressursUrl?.let { "\"$it\"" } ?: "null"},
      "notifikasjonInnhold": {
        "epostTittel": "E-posttittel",
        "epostBody": "<p>E-postbody</p>",

--- a/src/test/kotlin/no/nav/syfo/service/OppfolgingsplanVarselServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/service/OppfolgingsplanVarselServiceSpek.kt
@@ -40,6 +40,7 @@ import no.nav.syfo.testutil.mocks.FNR_2
 import no.nav.syfo.testutil.mocks.ORGNUMMER
 import org.amshove.kluent.shouldBeEqualTo
 import java.net.URI
+import java.time.Duration
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -170,7 +171,7 @@ class OppfolgingsplanVarselServiceSpek :
                 notifikasjonInputSlot.captured.link shouldBeEqualTo expectedUrl
                 notifikasjonInputSlot.captured.grupperingsid shouldBeEqualTo storedSak?.grupperingsid
                 storedSak?.lenke shouldBeEqualTo expectedUrl
-                storedSak?.hardDeleteDate shouldBeEqualTo notifikasjonInputSlot.captured.hardDeleteDate
+                storedSak?.hardDeleteDate shouldBeSameTimestampAs notifikasjonInputSlot.captured.hardDeleteDate
             }
 
             it("Oppfolgingsplan foresporsel should reuse existing sak and preserve status") {
@@ -218,7 +219,7 @@ class OppfolgingsplanVarselServiceSpek :
                 nyStatusSakInputSlot.captured.oppdatertHardDeleteDateTime shouldBeEqualTo
                     notifikasjonInputSlot.captured.hardDeleteDate
                 updatedSak?.id shouldBeEqualTo sakId
-                updatedSak?.hardDeleteDate shouldBeEqualTo notifikasjonInputSlot.captured.hardDeleteDate
+                updatedSak?.hardDeleteDate shouldBeSameTimestampAs notifikasjonInputSlot.captured.hardDeleteDate
                 coVerify(exactly = 0) { arbeidsgiverNotifikasjonService.createNewSak(any()) }
                 coVerify(exactly = 0) { pdlClient.hentPerson(any()) }
                 coVerify(exactly = 1) { narmesteLederService.getNarmesteLederRelasjon(FNR_1, ORGNUMMER) }
@@ -334,7 +335,7 @@ class OppfolgingsplanVarselServiceSpek :
                 notifikasjonInputSlot.captured.link shouldBeEqualTo expectedNotifikasjonLink
                 notifikasjonInputSlot.captured.grupperingsid shouldBeEqualTo storedSak?.grupperingsid
                 storedSak?.lenke shouldBeEqualTo expectedSakUrl
-                storedSak?.hardDeleteDate shouldBeEqualTo notifikasjonInputSlot.captured.hardDeleteDate
+                storedSak?.hardDeleteDate shouldBeSameTimestampAs notifikasjonInputSlot.captured.hardDeleteDate
                 coVerify(exactly = 1) { arbeidsgiverNotifikasjonService.createNewSak(any()) }
                 coVerify(exactly = 0) { arbeidsgiverNotifikasjonService.nyStatusSak(any()) }
             }
@@ -399,7 +400,7 @@ class OppfolgingsplanVarselServiceSpek :
                     eksisterendeSak.initiellStatus.let { SakStatus.valueOf(it.name) }
                 nyStatusSakInputSlot.captured.oppdatertHardDeleteDateTime shouldBeEqualTo
                     notifikasjonInputSlot.captured.hardDeleteDate
-                updatedSak?.hardDeleteDate shouldBeEqualTo notifikasjonInputSlot.captured.hardDeleteDate
+                updatedSak?.hardDeleteDate shouldBeSameTimestampAs notifikasjonInputSlot.captured.hardDeleteDate
                 coVerify(exactly = 0) { arbeidsgiverNotifikasjonService.createNewSak(any()) }
             }
 
@@ -706,6 +707,15 @@ private fun narmesteLederRelasjon(narmesteLederId: String) =
         navn = "Test Lansen",
         narmesteLederEpost = "test@test.no",
     )
+
+private infix fun LocalDateTime?.shouldBeSameTimestampAs(expected: LocalDateTime?) {
+    val actual = requireNotNull(this)
+    val expectedTimestamp = requireNotNull(expected)
+    val diffNanos = kotlin.math.abs(Duration.between(actual, expectedTimestamp).toNanos())
+    if (diffNanos >= 1_000_000) {
+        throw AssertionError("Expected <$actual> to be within 1 ms of <$expectedTimestamp>")
+    }
+}
 
 private fun personData() =
     HentPersonData(

--- a/src/test/kotlin/no/nav/syfo/service/OppfolgingsplanVarselServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/service/OppfolgingsplanVarselServiceSpek.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.service
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -17,10 +18,13 @@ import no.nav.syfo.consumer.pdl.HentPerson
 import no.nav.syfo.consumer.pdl.HentPersonData
 import no.nav.syfo.consumer.pdl.Navn
 import no.nav.syfo.consumer.pdl.PdlClient
+import no.nav.syfo.db.domain.PUtsendtVarselFeilet
+import no.nav.syfo.kafka.common.createObjectMapper
 import no.nav.syfo.kafka.consumers.varselbus.domain.ArbeidstakerHendelse
 import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType
 import no.nav.syfo.kafka.consumers.varselbus.domain.NarmesteLederHendelse
 import no.nav.syfo.kafka.producers.dinesykmeldte.DineSykmeldteHendelseKafkaProducer
+import no.nav.syfo.kafka.producers.dinesykmeldte.domain.DineSykmeldteVarsel
 import no.nav.syfo.kafka.producers.dittsykefravaer.DittSykefravaerMeldingKafkaProducer
 import no.nav.syfo.testutil.EmbeddedDatabase
 import no.nav.syfo.testutil.mocks.FNR_1
@@ -28,7 +32,9 @@ import no.nav.syfo.testutil.mocks.FNR_2
 import no.nav.syfo.testutil.mocks.ORGNUMMER
 import org.amshove.kluent.shouldBeEqualTo
 import java.net.URI
+import java.time.LocalDateTime
 import java.util.UUID
+import no.nav.syfo.kafka.consumers.varselbus.domain.DineSykmeldteHendelseType
 
 class OppfolgingsplanVarselServiceSpek :
     DescribeSpec({
@@ -142,7 +148,7 @@ class OppfolgingsplanVarselServiceSpek :
                             ),
                     )
                 coEvery { arbeidsgiverNotifikasjonService.createNewSak(any()) } returns UUID.randomUUID().toString()
-                coEvery { arbeidsgiverNotifikasjonService.sendNotifikasjon(any<ArbeidsgiverNotifikasjonNarmestelederInput>()) } returns Unit
+                coEvery { arbeidsgiverNotifikasjonService.sendNotifikasjon(any<ArbeidsgiverNotifikasjonNarmestelederInput>()) } returns true
 
                 val varselHendelse =
                     NarmesteLederHendelse(
@@ -172,5 +178,203 @@ class OppfolgingsplanVarselServiceSpek :
                 notifikasjonInputSlot.captured.link shouldBeEqualTo expectedUrl
                 storedSak?.lenke shouldBeEqualTo expectedUrl
             }
+
+            it("Oppfolgingsplan varselbestilling should map payload texts to Dine Sykmeldte and arbeidsgivernotifikasjon") {
+                val dineSykmeldteVarselSlot = slot<DineSykmeldteVarsel>()
+                val notifikasjonInputSlot = slot<ArbeidsgiverNotifikasjonNarmestelederInput>()
+                justRun { dineSykmeldteHendelseKafkaProducer.sendVarsel(capture(dineSykmeldteVarselSlot)) }
+                coEvery { arbeidsgiverNotifikasjonService.sendNotifikasjon(capture(notifikasjonInputSlot)) } returns true
+
+                oppfolgingsplanVarselService.sendVarselbestillingTilNarmesteLeder(
+                    oppfolgingsplanVarselbestillingHendelse(),
+                )
+                dineSykmeldteVarselSlot.captured.tekst shouldBeEqualTo "Dine Sykmeldte-tekst"
+                notifikasjonInputSlot.captured.messageText shouldBeEqualTo "Dine Sykmeldte-tekst"
+                notifikasjonInputSlot.captured.messageText shouldBeEqualTo "Dine Sykmeldte-tekst"
+                notifikasjonInputSlot.captured.epostTittel shouldBeEqualTo "E-posttittel"
+                notifikasjonInputSlot.captured.epostHtmlBody shouldBeEqualTo "<p>E-postbody</p>"
+                notifikasjonInputSlot.captured.meldingstype shouldBeEqualTo Meldingstype.BESKJED
+            }
+
+            it("Oppfolgingsplan varselbestilling should reject unsupported varselType") {
+                val exception =
+                    shouldThrow<IllegalArgumentException> {
+                        oppfolgingsplanVarselService.sendVarselbestillingTilNarmesteLeder(
+                            oppfolgingsplanVarselbestillingHendelse(arbeidsgiverMeldingType = "KORT_BESKJED"),
+                        )
+                    }
+
+                exception.message shouldBeEqualTo "Oppfølgingsplanvarsel har ugyldig data.varselType=KORT_BESKJED"
+            }
+
+            it("Oppfolgingsplan varselbestilling should reject missing notifikasjonInnhold") {
+                val exception =
+                    shouldThrow<IllegalArgumentException> {
+                        oppfolgingsplanVarselService.sendVarselbestillingTilNarmesteLeder(
+                            oppfolgingsplanVarselbestillingHendelse(
+                                rawData = """{"varselType":"BESKJED"}""",
+                            ),
+                        )
+                    }
+
+                exception.message shouldBeEqualTo "Oppfølgingsplanvarsel mangler feltet: data.notifikasjonInnhold"
+            }
+
+            it("Oppfolgingsplan varselbestilling should reject missing explicit varselTekst") {
+                val exception =
+                    shouldThrow<IllegalArgumentException> {
+                        oppfolgingsplanVarselService.sendVarselbestillingTilNarmesteLeder(
+                            oppfolgingsplanVarselbestillingHendelse(
+                                rawData =
+                                    """
+                                    {
+                                      "arbeidsgiverMeldingType": "BESKJED",
+                                      "notifikasjonInnhold": {
+                                        "epostTittel": "E-posttittel",
+                                        "epostBody": "<p>E-postbody</p>"
+                                      }
+                                    }
+                                    """.trimIndent(),
+                            ),
+                        )
+                    }
+
+                exception.message shouldBeEqualTo
+                    "Oppfølgingsplanvarsel mangler feltet: data.notifikasjonInnhold.varselTekst"
+            }
+
+            it("Oppfolgingsplan varselbestilling retry should reuse uuidEksternReferanse as notifikasjonsuuid") {
+                val notifikasjonInputSlot = slot<ArbeidsgiverNotifikasjonNarmestelederInput>()
+                val eksternReferanse = UUID.randomUUID()
+                coEvery { arbeidsgiverNotifikasjonService.sendNotifikasjon(capture(notifikasjonInputSlot)) } returns true
+
+                val result =
+                    oppfolgingsplanVarselService.resendVarselbestillingTilArbeidsgiverNotifikasjon(
+                        PUtsendtVarselFeilet(
+                            uuid = UUID.randomUUID().toString(),
+                            uuidEksternReferanse = eksternReferanse.toString(),
+                            arbeidstakerFnr = FNR_1,
+                            narmesteLederFnr = FNR_2,
+                            orgnummer = ORGNUMMER,
+                            hendelsetypeNavn = HendelseType.NL_OPPFOLGINGSPLAN_VARSELBESTILLING.name,
+                            arbeidsgivernotifikasjonMerkelapp = ARBEIDSGIVERNOTIFIKASJON_OPPFOLGING_MERKELAPP,
+                            brukernotifikasjonerMeldingType = null,
+                            journalpostId = null,
+                            kanal = "ARBEIDSGIVERNOTIFIKASJON",
+                            feilmelding = "noe galt",
+                            utsendtForsokTidspunkt = LocalDateTime.now(),
+                            hendelseJson = createObjectMapper().writeValueAsString(
+                                oppfolgingsplanVarselbestillingHendelse()
+                            ),
+                        ),
+                    )
+
+                result shouldBeEqualTo ArbeidsgiverVarselResendResult.RESENT
+                notifikasjonInputSlot.captured.uuid shouldBeEqualTo eksternReferanse
+            }
+
+            it("Oppfolgingsplan varselbestilling retry should stay retryable when narmeste leder info mangler") {
+                coEvery {
+                    arbeidsgiverNotifikasjonService.sendNotifikasjon(any<ArbeidsgiverNotifikasjonNarmestelederInput>())
+                } returns false
+
+                val result =
+                    oppfolgingsplanVarselService.resendVarselbestillingTilArbeidsgiverNotifikasjon(
+                        PUtsendtVarselFeilet(
+                            uuid = UUID.randomUUID().toString(),
+                            uuidEksternReferanse = UUID.randomUUID().toString(),
+                            arbeidstakerFnr = FNR_1,
+                            narmesteLederFnr = FNR_2,
+                            orgnummer = ORGNUMMER,
+                            hendelsetypeNavn = HendelseType.NL_OPPFOLGINGSPLAN_VARSELBESTILLING.name,
+                            arbeidsgivernotifikasjonMerkelapp = ARBEIDSGIVERNOTIFIKASJON_OPPFOLGING_MERKELAPP,
+                            brukernotifikasjonerMeldingType = null,
+                            journalpostId = null,
+                            kanal = "ARBEIDSGIVERNOTIFIKASJON",
+                            feilmelding = "noe galt",
+                            utsendtForsokTidspunkt = LocalDateTime.now(),
+                            hendelseJson = createObjectMapper().writeValueAsString(
+                                oppfolgingsplanVarselbestillingHendelse()
+                            ),
+                        ),
+                    )
+
+                result shouldBeEqualTo ArbeidsgiverVarselResendResult.RETRYABLE_FAILURE
+            }
+
+            it("Oppfolgingsplan varselbestilling retry should ignore extra smsTekst in stored hendelseJson") {
+                val notifikasjonInputSlot = slot<ArbeidsgiverNotifikasjonNarmestelederInput>()
+                coEvery { arbeidsgiverNotifikasjonService.sendNotifikasjon(capture(notifikasjonInputSlot)) } returns true
+
+                val result =
+                    oppfolgingsplanVarselService.resendVarselbestillingTilArbeidsgiverNotifikasjon(
+                        PUtsendtVarselFeilet(
+                            uuid = UUID.randomUUID().toString(),
+                            uuidEksternReferanse = UUID.randomUUID().toString(),
+                            arbeidstakerFnr = FNR_1,
+                            narmesteLederFnr = FNR_2,
+                            orgnummer = ORGNUMMER,
+                            hendelsetypeNavn = HendelseType.NL_OPPFOLGINGSPLAN_VARSELBESTILLING.name,
+                            arbeidsgivernotifikasjonMerkelapp = ARBEIDSGIVERNOTIFIKASJON_OPPFOLGING_MERKELAPP,
+                            brukernotifikasjonerMeldingType = null,
+                            journalpostId = null,
+                            kanal = "ARBEIDSGIVERNOTIFIKASJON",
+                            feilmelding = "noe galt",
+                            utsendtForsokTidspunkt = LocalDateTime.now(),
+                            hendelseJson =
+                                """
+                                {
+                                  "@type": "NarmesteLederHendelse",
+                                  "type": "NL_OPPFOLGINGSPLAN_VARSELBESTILLING",
+                                  "ferdigstill": false,
+                                  "narmesteLederFnr": "$FNR_2",
+                                  "arbeidstakerFnr": "$FNR_1",
+                                  "orgnummer": "$ORGNUMMER",
+                                  "data": {
+                                    "arbeidsgiverMeldingType": "BESKJED",
+                                    "dineSykmeldteHendelseType": "OPPFOLGINGSPLAN_OPPRETTET",
+                                    "notifikasjonInnhold": {
+                                      "epostTittel": "E-posttittel",
+                                      "epostBody": "<p>E-postbody</p>",
+                                      "smsTekst": "Gammel sms-tekst",
+                                      "varselTekst": "Dine Sykmeldte-tekst"
+                                    }
+                                  }
+                                }
+                                """.trimIndent(),
+                        ),
+                    )
+
+                result shouldBeEqualTo ArbeidsgiverVarselResendResult.RESENT
+                notifikasjonInputSlot.captured.messageText shouldBeEqualTo "Dine Sykmeldte-tekst"
+            }
         }
     })
+
+private fun oppfolgingsplanVarselbestillingHendelse(
+    arbeidsgiverMeldingType: String? = Meldingstype.BESKJED.name,
+    dineSykmeldteHendelseType: String? = DineSykmeldteHendelseType.OPPFOLGINGSPLAN_PAAMINNELSE.name,
+    rawData: String? = null,
+) = NarmesteLederHendelse(
+    type = HendelseType.NL_OPPFOLGINGSPLAN_VARSELBESTILLING,
+    ferdigstill = false,
+    data =
+        createObjectMapper().readTree(
+            rawData ?: (
+                """
+                {
+                 "arbeidsgiverMeldingType": ${arbeidsgiverMeldingType?.let { "\"$it\"" } ?: "null"},
+                 "dineSykmeldteHendelseType": ${dineSykmeldteHendelseType?.let { "\"$it\"" } ?: "null"},
+                 "notifikasjonInnhold": {
+                   "epostTittel": "E-posttittel",
+                   "epostBody": "<p>E-postbody</p>",
+                   "varselTekst": "Dine Sykmeldte-tekst"
+                 }
+                }
+                """.trimIndent()
+                ),
+        ),
+    narmesteLederFnr = FNR_2,
+    arbeidstakerFnr = FNR_1,
+    orgnummer = ORGNUMMER,
+)

--- a/src/test/kotlin/no/nav/syfo/service/OppfolgingsplanVarselServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/service/OppfolgingsplanVarselServiceSpek.kt
@@ -1,6 +1,5 @@
 package no.nav.syfo.service
 
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
@@ -31,6 +30,7 @@ import no.nav.syfo.kafka.consumers.varselbus.domain.NarmesteLederHendelse
 import no.nav.syfo.kafka.producers.dinesykmeldte.DineSykmeldteHendelseKafkaProducer
 import no.nav.syfo.kafka.producers.dinesykmeldte.domain.DineSykmeldteVarsel
 import no.nav.syfo.kafka.producers.dittsykefravaer.DittSykefravaerMeldingKafkaProducer
+import no.nav.syfo.metrics.COUNT_OPPFOLGINGSPLAN_VARSEL_UGYLDIG
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NySakNarmesteLederInput
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NyStatusSakInput
 import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.SakStatus
@@ -430,6 +430,7 @@ class OppfolgingsplanVarselServiceSpek :
                 utsendteVarsler.count { it.kanal == "DINE_SYKMELDTE" } shouldBeEqualTo 1
                 feiledeVarsler.size shouldBeEqualTo 1
                 feiledeVarsler.single().kanal shouldBeEqualTo "ARBEIDSGIVERNOTIFIKASJON"
+                feiledeVarsler.single().resendExhausted shouldBeEqualTo false
                 feiledeVarsler.single().hendelseJson shouldBeEqualTo
                     createObjectMapper().writeValueAsString(
                         oppfolgingsplanVarselbestillingHendelse(),
@@ -464,56 +465,105 @@ class OppfolgingsplanVarselServiceSpek :
                 utsendteVarsler.count { it.kanal == "DINE_SYKMELDTE" } shouldBeEqualTo 1
                 utsendteVarsler.count { it.kanal == "ARBEIDSGIVERNOTIFIKASJON" } shouldBeEqualTo 0
                 feiledeVarsler.size shouldBeEqualTo 1
+                feiledeVarsler.single().resendExhausted shouldBeEqualTo false
                 feiledeVarsler.single().hendelseJson shouldBeEqualTo
                     createObjectMapper().writeValueAsString(
                         oppfolgingsplanVarselbestillingHendelse(),
                     )
             }
 
-            it("Oppfolgingsplan varselbestilling should reject unsupported arbeidsgiverMeldingType") {
-                val exception =
-                    shouldThrow<IllegalArgumentException> {
-                        oppfolgingsplanVarselService.sendVarselbestillingTilNarmesteLeder(
-                            oppfolgingsplanVarselbestillingHendelse(arbeidsgiverMeldingType = "KORT_BESKJED"),
-                        )
-                    }
+            it(
+                "Oppfolgingsplan varselbestilling should store permanent failure for unsupported arbeidsgiverMeldingType without side effects",
+            ) {
+                val hendelse =
+                    oppfolgingsplanVarselbestillingHendelse(
+                        arbeidsgiverMeldingType = "KORT_BESKJED",
+                    )
+                val invalidPayloadCountBefore = COUNT_OPPFOLGINGSPLAN_VARSEL_UGYLDIG.count()
 
+                oppfolgingsplanVarselService.sendVarselbestillingTilNarmesteLeder(hendelse)
+
+                val utsendteVarsler = embeddedDatabase.fetchUtsendtVarselByFnr(FNR_1)
+                val feiledeVarsler = embeddedDatabase.fetchUtsendtVarselFeiletByFnr(FNR_1)
+
+                utsendteVarsler.size shouldBeEqualTo 0
+                feiledeVarsler.size shouldBeEqualTo 1
+                feiledeVarsler.single().kanal shouldBeEqualTo "ARBEIDSGIVERNOTIFIKASJON"
+                feiledeVarsler.single().resendExhausted shouldBeEqualTo true
+                feiledeVarsler.single().feilmelding shouldBeEqualTo
+                    "Oppfølgingsplanvarsel har ugyldig data.arbeidsgiverMeldingType=KORT_BESKJED"
+                feiledeVarsler.single().hendelseJson shouldBeEqualTo createObjectMapper().writeValueAsString(hendelse)
+                COUNT_OPPFOLGINGSPLAN_VARSEL_UGYLDIG.count() shouldBeEqualTo invalidPayloadCountBefore + 1.0
+                verify(exactly = 0) { dineSykmeldteHendelseKafkaProducer.sendVarsel(any()) }
+                coVerify(exactly = 0) { narmesteLederService.getNarmesteLederRelasjon(any(), any()) }
+                coVerify(exactly = 0) { pdlClient.hentPerson(any()) }
+                coVerify(exactly = 0) { arbeidsgiverNotifikasjonService.createNewSak(any()) }
+                coVerify(exactly = 0) {
+                    arbeidsgiverNotifikasjonService.sendNotifikasjon(
+                        any<ArbeidsgiverNotifikasjonNarmestelederInput>(),
+                    )
+                }
             }
 
-            it("Oppfolgingsplan varselbestilling should reject missing notifikasjonInnhold") {
-                val exception =
-                    shouldThrow<IllegalArgumentException> {
-                        oppfolgingsplanVarselService.sendVarselbestillingTilNarmesteLeder(
-                            oppfolgingsplanVarselbestillingHendelse(
-                                rawData = """{"data.arbeidsgiverMeldingType":"BESKJED"}""",
-                            ),
-                        )
-                    }
+            it("Oppfolgingsplan varselbestilling should store permanent failure for missing notifikasjonInnhold") {
+                val hendelse =
+                    oppfolgingsplanVarselbestillingHendelse(
+                        rawData = """{"data.arbeidsgiverMeldingType":"BESKJED"}""",
+                    )
 
-                exception.message shouldBeEqualTo "Oppfølgingsplanvarsel mangler feltet: data.notifikasjonInnhold"
+                oppfolgingsplanVarselService.sendVarselbestillingTilNarmesteLeder(hendelse)
+
+                val utsendteVarsler = embeddedDatabase.fetchUtsendtVarselByFnr(FNR_1)
+                val feiledeVarsler = embeddedDatabase.fetchUtsendtVarselFeiletByFnr(FNR_1)
+
+                utsendteVarsler.size shouldBeEqualTo 0
+                feiledeVarsler.size shouldBeEqualTo 1
+                feiledeVarsler.single().resendExhausted shouldBeEqualTo true
+                feiledeVarsler.single().feilmelding shouldBeEqualTo
+                    "Oppfølgingsplanvarsel mangler feltet: data.notifikasjonInnhold"
+                feiledeVarsler.single().hendelseJson shouldBeEqualTo createObjectMapper().writeValueAsString(hendelse)
+                verify(exactly = 0) { dineSykmeldteHendelseKafkaProducer.sendVarsel(any()) }
+                coVerify(exactly = 0) { narmesteLederService.getNarmesteLederRelasjon(any(), any()) }
+                coVerify(exactly = 0) {
+                    arbeidsgiverNotifikasjonService.sendNotifikasjon(
+                        any<ArbeidsgiverNotifikasjonNarmestelederInput>(),
+                    )
+                }
             }
 
-            it("Oppfolgingsplan varselbestilling should reject missing explicit varselTekst") {
-                val exception =
-                    shouldThrow<IllegalArgumentException> {
-                        oppfolgingsplanVarselService.sendVarselbestillingTilNarmesteLeder(
-                            oppfolgingsplanVarselbestillingHendelse(
-                                rawData =
-                                    """
-                                    {
-                                      "arbeidsgiverMeldingType": "BESKJED",
-                                      "notifikasjonInnhold": {
-                                        "epostTittel": "E-posttittel",
-                                        "epostBody": "<p>E-postbody</p>"
-                                      }
-                                    }
-                                    """.trimIndent(),
-                            ),
-                        )
-                    }
+            it("Oppfolgingsplan varselbestilling should store permanent failure for missing explicit varselTekst") {
+                val hendelse =
+                    oppfolgingsplanVarselbestillingHendelse(
+                        rawData =
+                            """
+                            {
+                              "arbeidsgiverMeldingType": "BESKJED",
+                              "notifikasjonInnhold": {
+                                "epostTittel": "E-posttittel",
+                                "epostBody": "<p>E-postbody</p>"
+                              }
+                            }
+                            """.trimIndent(),
+                    )
 
-                exception.message shouldBeEqualTo
+                oppfolgingsplanVarselService.sendVarselbestillingTilNarmesteLeder(hendelse)
+
+                val utsendteVarsler = embeddedDatabase.fetchUtsendtVarselByFnr(FNR_1)
+                val feiledeVarsler = embeddedDatabase.fetchUtsendtVarselFeiletByFnr(FNR_1)
+
+                utsendteVarsler.size shouldBeEqualTo 0
+                feiledeVarsler.size shouldBeEqualTo 1
+                feiledeVarsler.single().resendExhausted shouldBeEqualTo true
+                feiledeVarsler.single().feilmelding shouldBeEqualTo
                     "Oppfølgingsplanvarsel mangler feltet: data.notifikasjonInnhold.varselTekst"
+                feiledeVarsler.single().hendelseJson shouldBeEqualTo createObjectMapper().writeValueAsString(hendelse)
+                verify(exactly = 0) { dineSykmeldteHendelseKafkaProducer.sendVarsel(any()) }
+                coVerify(exactly = 0) { narmesteLederService.getNarmesteLederRelasjon(any(), any()) }
+                coVerify(exactly = 0) {
+                    arbeidsgiverNotifikasjonService.sendNotifikasjon(
+                        any<ArbeidsgiverNotifikasjonNarmestelederInput>(),
+                    )
+                }
             }
 
             it("Oppfolgingsplan varselbestilling retry should reuse uuidEksternReferanse, reuse sak and not resend Dine Sykmeldte") {

--- a/src/test/kotlin/no/nav/syfo/service/OppfolgingsplanVarselServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/service/OppfolgingsplanVarselServiceSpek.kt
@@ -2,6 +2,7 @@ package no.nav.syfo.service
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
+import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.justRun
@@ -19,13 +20,20 @@ import no.nav.syfo.consumer.pdl.HentPersonData
 import no.nav.syfo.consumer.pdl.Navn
 import no.nav.syfo.consumer.pdl.PdlClient
 import no.nav.syfo.db.domain.PUtsendtVarselFeilet
+import no.nav.syfo.db.fetchUtsendtVarselByFnr
+import no.nav.syfo.db.fetchUtsendtVarselFeiletByFnr
+import no.nav.syfo.db.storeArbeidsgivernotifikasjonerSak
 import no.nav.syfo.kafka.common.createObjectMapper
 import no.nav.syfo.kafka.consumers.varselbus.domain.ArbeidstakerHendelse
+import no.nav.syfo.kafka.consumers.varselbus.domain.DineSykmeldteHendelseType
 import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType
 import no.nav.syfo.kafka.consumers.varselbus.domain.NarmesteLederHendelse
 import no.nav.syfo.kafka.producers.dinesykmeldte.DineSykmeldteHendelseKafkaProducer
 import no.nav.syfo.kafka.producers.dinesykmeldte.domain.DineSykmeldteVarsel
 import no.nav.syfo.kafka.producers.dittsykefravaer.DittSykefravaerMeldingKafkaProducer
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NySakNarmesteLederInput
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.NyStatusSakInput
+import no.nav.syfo.producer.arbeidsgivernotifikasjon.domain.SakStatus
 import no.nav.syfo.testutil.EmbeddedDatabase
 import no.nav.syfo.testutil.mocks.FNR_1
 import no.nav.syfo.testutil.mocks.FNR_2
@@ -34,7 +42,6 @@ import org.amshove.kluent.shouldBeEqualTo
 import java.net.URI
 import java.time.LocalDateTime
 import java.util.UUID
-import no.nav.syfo.kafka.consumers.varselbus.domain.DineSykmeldteHendelseType
 
 class OppfolgingsplanVarselServiceSpek :
     DescribeSpec({
@@ -70,15 +77,20 @@ class OppfolgingsplanVarselServiceSpek :
             )
 
         describe("OppfolgingsplanVarselServiceSpek") {
-            justRun {
-                brukernotifikasjonerService.sendBrukernotifikasjonVarsel(
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                )
+            beforeTest {
+                embeddedDatabase.dropData()
+                clearAllMocks()
+                justRun {
+                    brukernotifikasjonerService.sendBrukernotifikasjonVarsel(
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                    )
+                }
+                justRun { dineSykmeldteHendelseKafkaProducer.sendVarsel(any()) }
             }
 
             it("Non-reserved users should be notified externally") {
@@ -127,40 +139,19 @@ class OppfolgingsplanVarselServiceSpek :
                 }
             }
 
-            it("Oppfolgingsplan foresporsel should use dinesykmeldte url for arbeidsgivernotifikasjon and sak") {
+            it("Oppfolgingsplan foresporsel should create new sak and reuse sak values in notifikasjon") {
                 val narmesteLederId = "1234"
                 val expectedUrl = "$fakeDinesykmeldteUrl/$narmesteLederId"
                 val notifikasjonInputSlot = slot<ArbeidsgiverNotifikasjonNarmestelederInput>()
 
-                coEvery { narmesteLederService.getNarmesteLederRelasjon(FNR_1, ORGNUMMER) } returns
-                    NarmesteLederRelasjon(
-                        narmesteLederId = narmesteLederId,
-                        tilganger = listOf(Tilgang.SYKMELDING),
-                        navn = "Test Lansen",
-                        narmesteLederEpost = "test@test.no",
-                    )
-                coEvery { pdlClient.hentPerson(FNR_1) } returns
-                    HentPersonData(
-                        hentPerson =
-                            HentPerson(
-                                foedselsdato = listOf(Foedselsdato(foedselsdato = "1990-01-01")),
-                                navn = listOf(Navn(fornavn = "Test", mellomnavn = null, etternavn = "Testesen")),
-                            ),
-                    )
+                coEvery { narmesteLederService.getNarmesteLederRelasjon(FNR_1, ORGNUMMER) } returns narmesteLederRelasjon(narmesteLederId)
+                coEvery { pdlClient.hentPerson(FNR_1) } returns personData()
                 coEvery { arbeidsgiverNotifikasjonService.createNewSak(any()) } returns UUID.randomUUID().toString()
                 coEvery { arbeidsgiverNotifikasjonService.sendNotifikasjon(any<ArbeidsgiverNotifikasjonNarmestelederInput>()) } returns true
 
-                val varselHendelse =
-                    NarmesteLederHendelse(
-                        type = HendelseType.NL_OPPFOLGINGSPLAN_FORESPORSEL,
-                        ferdigstill = false,
-                        data = null,
-                        narmesteLederFnr = FNR_2,
-                        arbeidstakerFnr = FNR_1,
-                        orgnummer = ORGNUMMER,
-                    )
-
-                oppfolgingsplanVarselService.sendOppfolgingsplanForesporselVarselTilNarmesteLeder(varselHendelse)
+                oppfolgingsplanVarselService.sendOppfolgingsplanForesporselVarselTilNarmesteLeder(
+                    oppfolgingsplanForesporselHendelse(),
+                )
 
                 coVerify(exactly = 1) {
                     arbeidsgiverNotifikasjonService.sendNotifikasjon(capture(notifikasjonInputSlot))
@@ -168,6 +159,7 @@ class OppfolgingsplanVarselServiceSpek :
                 coVerify(exactly = 1) {
                     arbeidsgiverNotifikasjonService.createNewSak(any())
                 }
+                coVerify(exactly = 1) { narmesteLederService.getNarmesteLederRelasjon(FNR_1, ORGNUMMER) }
 
                 val storedSak =
                     senderFacade.getPaagaaendeSak(
@@ -176,24 +168,300 @@ class OppfolgingsplanVarselServiceSpek :
                     )
 
                 notifikasjonInputSlot.captured.link shouldBeEqualTo expectedUrl
+                notifikasjonInputSlot.captured.grupperingsid shouldBeEqualTo storedSak?.grupperingsid
                 storedSak?.lenke shouldBeEqualTo expectedUrl
+                storedSak?.hardDeleteDate shouldBeEqualTo notifikasjonInputSlot.captured.hardDeleteDate
             }
 
-            it("Oppfolgingsplan varselbestilling should map payload texts to Dine Sykmeldte and arbeidsgivernotifikasjon") {
+            it("Oppfolgingsplan foresporsel should reuse existing sak and preserve status") {
+                val narmesteLederId = "1234"
+                val existingUrl = "https://existing.example/sak"
+                val eksisterendeSak =
+                    NySakNarmesteLederInput(
+                        grupperingsid = UUID.randomUUID().toString(),
+                        narmestelederId = narmesteLederId,
+                        merkelapp = ARBEIDSGIVERNOTIFIKASJON_OPPFOLGING_MERKELAPP,
+                        virksomhetsnummer = ORGNUMMER,
+                        narmesteLederFnr = FNR_2,
+                        ansattFnr = FNR_1,
+                        tittel = "Oppfølging av sykmeldt",
+                        lenke = existingUrl,
+                        initiellStatus = SakStatus.UNDER_BEHANDLING,
+                        hardDeleteDate = LocalDateTime.now().plusDays(1),
+                    )
+                val sakId =
+                    embeddedDatabase.storeArbeidsgivernotifikasjonerSak(
+                        eksisterendeSak,
+                        eksternSakId = "sak-1",
+                    )
+                val notifikasjonInputSlot = slot<ArbeidsgiverNotifikasjonNarmestelederInput>()
+                val nyStatusSakInputSlot = slot<NyStatusSakInput>()
+                coEvery { narmesteLederService.getNarmesteLederRelasjon(FNR_1, ORGNUMMER) } returns narmesteLederRelasjon(narmesteLederId)
+                coEvery { arbeidsgiverNotifikasjonService.nyStatusSak(capture(nyStatusSakInputSlot)) } returns "sak-1"
+                coEvery { arbeidsgiverNotifikasjonService.sendNotifikasjon(capture(notifikasjonInputSlot)) } returns true
+
+                oppfolgingsplanVarselService.sendOppfolgingsplanForesporselVarselTilNarmesteLeder(
+                    oppfolgingsplanForesporselHendelse(),
+                )
+
+                val updatedSak =
+                    senderFacade.getPaagaaendeSak(
+                        narmesteLederId = narmesteLederId,
+                        merkelapp = ARBEIDSGIVERNOTIFIKASJON_OPPFOLGING_MERKELAPP,
+                    )
+
+                notifikasjonInputSlot.captured.grupperingsid shouldBeEqualTo eksisterendeSak.grupperingsid
+                notifikasjonInputSlot.captured.link shouldBeEqualTo existingUrl
+                nyStatusSakInputSlot.captured.grupperingsId shouldBeEqualTo eksisterendeSak.grupperingsid
+                nyStatusSakInputSlot.captured.sakStatus shouldBeEqualTo
+                    eksisterendeSak.initiellStatus.let { SakStatus.valueOf(it.name) }
+                nyStatusSakInputSlot.captured.oppdatertHardDeleteDateTime shouldBeEqualTo
+                    notifikasjonInputSlot.captured.hardDeleteDate
+                updatedSak?.id shouldBeEqualTo sakId
+                updatedSak?.hardDeleteDate shouldBeEqualTo notifikasjonInputSlot.captured.hardDeleteDate
+                coVerify(exactly = 0) { arbeidsgiverNotifikasjonService.createNewSak(any()) }
+                coVerify(exactly = 0) { pdlClient.hentPerson(any()) }
+                coVerify(exactly = 1) { narmesteLederService.getNarmesteLederRelasjon(FNR_1, ORGNUMMER) }
+            }
+
+            it("Oppfolgingsplan foresporsel should fallback to generated link for existing sak without lenke") {
+                val narmesteLederId = "1234"
+                val expectedUrl = "$fakeDinesykmeldteUrl/$narmesteLederId"
+                val eksisterendeSak =
+                    NySakNarmesteLederInput(
+                        grupperingsid = UUID.randomUUID().toString(),
+                        narmestelederId = narmesteLederId,
+                        merkelapp = ARBEIDSGIVERNOTIFIKASJON_OPPFOLGING_MERKELAPP,
+                        virksomhetsnummer = ORGNUMMER,
+                        narmesteLederFnr = FNR_2,
+                        ansattFnr = FNR_1,
+                        tittel = "Oppfølging av sykmeldt",
+                        lenke = expectedUrl,
+                        initiellStatus = SakStatus.MOTTATT,
+                        hardDeleteDate = LocalDateTime.now().plusDays(1),
+                    )
+                val sakId =
+                    embeddedDatabase.storeArbeidsgivernotifikasjonerSak(
+                        eksisterendeSak,
+                        eksternSakId = "sak-1",
+                    )
+                embeddedDatabase.connection.use { connection ->
+                    val preparedStatement =
+                        connection.prepareStatement(
+                            """
+                            UPDATE ARBEIDSGIVERNOTIFIKASJONER_SAK
+                            SET lenke = NULL
+                            WHERE id = ?
+                            """.trimIndent(),
+                        )
+                    preparedStatement.use {
+                        preparedStatement.setObject(1, UUID.fromString(sakId))
+                        preparedStatement.executeUpdate()
+                    }
+                    connection.commit()
+                }
+                val notifikasjonInputSlot = slot<ArbeidsgiverNotifikasjonNarmestelederInput>()
+                coEvery { narmesteLederService.getNarmesteLederRelasjon(FNR_1, ORGNUMMER) } returns narmesteLederRelasjon(narmesteLederId)
+                coEvery { arbeidsgiverNotifikasjonService.nyStatusSak(any()) } returns "sak-1"
+                coEvery { arbeidsgiverNotifikasjonService.sendNotifikasjon(capture(notifikasjonInputSlot)) } returns true
+
+                oppfolgingsplanVarselService.sendOppfolgingsplanForesporselVarselTilNarmesteLeder(
+                    oppfolgingsplanForesporselHendelse(),
+                )
+
+                notifikasjonInputSlot.captured.grupperingsid shouldBeEqualTo eksisterendeSak.grupperingsid
+                notifikasjonInputSlot.captured.link shouldBeEqualTo expectedUrl
+                coVerify(exactly = 0) { arbeidsgiverNotifikasjonService.createNewSak(any()) }
+                coVerify(exactly = 0) { pdlClient.hentPerson(any()) }
+            }
+
+            it("Oppfolgingsplan foresporsel should stop before sak handling when narmeste-lederrelasjon or epost mangler") {
+                coEvery { narmesteLederService.getNarmesteLederRelasjon(FNR_1, ORGNUMMER) } returns null andThen
+                    NarmesteLederRelasjon(
+                        narmesteLederId = "1234",
+                        narmesteLederFnr = FNR_2,
+                        tilganger = listOf(Tilgang.SYKMELDING),
+                        navn = "Test Lansen",
+                        narmesteLederEpost = null,
+                    )
+
+                oppfolgingsplanVarselService.sendOppfolgingsplanForesporselVarselTilNarmesteLeder(
+                    oppfolgingsplanForesporselHendelse(),
+                )
+                oppfolgingsplanVarselService.sendOppfolgingsplanForesporselVarselTilNarmesteLeder(
+                    oppfolgingsplanForesporselHendelse(),
+                )
+
+                coVerify(exactly = 0) { arbeidsgiverNotifikasjonService.createNewSak(any()) }
+                coVerify(exactly = 0) { arbeidsgiverNotifikasjonService.nyStatusSak(any()) }
+                coVerify(exactly = 0) {
+                    arbeidsgiverNotifikasjonService.sendNotifikasjon(
+                        any<ArbeidsgiverNotifikasjonNarmestelederInput>(),
+                    )
+                }
+                coVerify(exactly = 0) { pdlClient.hentPerson(any()) }
+            }
+
+            it("Oppfolgingsplan varselbestilling should create new sak, set link and map payload texts") {
+                val narmesteLederId = "1234"
+                val expectedUrl = "$fakeDinesykmeldteUrl/$narmesteLederId"
                 val dineSykmeldteVarselSlot = slot<DineSykmeldteVarsel>()
                 val notifikasjonInputSlot = slot<ArbeidsgiverNotifikasjonNarmestelederInput>()
                 justRun { dineSykmeldteHendelseKafkaProducer.sendVarsel(capture(dineSykmeldteVarselSlot)) }
+                coEvery { narmesteLederService.getNarmesteLederRelasjon(FNR_1, ORGNUMMER) } returns narmesteLederRelasjon(narmesteLederId)
+                coEvery { pdlClient.hentPerson(FNR_1) } returns personData()
+                coEvery { arbeidsgiverNotifikasjonService.createNewSak(any()) } returns UUID.randomUUID().toString()
+                coEvery { arbeidsgiverNotifikasjonService.sendNotifikasjon(capture(notifikasjonInputSlot)) } returns true
+
+                oppfolgingsplanVarselService.sendVarselbestillingTilNarmesteLeder(oppfolgingsplanVarselbestillingHendelse())
+
+                val storedSak =
+                    senderFacade.getPaagaaendeSak(
+                        narmesteLederId = narmesteLederId,
+                        merkelapp = ARBEIDSGIVERNOTIFIKASJON_OPPFOLGING_MERKELAPP,
+                    )
+
+                dineSykmeldteVarselSlot.captured.tekst shouldBeEqualTo "Dine Sykmeldte-tekst"
+                notifikasjonInputSlot.captured.messageText shouldBeEqualTo "Dine Sykmeldte-tekst"
+                notifikasjonInputSlot.captured.epostTittel shouldBeEqualTo "E-posttittel"
+                notifikasjonInputSlot.captured.epostHtmlBody shouldBeEqualTo "<p>E-postbody</p>"
+                notifikasjonInputSlot.captured.meldingstype shouldBeEqualTo Meldingstype.BESKJED
+                notifikasjonInputSlot.captured.link shouldBeEqualTo expectedUrl
+                notifikasjonInputSlot.captured.grupperingsid shouldBeEqualTo storedSak?.grupperingsid
+                storedSak?.lenke shouldBeEqualTo expectedUrl
+                storedSak?.hardDeleteDate shouldBeEqualTo notifikasjonInputSlot.captured.hardDeleteDate
+                coVerify(exactly = 1) { arbeidsgiverNotifikasjonService.createNewSak(any()) }
+                coVerify(exactly = 0) { arbeidsgiverNotifikasjonService.nyStatusSak(any()) }
+            }
+
+            it("Oppfolgingsplan varselbestilling should reuse existing sak, fallback to generated link and update hardDeleteDate locally") {
+                val narmesteLederId = "1234"
+                val expectedUrl = "$fakeDinesykmeldteUrl/$narmesteLederId"
+                val eksisterendeSak =
+                    NySakNarmesteLederInput(
+                        grupperingsid = UUID.randomUUID().toString(),
+                        narmestelederId = narmesteLederId,
+                        merkelapp = ARBEIDSGIVERNOTIFIKASJON_OPPFOLGING_MERKELAPP,
+                        virksomhetsnummer = ORGNUMMER,
+                        narmesteLederFnr = FNR_2,
+                        ansattFnr = FNR_1,
+                        tittel = "Oppfølging av sykmeldt",
+                        lenke = "https://unused.example",
+                        initiellStatus = SakStatus.UNDER_BEHANDLING,
+                        hardDeleteDate = LocalDateTime.now().plusDays(1),
+                    )
+                val sakId =
+                    embeddedDatabase.storeArbeidsgivernotifikasjonerSak(
+                        eksisterendeSak,
+                        eksternSakId = "sak-1",
+                    )
+                embeddedDatabase.connection.use { connection ->
+                    val preparedStatement =
+                        connection.prepareStatement(
+                            """
+                            UPDATE ARBEIDSGIVERNOTIFIKASJONER_SAK
+                            SET lenke = NULL
+                            WHERE id = ?
+                            """.trimIndent(),
+                        )
+                    preparedStatement.use {
+                        preparedStatement.setObject(1, UUID.fromString(sakId))
+                        preparedStatement.executeUpdate()
+                    }
+                    connection.commit()
+                }
+                val notifikasjonInputSlot = slot<ArbeidsgiverNotifikasjonNarmestelederInput>()
+                val nyStatusSakInputSlot = slot<NyStatusSakInput>()
+                coEvery { narmesteLederService.getNarmesteLederRelasjon(FNR_1, ORGNUMMER) } returns
+                    narmesteLederRelasjon(narmesteLederId)
+                coEvery { arbeidsgiverNotifikasjonService.nyStatusSak(capture(nyStatusSakInputSlot)) } returns "sak-1"
                 coEvery { arbeidsgiverNotifikasjonService.sendNotifikasjon(capture(notifikasjonInputSlot)) } returns true
 
                 oppfolgingsplanVarselService.sendVarselbestillingTilNarmesteLeder(
                     oppfolgingsplanVarselbestillingHendelse(),
                 )
-                dineSykmeldteVarselSlot.captured.tekst shouldBeEqualTo "Dine Sykmeldte-tekst"
-                notifikasjonInputSlot.captured.messageText shouldBeEqualTo "Dine Sykmeldte-tekst"
-                notifikasjonInputSlot.captured.messageText shouldBeEqualTo "Dine Sykmeldte-tekst"
-                notifikasjonInputSlot.captured.epostTittel shouldBeEqualTo "E-posttittel"
-                notifikasjonInputSlot.captured.epostHtmlBody shouldBeEqualTo "<p>E-postbody</p>"
-                notifikasjonInputSlot.captured.meldingstype shouldBeEqualTo Meldingstype.BESKJED
+
+                val updatedSak =
+                    senderFacade.getPaagaaendeSak(
+                        narmesteLederId = narmesteLederId,
+                        merkelapp = ARBEIDSGIVERNOTIFIKASJON_OPPFOLGING_MERKELAPP,
+                    )
+
+                notifikasjonInputSlot.captured.grupperingsid shouldBeEqualTo eksisterendeSak.grupperingsid
+                notifikasjonInputSlot.captured.link shouldBeEqualTo expectedUrl
+                nyStatusSakInputSlot.captured.grupperingsId shouldBeEqualTo eksisterendeSak.grupperingsid
+                nyStatusSakInputSlot.captured.sakStatus shouldBeEqualTo
+                    eksisterendeSak.initiellStatus.let { SakStatus.valueOf(it.name) }
+                nyStatusSakInputSlot.captured.oppdatertHardDeleteDateTime shouldBeEqualTo
+                    notifikasjonInputSlot.captured.hardDeleteDate
+                updatedSak?.hardDeleteDate shouldBeEqualTo notifikasjonInputSlot.captured.hardDeleteDate
+                coVerify(exactly = 0) { arbeidsgiverNotifikasjonService.createNewSak(any()) }
+            }
+
+            it("Oppfolgingsplan varselbestilling should skip NL lookup and sak handling for Dine Sykmeldte only") {
+                oppfolgingsplanVarselService.sendVarselbestillingTilNarmesteLeder(
+                    oppfolgingsplanVarselbestillingHendelse(arbeidsgiverMeldingType = null),
+                )
+
+                verify(exactly = 1) { dineSykmeldteHendelseKafkaProducer.sendVarsel(any()) }
+                coVerify(exactly = 0) { narmesteLederService.getNarmesteLederRelasjon(any(), any()) }
+                coVerify(exactly = 0) { arbeidsgiverNotifikasjonService.createNewSak(any()) }
+                coVerify(exactly = 0) {
+                    arbeidsgiverNotifikasjonService.sendNotifikasjon(
+                        any<ArbeidsgiverNotifikasjonNarmestelederInput>(),
+                    )
+                }
+            }
+
+            it("Oppfolgingsplan varselbestilling should store retryable AG failure when narmeste-lederrelasjon mangler") {
+                coEvery { narmesteLederService.getNarmesteLederRelasjon(FNR_1, ORGNUMMER) } returns null
+
+                oppfolgingsplanVarselService.sendVarselbestillingTilNarmesteLeder(oppfolgingsplanVarselbestillingHendelse())
+
+                val utsendteVarsler = embeddedDatabase.fetchUtsendtVarselByFnr(FNR_1)
+                val feiledeVarsler = embeddedDatabase.fetchUtsendtVarselFeiletByFnr(FNR_1)
+
+                utsendteVarsler.count { it.kanal == "DINE_SYKMELDTE" } shouldBeEqualTo 1
+                feiledeVarsler.size shouldBeEqualTo 1
+                feiledeVarsler.single().kanal shouldBeEqualTo "ARBEIDSGIVERNOTIFIKASJON"
+                feiledeVarsler.single().hendelseJson shouldBeEqualTo
+                    createObjectMapper().writeValueAsString(
+                        oppfolgingsplanVarselbestillingHendelse(),
+                    )
+                val eksternReferanse = requireNotNull(feiledeVarsler.single().uuidEksternReferanse)
+                UUID.fromString(eksternReferanse).toString() shouldBeEqualTo eksternReferanse
+                coVerify(exactly = 0) {
+                    arbeidsgiverNotifikasjonService.sendNotifikasjon(
+                        any<ArbeidsgiverNotifikasjonNarmestelederInput>(),
+                    )
+                }
+            }
+
+            it("Oppfolgingsplan varselbestilling should store retryable AG failure when AG send is skipped after sak is prepared") {
+                coEvery { narmesteLederService.getNarmesteLederRelasjon(FNR_1, ORGNUMMER) } returns
+                    narmesteLederRelasjon("1234")
+                coEvery { pdlClient.hentPerson(FNR_1) } returns personData()
+                coEvery { arbeidsgiverNotifikasjonService.createNewSak(any()) } returns "sak-1"
+                coEvery {
+                    arbeidsgiverNotifikasjonService.sendNotifikasjon(
+                        any<ArbeidsgiverNotifikasjonNarmestelederInput>(),
+                    )
+                } returns false
+
+                oppfolgingsplanVarselService.sendVarselbestillingTilNarmesteLeder(
+                    oppfolgingsplanVarselbestillingHendelse(),
+                )
+
+                val utsendteVarsler = embeddedDatabase.fetchUtsendtVarselByFnr(FNR_1)
+                val feiledeVarsler = embeddedDatabase.fetchUtsendtVarselFeiletByFnr(FNR_1)
+
+                utsendteVarsler.count { it.kanal == "DINE_SYKMELDTE" } shouldBeEqualTo 1
+                utsendteVarsler.count { it.kanal == "ARBEIDSGIVERNOTIFIKASJON" } shouldBeEqualTo 0
+                feiledeVarsler.size shouldBeEqualTo 1
+                feiledeVarsler.single().hendelseJson shouldBeEqualTo
+                    createObjectMapper().writeValueAsString(
+                        oppfolgingsplanVarselbestillingHendelse(),
+                    )
             }
 
             it("Oppfolgingsplan varselbestilling should reject unsupported varselType") {
@@ -243,9 +511,27 @@ class OppfolgingsplanVarselServiceSpek :
                     "Oppfølgingsplanvarsel mangler feltet: data.notifikasjonInnhold.varselTekst"
             }
 
-            it("Oppfolgingsplan varselbestilling retry should reuse uuidEksternReferanse as notifikasjonsuuid") {
+            it("Oppfolgingsplan varselbestilling retry should reuse uuidEksternReferanse, reuse sak and not resend Dine Sykmeldte") {
                 val notifikasjonInputSlot = slot<ArbeidsgiverNotifikasjonNarmestelederInput>()
+                val nyStatusSakInputSlot = slot<NyStatusSakInput>()
                 val eksternReferanse = UUID.randomUUID()
+                val narmesteLederId = "1234"
+                val eksisterendeSak =
+                    NySakNarmesteLederInput(
+                        grupperingsid = UUID.randomUUID().toString(),
+                        narmestelederId = narmesteLederId,
+                        merkelapp = ARBEIDSGIVERNOTIFIKASJON_OPPFOLGING_MERKELAPP,
+                        virksomhetsnummer = ORGNUMMER,
+                        narmesteLederFnr = FNR_2,
+                        ansattFnr = FNR_1,
+                        tittel = "Oppfølging av sykmeldt",
+                        lenke = "$fakeDinesykmeldteUrl/$narmesteLederId",
+                        initiellStatus = SakStatus.MOTTATT,
+                        hardDeleteDate = LocalDateTime.now().plusDays(1),
+                    )
+                embeddedDatabase.storeArbeidsgivernotifikasjonerSak(eksisterendeSak, eksternSakId = "sak-1")
+                coEvery { narmesteLederService.getNarmesteLederRelasjon(FNR_1, ORGNUMMER) } returns narmesteLederRelasjon(narmesteLederId)
+                coEvery { arbeidsgiverNotifikasjonService.nyStatusSak(capture(nyStatusSakInputSlot)) } returns "sak-1"
                 coEvery { arbeidsgiverNotifikasjonService.sendNotifikasjon(capture(notifikasjonInputSlot)) } returns true
 
                 val result =
@@ -263,20 +549,23 @@ class OppfolgingsplanVarselServiceSpek :
                             kanal = "ARBEIDSGIVERNOTIFIKASJON",
                             feilmelding = "noe galt",
                             utsendtForsokTidspunkt = LocalDateTime.now(),
-                            hendelseJson = createObjectMapper().writeValueAsString(
-                                oppfolgingsplanVarselbestillingHendelse()
-                            ),
+                            hendelseJson =
+                                createObjectMapper().writeValueAsString(
+                                    oppfolgingsplanVarselbestillingHendelse(),
+                                ),
                         ),
                     )
 
                 result shouldBeEqualTo ArbeidsgiverVarselResendResult.RESENT
                 notifikasjonInputSlot.captured.uuid shouldBeEqualTo eksternReferanse
+                notifikasjonInputSlot.captured.grupperingsid shouldBeEqualTo eksisterendeSak.grupperingsid
+                nyStatusSakInputSlot.captured.grupperingsId shouldBeEqualTo eksisterendeSak.grupperingsid
+                verify(exactly = 0) { dineSykmeldteHendelseKafkaProducer.sendVarsel(any()) }
+                coVerify(exactly = 0) { arbeidsgiverNotifikasjonService.createNewSak(any()) }
             }
 
-            it("Oppfolgingsplan varselbestilling retry should stay retryable when narmeste leder info mangler") {
-                coEvery {
-                    arbeidsgiverNotifikasjonService.sendNotifikasjon(any<ArbeidsgiverNotifikasjonNarmestelederInput>())
-                } returns false
+            it("Oppfolgingsplan varselbestilling retry should stay retryable when narmeste-lederrelasjon mangler") {
+                coEvery { narmesteLederService.getNarmesteLederRelasjon(FNR_1, ORGNUMMER) } returns null
 
                 val result =
                     oppfolgingsplanVarselService.resendVarselbestillingTilArbeidsgiverNotifikasjon(
@@ -293,17 +582,26 @@ class OppfolgingsplanVarselServiceSpek :
                             kanal = "ARBEIDSGIVERNOTIFIKASJON",
                             feilmelding = "noe galt",
                             utsendtForsokTidspunkt = LocalDateTime.now(),
-                            hendelseJson = createObjectMapper().writeValueAsString(
-                                oppfolgingsplanVarselbestillingHendelse()
-                            ),
+                            hendelseJson =
+                                createObjectMapper().writeValueAsString(
+                                    oppfolgingsplanVarselbestillingHendelse(),
+                                ),
                         ),
                     )
 
                 result shouldBeEqualTo ArbeidsgiverVarselResendResult.RETRYABLE_FAILURE
+                coVerify(exactly = 0) {
+                    arbeidsgiverNotifikasjonService.sendNotifikasjon(
+                        any<ArbeidsgiverNotifikasjonNarmestelederInput>(),
+                    )
+                }
             }
 
             it("Oppfolgingsplan varselbestilling retry should ignore extra smsTekst in stored hendelseJson") {
                 val notifikasjonInputSlot = slot<ArbeidsgiverNotifikasjonNarmestelederInput>()
+                coEvery { narmesteLederService.getNarmesteLederRelasjon(FNR_1, ORGNUMMER) } returns narmesteLederRelasjon("1234")
+                coEvery { pdlClient.hentPerson(FNR_1) } returns personData()
+                coEvery { arbeidsgiverNotifikasjonService.createNewSak(any()) } returns UUID.randomUUID().toString()
                 coEvery { arbeidsgiverNotifikasjonService.sendNotifikasjon(capture(notifikasjonInputSlot)) } returns true
 
                 val result =
@@ -360,21 +658,52 @@ private fun oppfolgingsplanVarselbestillingHendelse(
     ferdigstill = false,
     data =
         createObjectMapper().readTree(
-            rawData ?: (
-                """
-                {
-                 "arbeidsgiverMeldingType": ${arbeidsgiverMeldingType?.let { "\"$it\"" } ?: "null"},
-                 "dineSykmeldteHendelseType": ${dineSykmeldteHendelseType?.let { "\"$it\"" } ?: "null"},
-                 "notifikasjonInnhold": {
-                   "epostTittel": "E-posttittel",
-                   "epostBody": "<p>E-postbody</p>",
-                   "varselTekst": "Dine Sykmeldte-tekst"
-                 }
-                }
-                """.trimIndent()
-                ),
+            rawData ?: defaultOppfolgingsplanVarselbestillingData(arbeidsgiverMeldingType, dineSykmeldteHendelseType),
         ),
     narmesteLederFnr = FNR_2,
     arbeidstakerFnr = FNR_1,
     orgnummer = ORGNUMMER,
 )
+
+private fun oppfolgingsplanForesporselHendelse() =
+    NarmesteLederHendelse(
+        type = HendelseType.NL_OPPFOLGINGSPLAN_FORESPORSEL,
+        ferdigstill = false,
+        data = null,
+        narmesteLederFnr = FNR_2,
+        arbeidstakerFnr = FNR_1,
+        orgnummer = ORGNUMMER,
+    )
+
+private fun defaultOppfolgingsplanVarselbestillingData(
+    arbeidsgiverMeldingType: String?,
+    dineSykmeldteHendelseType: String?,
+) = """
+    {
+     "arbeidsgiverMeldingType": ${arbeidsgiverMeldingType?.let { "\"$it\"" } ?: "null"},
+     "dineSykmeldteHendelseType": ${dineSykmeldteHendelseType?.let { "\"$it\"" } ?: "null"},
+     "notifikasjonInnhold": {
+       "epostTittel": "E-posttittel",
+       "epostBody": "<p>E-postbody</p>",
+       "varselTekst": "Dine Sykmeldte-tekst"
+     }
+    }
+    """.trimIndent()
+
+private fun narmesteLederRelasjon(narmesteLederId: String) =
+    NarmesteLederRelasjon(
+        narmesteLederId = narmesteLederId,
+        narmesteLederFnr = FNR_2,
+        tilganger = listOf(Tilgang.SYKMELDING),
+        navn = "Test Lansen",
+        narmesteLederEpost = "test@test.no",
+    )
+
+private fun personData() =
+    HentPersonData(
+        hentPerson =
+            HentPerson(
+                foedselsdato = listOf(Foedselsdato(foedselsdato = "1990-01-01")),
+                navn = listOf(Navn(fornavn = "Test", mellomnavn = null, etternavn = "Testesen")),
+            ),
+    )

--- a/src/test/kotlin/no/nav/syfo/service/OppfolgingsplanVarselServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/service/OppfolgingsplanVarselServiceSpek.kt
@@ -470,7 +470,7 @@ class OppfolgingsplanVarselServiceSpek :
                     )
             }
 
-            it("Oppfolgingsplan varselbestilling should reject unsupported varselType") {
+            it("Oppfolgingsplan varselbestilling should reject unsupported arbeidsgiverMeldingType") {
                 val exception =
                     shouldThrow<IllegalArgumentException> {
                         oppfolgingsplanVarselService.sendVarselbestillingTilNarmesteLeder(
@@ -478,7 +478,6 @@ class OppfolgingsplanVarselServiceSpek :
                         )
                     }
 
-                exception.message shouldBeEqualTo "Oppfølgingsplanvarsel har ugyldig data.varselType=KORT_BESKJED"
             }
 
             it("Oppfolgingsplan varselbestilling should reject missing notifikasjonInnhold") {
@@ -486,7 +485,7 @@ class OppfolgingsplanVarselServiceSpek :
                     shouldThrow<IllegalArgumentException> {
                         oppfolgingsplanVarselService.sendVarselbestillingTilNarmesteLeder(
                             oppfolgingsplanVarselbestillingHendelse(
-                                rawData = """{"varselType":"BESKJED"}""",
+                                rawData = """{"data.arbeidsgiverMeldingType":"BESKJED"}""",
                             ),
                         )
                     }

--- a/src/test/kotlin/no/nav/syfo/service/SenderFacadeSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/service/SenderFacadeSpek.kt
@@ -15,6 +15,7 @@ import no.nav.syfo.db.ARBEIDSTAKER_AKTOR_ID_1
 import no.nav.syfo.db.domain.Kanal
 import no.nav.syfo.db.domain.PUtsendtVarsel
 import no.nav.syfo.db.domain.VarselType
+import no.nav.syfo.db.fetchUtsendtVarselByFnr
 import no.nav.syfo.db.fetchUtsendtVarselFeiletByFnr
 import no.nav.syfo.db.setUtsendtVarselToFerdigstilt
 import no.nav.syfo.db.storeUtsendtVarsel
@@ -22,6 +23,7 @@ import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.exceptions.JournalpostDistribusjonGoneException
 import no.nav.syfo.kafka.consumers.varselbus.domain.ArbeidstakerHendelse
 import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType
+import no.nav.syfo.kafka.consumers.varselbus.domain.NarmesteLederHendelse
 import no.nav.syfo.kafka.producers.dinesykmeldte.DineSykmeldteHendelseKafkaProducer
 import no.nav.syfo.kafka.producers.dittsykefravaer.DittSykefravaerMeldingKafkaProducer
 import no.nav.syfo.planner.ARBEIDSTAKER_FNR_1
@@ -264,6 +266,82 @@ class SenderFacadeSpek :
                 storedSak?.narmesteLederFnr shouldBe null
                 storedSakWithWrongMottakerType shouldBe null
                 mutationSlot.captured.lenke shouldBe Optional.Absent
+            }
+
+            it("Does not store arbeidsgivernotifikasjon as sent when sending is skipped") {
+                coEvery {
+                    arbeidsgiverNotifikasjonService.sendNotifikasjon(any<ArbeidsgiverNotifikasjonNarmestelederInput>())
+                } returns false
+
+                senderFacade.sendTilArbeidsgiverNotifikasjon(
+                    varselHendelse =
+                        NarmesteLederHendelse(
+                            type = HendelseType.NL_OPPFOLGINGSPLAN_VARSELBESTILLING,
+                            ferdigstill = false,
+                            data = null,
+                            narmesteLederFnr = "12345678910",
+                            arbeidstakerFnr = ARBEIDSTAKER_FNR_1,
+                            orgnummer = "999999999",
+                        ),
+                    notifikasjon =
+                        ArbeidsgiverNotifikasjonNarmestelederInput(
+                            uuid = UUID.randomUUID(),
+                            virksomhetsnummer = "999999999",
+                            narmesteLederFnr = "12345678910",
+                            ansattFnr = ARBEIDSTAKER_FNR_1,
+                            merkelapp = "merkelapp",
+                            messageText = "tekst",
+                            epostTittel = "tittel",
+                            epostHtmlBody = "body",
+                            hardDeleteDate = LocalDateTime.now().plusDays(1),
+                            grupperingsid = UUID.randomUUID().toString(),
+                        ),
+                )
+
+                embeddedDatabase.fetchUtsendtVarselByFnr(ARBEIDSTAKER_FNR_1).size shouldBe 0
+                embeddedDatabase.fetchUtsendtVarselFeiletByFnr(ARBEIDSTAKER_FNR_1).size shouldBe 0
+            }
+
+            it("Stores failed arbeidsgivernotifikasjon with hendelseJson when sending throws") {
+                val hendelseJson = """{"type":"NL_OPPFOLGINGSPLAN_VARSELBESTILLING","data":{"foo":"bar"}}"""
+                val varselHendelse =
+                    NarmesteLederHendelse(
+                        type = HendelseType.NL_OPPFOLGINGSPLAN_VARSELBESTILLING,
+                        ferdigstill = false,
+                        data = emptyMap<String, Any>(),
+                        narmesteLederFnr = "12345678910",
+                        arbeidstakerFnr = ARBEIDSTAKER_FNR_1,
+                        orgnummer = "999999999",
+                    )
+                val notifikasjon =
+                    ArbeidsgiverNotifikasjonNarmestelederInput(
+                        uuid = UUID.randomUUID(),
+                        virksomhetsnummer = "999999999",
+                        narmesteLederFnr = "12345678910",
+                        ansattFnr = ARBEIDSTAKER_FNR_1,
+                        merkelapp = "merkelapp",
+                        messageText = "tekst",
+                        epostTittel = "tittel",
+                        epostHtmlBody = "body",
+                        hardDeleteDate = LocalDateTime.now().plusDays(1),
+                        grupperingsid = UUID.randomUUID().toString(),
+                    )
+                coEvery { arbeidsgiverNotifikasjonService.sendNotifikasjon(notifikasjon) } throws
+                    IllegalStateException("ArbeidsgiverNotifikasjonProdusent returnerte null ID ved utsending til nærmeste leder")
+
+                val result =
+                    senderFacade.sendTilArbeidsgiverNotifikasjon(
+                        varselHendelse = varselHendelse,
+                        notifikasjon = notifikasjon,
+                        hendelseJson = hendelseJson,
+                    )
+
+                result shouldBe false
+                embeddedDatabase.fetchUtsendtVarselByFnr(ARBEIDSTAKER_FNR_1).size shouldBe 0
+                val feiledeVarsler = embeddedDatabase.fetchUtsendtVarselFeiletByFnr(ARBEIDSTAKER_FNR_1)
+                feiledeVarsler.size shouldBe 1
+                feiledeVarsler.single().hendelseJson shouldBe hendelseJson
+                feiledeVarsler.single().uuidEksternReferanse shouldBe notifikasjon.uuid.toString()
             }
         }
     })

--- a/src/test/kotlin/no/nav/syfo/service/VarselBusServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/service/VarselBusServiceTest.kt
@@ -7,6 +7,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import no.nav.syfo.kafka.consumers.varselbus.domain.ArbeidsgiverNotifikasjonTilAltinnRessursHendelse
 import no.nav.syfo.kafka.consumers.varselbus.domain.HendelseType
+import no.nav.syfo.kafka.consumers.varselbus.domain.NarmesteLederHendelse
 import java.util.UUID
 
 class VarselBusServiceTest :
@@ -77,6 +78,27 @@ class VarselBusServiceTest :
 
                 coVerify(exactly = 0) { senderFacade.ferdigstillArbeidstakerVarsler(any()) }
                 coVerify(exactly = 0) { senderFacade.ferdigstillNarmesteLederVarsler(any()) }
+            }
+
+            it("ruter NL_OPPFOLGINGSPLAN_VARSELBESTILLING til OppfolgingsplanVarselService") {
+                val hendelse =
+                    NarmesteLederHendelse(
+                        type = HendelseType.NL_OPPFOLGINGSPLAN_VARSELBESTILLING,
+                        ferdigstill = false,
+                        data =
+                            """
+                            {"varselType":"BESKJED","notifikasjonInnhold":{"epostTittel":"Tittel","epostBody":"Body","varselTekst":"Varsel"}}
+                            """.trimIndent(),
+                        narmesteLederFnr = "12345678910",
+                        arbeidstakerFnr = "10987654321",
+                        orgnummer = "999888777",
+                    )
+
+                varselBusService.processVarselHendelse(hendelse)
+
+                coVerify(exactly = 1) {
+                    oppfolgingsplanVarselService.sendVarselbestillingTilNarmesteLeder(hendelse)
+                }
             }
         }
     })


### PR DESCRIPTION
## Beskrivelse

Implementerer støtte for generisk `NL_OPPFOLGINGSPLAN_VARSELBESTILLING`, slik at oppfølgingsplan-backend kan bestille varsler til nærmeste leder med payload-styrt innhold.

## Endringer

- Ny hendelsestype og payload for oppfølgingsplan-varselbestilling uten SMS i arbeidsgivernotifikasjon
- Sender varsel til Dine Sykmeldte og arbeidsgivernotifikasjon basert på payload
- Gjenbruker eller oppretter arbeidsgivernotifikasjon-sak med riktig link, gruppering og hardDeleteDate
- Retry for feilede arbeidsgivernotifikasjoner med lagret `hendelse_json` og gjenbruk av ekstern referanse
- Refaktorert felles sak-/link-/notifikasjonsbygging i `OppfolgingsplanVarselService`
- Tester for routing, payload-validering, saksgjenbruk, retry og lenke-substitusjon

## Issue

Closes #1017

Del av epic: navikt/syfo-oppfolgingsplan-backend#330

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)

Verifisering: `./gradlew build`
