### PR TITLE
fix(kafka): wake up consumers on pod shutdown

### DIFF
--- a/src/main/kotlin/no/nav/syfo/BootstrapApplication.kt
+++ b/src/main/kotlin/no/nav/syfo/BootstrapApplication.kt
@@ -8,6 +8,7 @@ import com.typesafe.config.ConfigFactory
 import io.ktor.serialization.jackson.jackson
 import io.ktor.server.application.Application
 import io.ktor.server.application.ApplicationEnvironment
+import io.ktor.server.application.ApplicationStopping
 import io.ktor.server.application.install
 import io.ktor.server.config.HoconApplicationConfig
 import io.ktor.server.engine.applicationEnvironment
@@ -358,18 +359,32 @@ fun Application.kafkaModule(
     varselbusService: VarselBusService,
     testdataResetService: TestdataResetService,
 ) {
+    val varselBusKafkaConsumer = VarselBusKafkaConsumer(env, varselbusService)
+    val testdataResetConsumer =
+        if (env.isDevGcp()) {
+            TestdataResetConsumer(env, testdataResetService)
+        } else {
+            null
+        }
+
+    monitor.subscribe(ApplicationStopping) {
+        state.shutdownApplication()
+        varselBusKafkaConsumer.wakeup()
+        testdataResetConsumer?.wakeup()
+    }
+
     launch(backgroundTasksContext) {
         launchKafkaListener(
             state,
-            VarselBusKafkaConsumer(env, varselbusService),
+            varselBusKafkaConsumer,
         )
     }
 
-    if (env.isDevGcp()) {
+    if (testdataResetConsumer != null) {
         launch(backgroundTasksContext) {
             launchKafkaListener(
                 state,
-                TestdataResetConsumer(env, testdataResetService),
+                testdataResetConsumer,
             )
         }
     }

--- a/src/main/kotlin/no/nav/syfo/kafka/common/KafkaCommon.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/common/KafkaCommon.kt
@@ -40,9 +40,12 @@ const val PKCS12 = "PKCS12"
 const val SSL = "SSL"
 
 val pollDurationInMillis = Duration.ofMillis(1000L)
+val kafkaConsumerCloseDuration = Duration.ofSeconds(3)
 
 interface KafkaListener {
     suspend fun listen(applicationState: ApplicationState)
+
+    fun wakeup() {}
 }
 
 fun commonProperties(env: Environment): Properties =

--- a/src/main/kotlin/no/nav/syfo/kafka/consumers/testdata/reset/TestdataResetConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/consumers/testdata/reset/TestdataResetConsumer.kt
@@ -1,15 +1,19 @@
 package no.nav.syfo.kafka.consumers.testdata.reset
 
+import kotlinx.coroutines.CancellationException
 import no.nav.syfo.ApplicationState
 import no.nav.syfo.Environment
 import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.kafka.common.KafkaListener
 import no.nav.syfo.kafka.common.TOPIC_TESTDATA_RESET
 import no.nav.syfo.kafka.common.consumerProperties
+import no.nav.syfo.kafka.common.kafkaConsumerCloseDuration
 import no.nav.syfo.kafka.common.pollDurationInMillis
 import no.nav.syfo.service.TestdataResetService
 import org.apache.kafka.clients.CommonClientConfigs
+import org.apache.kafka.clients.consumer.CloseOptions
 import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.common.errors.WakeupException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.util.Properties
@@ -17,42 +21,65 @@ import java.util.Properties
 class TestdataResetConsumer(
     val env: Environment,
     private val testdataResetService: TestdataResetService,
+    private val kafkaListener: KafkaConsumer<String, String> = KafkaConsumer(createTestdataResetProperties(env)),
 ) : KafkaListener {
     private val log: Logger = LoggerFactory.getLogger(TestdataResetConsumer::class.java)
-    private val kafkaListener: KafkaConsumer<String, String>
 
     init {
-        val kafkaConfig = testdataResetProperties(env)
-        kafkaListener = KafkaConsumer(kafkaConfig)
         kafkaListener.subscribe(listOf(TOPIC_TESTDATA_RESET))
     }
 
     override suspend fun listen(applicationState: ApplicationState) {
         log.info("Started listening to topic $TOPIC_TESTDATA_RESET")
-        while (applicationState.running) {
-            kafkaListener.poll(pollDurationInMillis).forEach {
-                log.info("Received record from topic $TOPIC_TESTDATA_RESET")
+        try {
+            while (applicationState.running) {
                 try {
-                    if (it.value() != null) {
-                        testdataResetService.resetTestdata(PersonIdent(it.value()))
-                    } else {
-                        log.warn(
-                            "TestdataResetConsumer: Value of ConsumerRecord from topic $TOPIC_TESTDATA_RESET is null",
-                        )
+                    kafkaListener.poll(pollDurationInMillis).forEach {
+                        log.info("Received record from topic $TOPIC_TESTDATA_RESET")
+                        if (it.value() != null) {
+                            testdataResetService.resetTestdata(PersonIdent(it.value()))
+                        } else {
+                            log.warn(
+                                "TestdataResetConsumer: Value of ConsumerRecord from topic $TOPIC_TESTDATA_RESET is null",
+                            )
+                        }
+                        kafkaListener.commitSync()
                     }
+                } catch (e: WakeupException) {
+                    if (applicationState.running) {
+                        throw e
+                    }
+                    log.info("Kafka consumer for topic $TOPIC_TESTDATA_RESET received wakeup signal, shutting down")
+                    break
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     log.error("TestdataResetConsumer: Exception in [$TOPIC_TESTDATA_RESET]-listener: ${e.message}", e)
+                    kafkaListener.commitSync()
                 }
-                kafkaListener.commitSync()
             }
+        } finally {
+            closeKafkaListener()
         }
     }
 
-    fun testdataResetProperties(env: Environment): Properties {
-        val commonConsumerProperties = consumerProperties(env)
-        return commonConsumerProperties.apply {
-            remove(CommonClientConfigs.GROUP_ID_CONFIG)
-            put(CommonClientConfigs.GROUP_ID_CONFIG, "esyfovarsel-group-testdata-reset-01")
+    override fun wakeup() {
+        kafkaListener.wakeup()
+    }
+
+    private fun closeKafkaListener() {
+        try {
+            kafkaListener.close(CloseOptions.timeout(kafkaConsumerCloseDuration))
+        } catch (e: Exception) {
+            log.warn("Error closing kafka consumer for topic $TOPIC_TESTDATA_RESET", e)
         }
+    }
+}
+
+private fun createTestdataResetProperties(env: Environment): Properties {
+    val commonConsumerProperties = consumerProperties(env)
+    return commonConsumerProperties.apply {
+        remove(CommonClientConfigs.GROUP_ID_CONFIG)
+        put(CommonClientConfigs.GROUP_ID_CONFIG, "esyfovarsel-group-testdata-reset-01")
     }
 }

--- a/src/main/kotlin/no/nav/syfo/kafka/consumers/varselbus/VarselBusKafkaConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/consumers/varselbus/VarselBusKafkaConsumer.kt
@@ -1,51 +1,69 @@
 package no.nav.syfo.kafka.consumers.varselbus
 
 import com.fasterxml.jackson.module.kotlin.readValue
+import kotlinx.coroutines.CancellationException
 import no.nav.syfo.ApplicationState
 import no.nav.syfo.Environment
 import no.nav.syfo.kafka.common.KafkaListener
 import no.nav.syfo.kafka.common.TOPIC_VARSEL_BUS
 import no.nav.syfo.kafka.common.consumerProperties
 import no.nav.syfo.kafka.common.createObjectMapper
+import no.nav.syfo.kafka.common.kafkaConsumerCloseDuration
 import no.nav.syfo.kafka.common.pollDurationInMillis
 import no.nav.syfo.kafka.consumers.varselbus.domain.EsyfovarselHendelse
 import no.nav.syfo.kafka.consumers.varselbus.domain.isArbeidstakerHendelse
 import no.nav.syfo.kafka.consumers.varselbus.domain.toArbeidstakerHendelse
 import no.nav.syfo.service.VarselBusService
+import org.apache.kafka.clients.consumer.CloseOptions
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.common.errors.WakeupException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 class VarselBusKafkaConsumer(
     val env: Environment,
     val varselBusService: VarselBusService,
+    private val kafkaListener: KafkaConsumer<String, String> = KafkaConsumer(consumerProperties(env)),
 ) : KafkaListener {
     private val log: Logger = LoggerFactory.getLogger(VarselBusKafkaConsumer::class.qualifiedName)
-    private val kafkaListener: KafkaConsumer<String, String>
     private val objectMapper = createObjectMapper()
 
     init {
-        val kafkaConfig = consumerProperties(env)
-        kafkaListener = KafkaConsumer(kafkaConfig)
         kafkaListener.subscribe(listOf(TOPIC_VARSEL_BUS))
     }
 
     override suspend fun listen(applicationState: ApplicationState) {
         log.info("Started listening to topic $TOPIC_VARSEL_BUS")
 
-        while (applicationState.running) {
-            try {
-                kafkaListener.poll(pollDurationInMillis).forEach { processVarselBusRecord(it) }
-                kafkaListener.commitSync()
-            } catch (e: Exception) {
-                log.error(
-                    "Exception in [$TOPIC_VARSEL_BUS]-listener: ${e.message}",
-                    e,
-                )
-                kafkaListener.commitSync()
+        try {
+            while (applicationState.running) {
+                try {
+                    kafkaListener.poll(pollDurationInMillis).forEach { processVarselBusRecord(it) }
+                    kafkaListener.commitSync()
+                } catch (e: WakeupException) {
+                    if (applicationState.running) {
+                        throw e
+                    }
+                    log.info("Kafka consumer for topic $TOPIC_VARSEL_BUS received wakeup signal, shutting down")
+                    break
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    log.error(
+                        "Exception in [$TOPIC_VARSEL_BUS]-listener: ${e.message}",
+                        e,
+                    )
+                    kafkaListener.commitSync()
+                }
             }
+        } finally {
+            closeKafkaListener()
         }
+    }
+
+    override fun wakeup() {
+        kafkaListener.wakeup()
     }
 
     private suspend fun processVarselBusRecord(record: ConsumerRecord<String, String>) {
@@ -57,6 +75,14 @@ class VarselBusKafkaConsumer(
 
         if (varselEvent.isArbeidstakerHendelse()) {
             varselBusService.processVarselHendelseAsMinSideMicrofrontendEvent(varselEvent.toArbeidstakerHendelse())
+        }
+    }
+
+    private fun closeKafkaListener() {
+        try {
+            kafkaListener.close(CloseOptions.timeout(kafkaConsumerCloseDuration))
+        } catch (e: Exception) {
+            log.warn("Error closing kafka consumer for topic $TOPIC_VARSEL_BUS", e)
         }
     }
 }

--- a/src/test/kotlin/no/nav/syfo/kafka/consumers/varselbus/VarselBusKafkaConsumerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/kafka/consumers/varselbus/VarselBusKafkaConsumerTest.kt
@@ -1,0 +1,61 @@
+package no.nav.syfo.kafka.consumers.varselbus
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import no.nav.syfo.ApplicationState
+import no.nav.syfo.Environment
+import no.nav.syfo.kafka.common.kafkaConsumerCloseDuration
+import no.nav.syfo.service.VarselBusService
+import org.amshove.kluent.shouldBeEqualTo
+import org.apache.kafka.clients.consumer.CloseOptions
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.common.errors.WakeupException
+
+class VarselBusKafkaConsumerTest :
+    DescribeSpec({
+        describe("VarselBusKafkaConsumer") {
+            it("should stop cleanly and close kafka consumer when wakeup is triggered during shutdown") {
+                val kafkaListener = mockk<KafkaConsumer<String, String>>(relaxed = true)
+                val applicationState = ApplicationState(running = true)
+                val closeOptionsSlot = slot<CloseOptions>()
+                every {
+                    kafkaListener.poll(any())
+                } answers {
+                    applicationState.running = false
+                    throw WakeupException()
+                }
+                val consumer =
+                    VarselBusKafkaConsumer(
+                        env = mockk<Environment>(relaxed = true),
+                        varselBusService = mockk<VarselBusService>(relaxed = true),
+                        kafkaListener = kafkaListener,
+                    )
+
+                runBlocking {
+                    consumer.listen(applicationState)
+                }
+
+                verify(exactly = 1) { kafkaListener.close(capture(closeOptionsSlot)) }
+                closeOptionsSlot.captured.timeout().orElse(null) shouldBeEqualTo kafkaConsumerCloseDuration
+                verify(exactly = 0) { kafkaListener.commitSync() }
+            }
+
+            it("should delegate wakeup to the underlying kafka consumer") {
+                val kafkaListener = mockk<KafkaConsumer<String, String>>(relaxed = true)
+                val consumer =
+                    VarselBusKafkaConsumer(
+                        env = mockk<Environment>(relaxed = true),
+                        varselBusService = mockk<VarselBusService>(relaxed = true),
+                        kafkaListener = kafkaListener,
+                    )
+
+                consumer.wakeup()
+
+                verify(exactly = 1) { kafkaListener.wakeup() }
+            }
+        }
+    })


### PR DESCRIPTION
## Beskrivelse

Retter shutdown-problemet der Kafka-consumerne kunne bli staende i blokkerende Kafka-kall under pod-restart. Consumerne vekkes na pa `ApplicationStopping`, handterer `WakeupException` kontrollert og lukkes eksplisitt med timeout.

## Endringer

- `src/main/kotlin/no/nav/syfo/BootstrapApplication.kt`: registrerer `ApplicationStopping` og vekker consumerne ved shutdown
- `src/main/kotlin/no/nav/syfo/kafka/common/KafkaCommon.kt`: utvider `KafkaListener` med `wakeup()` og felles close-timeout
- `src/main/kotlin/no/nav/syfo/kafka/consumers/varselbus/VarselBusKafkaConsumer.kt`: handterer `WakeupException` og lukker consumer kontrollert
- `src/main/kotlin/no/nav/syfo/kafka/consumers/testdata/reset/TestdataResetConsumer.kt`: samme shutdown-handtering for dev-consumeren
- `src/test/kotlin/no/nav/syfo/kafka/consumers/varselbus/VarselBusKafkaConsumerTest.kt`: tester kontrollert shutdown og wakeup

## Issue

Closes #1056

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)