### PR TITLE
Oppgrader java til version 25

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -23,4 +23,4 @@ jobs:
     secrets: inherit
     with:
       app: esyfovarsel
-      java-version: '21'
+      java-version: '25'

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,5 @@
 [tools]
-java = { version = "21" }
+java = { version = "25" }
 
 [tasks.build]
 description = "Run build with gradle"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-21
+FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-25
 ENV TZ="Europe/Oslo"
 WORKDIR /app
 COPY build/libs/*.jar app.jar

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ plugins {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 allOpen {
     annotation("no.nav.syfo.annotation.Mockable")

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -2,7 +2,7 @@
 
 ## Krav
 
-Du trenger Java 21, Docker og [mise](https://mise.jdx.dev/).
+Du trenger Java 25, Docker og [mise](https://mise.jdx.dev/).
 
 ## Start lokale avhengigheter
 


### PR DESCRIPTION
## Beskrivelse

Oppgraderer prosjektet til Java 25 LTS og sørger for at Gradle faktisk bruker Java 25 ved bygging og kjøring av tester.

## Endringer

- `build.gradle.kts`: oppdatert Kotlin/Java toolchain til Java 25
- `Dockerfile`: oppdatert base image til `openjdk-25`
- `.github/workflows/build-and-deploy.yaml`: oppdatert `java-version` til `25`
- `mise.toml`: oppdatert lokal Java-versjon til `25`

## Issue

Closes #234
Del av epic: navikt/team-esyfo#143

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)