### PR TITLE
Oppgrader ktor til 3.5.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,3 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 20
-    ignore:
-      - dependency-name: "io.ktor:*"
-        versions:
-          - ">=3.5.0, <3.6.0"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ group = "no.nav.syfo"
 version = "1.0"
 
 val kluentVersion = "1.73"
-val ktorVersion = "3.4.3"
+val ktorVersion = "3.5.1"
 val prometheusVersion = "0.16.0"
 val micrometerVersion = "1.17.0"
 val kotestVersion = "6.2.1"


### PR DESCRIPTION
Oppgraderer Ktor-versjonen som brukes i tjenesten, og lar Dependabot igjen foreslå Ktor-oppdateringer (ved å fjerne en tidligere ignore-regel).

**Changes:**
- Oppdatert `ktorVersion` fra `3.4.3` til `3.5.1` i Gradle-buildet.
- Fjernet Dependabot `ignore`-regel for `io.ktor:*`, slik at Ktor-avhengigheter kan oppdateres automatisk igjen.
